### PR TITLE
feat(usage-extension): add loading spinner with cancel support

### DIFF
--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -93,6 +93,8 @@ Respects the `PI_CODING_AGENT_DIR` environment variable if set.
 ## Changelog
 
 ### 2026-01-12
+- Add loading spinner while parsing session files (Esc to cancel)
+- Make data loading async to keep UI responsive
 - Deduplicate assistant messages across branched sessions to avoid double-counting
 - Tokens total now excludes cache read/write tokens (cache remains in Cache column)
 - Thanks @nicobailon


### PR DESCRIPTION
Small QOL improvement. Make data loading async to keep UI responsive during session parsing. Show spinner with Esc to cancel while loading usage stats.

<img width="272" height="93" alt="Screenshot 2026-01-13 at 12 00 57 AM" src="https://github.com/user-attachments/assets/4dbe9677-797a-43a3-968c-8779ac2a3e1f" />
