### PR TITLE
fix(files-widget): address /readfiles P0 feedback

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this extension will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Let `/readfiles` browser search accept `j` and `k` as search text instead of hijacking them for navigation.
+- Fix viewer scrolling so the last lines of a file remain reachable.
+- Restore `G` / `Shift+G` navigation to jump to the bottom of the viewer.
+- Refresh an open viewer when the file changes on disk while `/readfiles` is open.
+- Accept pasted and multi-character text input in browser search and the inline comment prompt.
+
 ## [0.1.14] - 2026-02-03
 
 ### Added

--- a/files-widget/browser.ts
+++ b/files-widget/browser.ts
@@ -22,7 +22,7 @@ import { buildFileTreeFromPaths, flattenTree, getIgnoredNames, sortChildren, upd
 import type { DiffStats, FileNode, FlatNode } from "./types";
 import { isIgnoredStatus, isUntrackedStatus } from "./utils";
 import { createViewer, type CommentPayload, type ViewerAction } from "./viewer";
-import { getTextInput } from "./input-utils";
+import { createTextInputBuffer } from "./input-utils";
 
 export interface BrowserController {
   render(width: number): string[];
@@ -219,6 +219,7 @@ export function createFileBrowser(
   const gitBranch = repo ? getGitBranch(cwd) : "";
 
   const viewer = createViewer(cwd, theme, requestComment);
+  const textInput = createTextInputBuffer();
 
   const root = repo
     ? buildFileTreeFromPaths(cwd, getGitFileList(cwd), gitStatus, diffStats, ignored, agentModifiedFiles)
@@ -797,6 +798,7 @@ export function createFileBrowser(
     const maxIndex = Math.max(0, displayList.length - 1);
 
     if (matchesKey(data, "q") && !browser.searchMode) {
+      textInput.reset();
       stopBackgroundTasks();
       onClose();
       return;
@@ -805,7 +807,9 @@ export function createFileBrowser(
       if (browser.searchMode) {
         browser.searchMode = false;
         browser.searchQuery = "";
+        textInput.reset();
       } else {
+        textInput.reset();
         stopBackgroundTasks();
         onClose();
       }
@@ -814,12 +818,14 @@ export function createFileBrowser(
     if (matchesKey(data, "/") && !browser.searchMode) {
       browser.searchMode = true;
       browser.searchQuery = "";
+      textInput.reset();
       return;
     }
     if (browser.searchMode) {
       if (matchesKey(data, Key.enter)) {
         browser.searchMode = false;
         browser.selectedIndex = 0;
+        textInput.reset();
       } else if (matchesKey(data, Key.backspace)) {
         browser.searchQuery = browser.searchQuery.slice(0, -1);
         browser.selectedIndex = 0;
@@ -828,9 +834,9 @@ export function createFileBrowser(
       } else if (matchesKey(data, Key.up)) {
         browser.selectedIndex = Math.max(0, browser.selectedIndex - 1);
       } else {
-        const textInput = getTextInput(data);
-        if (textInput) {
-          browser.searchQuery += textInput;
+        const text = textInput.push(data);
+        if (text) {
+          browser.searchQuery += text;
           browser.selectedIndex = 0;
         }
       }

--- a/files-widget/browser.ts
+++ b/files-widget/browser.ts
@@ -22,7 +22,7 @@ import { buildFileTreeFromPaths, flattenTree, getIgnoredNames, sortChildren, upd
 import type { DiffStats, FileNode, FlatNode } from "./types";
 import { isIgnoredStatus, isUntrackedStatus } from "./utils";
 import { createViewer, type CommentPayload, type ViewerAction } from "./viewer";
-import { isPrintableChar } from "./input-utils";
+import { getTextInput } from "./input-utils";
 
 export interface BrowserController {
   render(width: number): string[];
@@ -794,6 +794,7 @@ export function createFileBrowser(
 
   function handleBrowserInput(data: string): void {
     const displayList = getDisplayList();
+    const maxIndex = Math.max(0, displayList.length - 1);
 
     if (matchesKey(data, "q") && !browser.searchMode) {
       stopBackgroundTasks();
@@ -815,14 +816,6 @@ export function createFileBrowser(
       browser.searchQuery = "";
       return;
     }
-    if (matchesKey(data, "j") || matchesKey(data, Key.down)) {
-      browser.selectedIndex = Math.min(displayList.length - 1, browser.selectedIndex + 1);
-      return;
-    }
-    if (matchesKey(data, "k") || matchesKey(data, Key.up)) {
-      browser.selectedIndex = Math.max(0, browser.selectedIndex - 1);
-      return;
-    }
     if (browser.searchMode) {
       if (matchesKey(data, Key.enter)) {
         browser.searchMode = false;
@@ -830,10 +823,25 @@ export function createFileBrowser(
       } else if (matchesKey(data, Key.backspace)) {
         browser.searchQuery = browser.searchQuery.slice(0, -1);
         browser.selectedIndex = 0;
-      } else if (isPrintableChar(data)) {
-        browser.searchQuery += data;
-        browser.selectedIndex = 0;
+      } else if (matchesKey(data, Key.down)) {
+        browser.selectedIndex = Math.min(maxIndex, browser.selectedIndex + 1);
+      } else if (matchesKey(data, Key.up)) {
+        browser.selectedIndex = Math.max(0, browser.selectedIndex - 1);
+      } else {
+        const textInput = getTextInput(data);
+        if (textInput) {
+          browser.searchQuery += textInput;
+          browser.selectedIndex = 0;
+        }
       }
+      return;
+    }
+    if (matchesKey(data, "j") || matchesKey(data, Key.down)) {
+      browser.selectedIndex = Math.min(maxIndex, browser.selectedIndex + 1);
+      return;
+    }
+    if (matchesKey(data, "k") || matchesKey(data, Key.up)) {
+      browser.selectedIndex = Math.max(0, browser.selectedIndex - 1);
       return;
     }
     if (matchesKey(data, Key.enter)) {
@@ -864,7 +872,7 @@ export function createFileBrowser(
       return;
     }
     if (matchesKey(data, Key.pageDown)) {
-      browser.selectedIndex = Math.min(displayList.length - 1, browser.selectedIndex + browser.browserHeight);
+      browser.selectedIndex = Math.min(maxIndex, browser.selectedIndex + browser.browserHeight);
       return;
     }
     if (matchesKey(data, Key.pageUp)) {

--- a/files-widget/constants.ts
+++ b/files-widget/constants.ts
@@ -14,5 +14,4 @@ export const MIN_PANEL_HEIGHT = 5;
 export const MAX_VIEWER_HEIGHT = 50;
 export const MAX_BROWSER_HEIGHT = 40;
 
-export const VIEWER_SCROLL_MARGIN = 10;
 export const SEARCH_SCROLL_OFFSET = 3;

--- a/files-widget/input-utils.ts
+++ b/files-widget/input-utils.ts
@@ -1,17 +1,12 @@
+import { decodeKittyPrintable } from "@mariozechner/pi-tui";
+
 const CONTROL_CHARS = /[\u0000-\u0008\u000B-\u001F\u007F]/g;
-const BRACKETED_PASTE_START = /\u001b\[200~/g;
-const BRACKETED_PASTE_END = /\u001b\[201~/g;
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
 
-export function getTextInput(data: string): string {
-  if (!data) {
-    return "";
-  }
-
-  const normalized = data
-    .replace(BRACKETED_PASTE_START, "")
-    .replace(BRACKETED_PASTE_END, "");
-
-  if (normalized.includes("\u001b")) {
+function sanitizeTextInput(data: string): string {
+  const normalized = decodeKittyPrintable(data) ?? data;
+  if (!normalized || normalized.includes("\u001b")) {
     return "";
   }
 
@@ -20,4 +15,73 @@ export function getTextInput(data: string): string {
     .replace(/\n/g, " ")
     .replace(/\t/g, " ")
     .replace(CONTROL_CHARS, "");
+}
+
+function getPendingStartSuffix(data: string): string {
+  const maxLength = BRACKETED_PASTE_START.length - 1;
+  for (let length = Math.min(data.length, maxLength); length > 0; length--) {
+    const suffix = data.slice(-length);
+    if (BRACKETED_PASTE_START.startsWith(suffix)) {
+      return suffix;
+    }
+  }
+  return "";
+}
+
+export interface TextInputBuffer {
+  push(data: string): string;
+  reset(): void;
+}
+
+export function createTextInputBuffer(): TextInputBuffer {
+  let isInPaste = false;
+  let pasteBuffer = "";
+  let pendingStart = "";
+
+  const push = (data: string): string => {
+    if (!data) {
+      return "";
+    }
+
+    const combined = pendingStart + data;
+    pendingStart = "";
+
+    if (!isInPaste) {
+      const startIndex = combined.indexOf(BRACKETED_PASTE_START);
+      if (startIndex === -1) {
+        const pendingSuffix = getPendingStartSuffix(combined);
+        const completeText = pendingSuffix ? combined.slice(0, combined.length - pendingSuffix.length) : combined;
+        pendingStart = pendingSuffix;
+        return sanitizeTextInput(completeText);
+      }
+
+      const beforePaste = combined.slice(0, startIndex);
+      const afterStart = combined.slice(startIndex + BRACKETED_PASTE_START.length);
+      isInPaste = true;
+      pasteBuffer = "";
+      return sanitizeTextInput(beforePaste) + push(afterStart);
+    }
+
+    pasteBuffer += combined;
+    const endIndex = pasteBuffer.indexOf(BRACKETED_PASTE_END);
+    if (endIndex === -1) {
+      return "";
+    }
+
+    const pastedText = pasteBuffer.slice(0, endIndex);
+    const remaining = pasteBuffer.slice(endIndex + BRACKETED_PASTE_END.length);
+    isInPaste = false;
+    pasteBuffer = "";
+
+    return sanitizeTextInput(pastedText) + push(remaining);
+  };
+
+  return {
+    push,
+    reset(): void {
+      isInPaste = false;
+      pasteBuffer = "";
+      pendingStart = "";
+    },
+  };
 }

--- a/files-widget/input-utils.ts
+++ b/files-widget/input-utils.ts
@@ -1,3 +1,13 @@
-export function isPrintableChar(data: string): boolean {
-  return data.length === 1 && data.charCodeAt(0) >= 32 && data.charCodeAt(0) < 127;
+const CONTROL_CHARS = /[\u0000-\u0008\u000B-\u001F\u007F]/g;
+
+export function getTextInput(data: string): string {
+  if (!data || data.includes("\u001b")) {
+    return "";
+  }
+
+  return data
+    .replace(/\r\n?/g, "\n")
+    .replace(/\n/g, " ")
+    .replace(/\t/g, " ")
+    .replace(CONTROL_CHARS, "");
 }

--- a/files-widget/input-utils.ts
+++ b/files-widget/input-utils.ts
@@ -1,11 +1,21 @@
 const CONTROL_CHARS = /[\u0000-\u0008\u000B-\u001F\u007F]/g;
+const BRACKETED_PASTE_START = /\u001b\[200~/g;
+const BRACKETED_PASTE_END = /\u001b\[201~/g;
 
 export function getTextInput(data: string): string {
-  if (!data || data.includes("\u001b")) {
+  if (!data) {
     return "";
   }
 
-  return data
+  const normalized = data
+    .replace(BRACKETED_PASTE_START, "")
+    .replace(BRACKETED_PASTE_END, "");
+
+  if (normalized.includes("\u001b")) {
+    return "";
+  }
+
+  return normalized
     .replace(/\r\n?/g, "\n")
     .replace(/\n/g, " ")
     .replace(/\t/g, " ")

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { relative } from "node:path";
 
 import {
@@ -8,12 +8,11 @@ import {
   MAX_VIEWER_HEIGHT,
   MIN_PANEL_HEIGHT,
   SEARCH_SCROLL_OFFSET,
-  VIEWER_SCROLL_MARGIN,
 } from "./constants";
 import { loadFileContent } from "./file-viewer";
 import type { FileNode } from "./types";
 import { isUntrackedStatus } from "./utils";
-import { isPrintableChar } from "./input-utils";
+import { getTextInput } from "./input-utils";
 
 export interface CommentPayload {
   relPath: string;
@@ -43,6 +42,7 @@ interface ViewerState {
   searchMatches: number[];
   searchIndex: number;
   lastRenderWidth: number;
+  lastLoadedMtimeMs: number | null;
   height: number;
 }
 
@@ -75,6 +75,7 @@ export function createViewer(
     searchMatches: [],
     searchIndex: 0,
     lastRenderWidth: 0,
+    lastLoadedMtimeMs: null,
     height: DEFAULT_VIEWER_HEIGHT,
   };
 
@@ -102,11 +103,46 @@ export function createViewer(
     }
   }
 
+  function getMaxScroll(): number {
+    return Math.max(0, state.content.length - state.height);
+  }
+
+  function refreshRawContent(): void {
+    if (!state.file) return;
+
+    try {
+      const fileStat = statSync(state.file.path);
+      state.rawContent = readFileSync(state.file.path, "utf-8");
+      state.file.lineCount = state.rawContent.split("\n").length;
+      state.lastLoadedMtimeMs = fileStat.mtimeMs;
+    } catch {
+      state.rawContent = "";
+      state.file.lineCount = undefined;
+      state.lastLoadedMtimeMs = null;
+    }
+  }
+
+  function hasFileChangedOnDisk(): boolean {
+    if (!state.file) return false;
+
+    try {
+      return state.lastLoadedMtimeMs === null || statSync(state.file.path).mtimeMs !== state.lastLoadedMtimeMs;
+    } catch {
+      return state.lastLoadedMtimeMs !== null;
+    }
+  }
+
+  function clampScroll(): void {
+    state.scroll = Math.min(getMaxScroll(), Math.max(0, state.scroll));
+  }
+
   function reloadContent(width: number): void {
     if (!state.file) return;
+    refreshRawContent();
     const hasChanges = !!state.file.gitStatus;
     state.content = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width);
     state.lastRenderWidth = width;
+    clampScroll();
   }
 
   function updateSearchMatches(): void {
@@ -124,6 +160,7 @@ export function createViewer(
 
     if (state.searchMatches.length > 0) {
       state.scroll = Math.max(0, state.searchMatches[0] - SEARCH_SCROLL_OFFSET);
+      clampScroll();
     }
   }
 
@@ -133,6 +170,7 @@ export function createViewer(
     if (state.searchIndex < 0) state.searchIndex = state.searchMatches.length - 1;
     if (state.searchIndex >= state.searchMatches.length) state.searchIndex = 0;
     state.scroll = Math.max(0, state.searchMatches[state.searchIndex] - SEARCH_SCROLL_OFFSET);
+    clampScroll();
   }
 
   function buildCommentPayload(): CommentPayload | null {
@@ -242,14 +280,8 @@ export function createViewer(
       setMode("normal");
       state.content = [];
       state.lastRenderWidth = 0;
-
-      try {
-        state.rawContent = readFileSync(file.path, "utf-8");
-        file.lineCount = state.rawContent.split("\n").length;
-      } catch {
-        state.rawContent = "";
-        file.lineCount = undefined;
-      }
+      state.lastLoadedMtimeMs = null;
+      refreshRawContent();
     },
 
     updateFileRef(file: FileNode | null): void {
@@ -259,13 +291,15 @@ export function createViewer(
     close(): void {
       state.file = null;
       state.content = [];
+      state.rawContent = "";
+      state.lastLoadedMtimeMs = null;
       setMode("normal");
     },
 
     render(width: number): string[] {
       if (!state.file) return [];
 
-      if (state.lastRenderWidth !== width || state.content.length === 0) {
+      if (state.lastRenderWidth !== width || state.content.length === 0 || hasFileChangedOnDisk()) {
         reloadContent(width);
       }
 
@@ -308,8 +342,11 @@ export function createViewer(
           setMode("normal");
         } else if (matchesKey(data, Key.backspace)) {
           state.commentText = state.commentText.slice(0, -1);
-        } else if (isPrintableChar(data)) {
-          state.commentText += data;
+        } else {
+          const textInput = getTextInput(data);
+          if (textInput) {
+            state.commentText += textInput;
+          }
         }
         return { type: "none" };
       }
@@ -322,9 +359,12 @@ export function createViewer(
         } else if (matchesKey(data, Key.backspace)) {
           state.searchQuery = state.searchQuery.slice(0, -1);
           updateSearchMatches();
-        } else if (isPrintableChar(data)) {
-          state.searchQuery += data;
-          updateSearchMatches();
+        } else {
+          const textInput = getTextInput(data);
+          if (textInput) {
+            state.searchQuery += textInput;
+            updateSearchMatches();
+          }
         }
         return { type: "none" };
       }
@@ -358,7 +398,7 @@ export function createViewer(
         if (state.mode === "select") {
           state.selectEnd = Math.min(state.content.length - 1, state.selectEnd + 1);
         } else {
-          state.scroll = Math.min(Math.max(0, state.content.length - VIEWER_SCROLL_MARGIN), state.scroll + 1);
+          state.scroll = Math.min(getMaxScroll(), state.scroll + 1);
         }
         return { type: "none" };
       }
@@ -371,7 +411,7 @@ export function createViewer(
         return { type: "none" };
       }
       if (matchesKey(data, Key.pageDown)) {
-        state.scroll = Math.min(Math.max(0, state.content.length - state.height), state.scroll + state.height);
+        state.scroll = Math.min(getMaxScroll(), state.scroll + state.height);
         return { type: "none" };
       }
       if (matchesKey(data, Key.pageUp)) {
@@ -382,16 +422,18 @@ export function createViewer(
         state.scroll = 0;
         return { type: "none" };
       }
-      if (matchesKey(data, "G")) {
-        state.scroll = Math.max(0, state.content.length - state.height);
+      if (matchesKey(data, "shift+g")) {
+        state.scroll = getMaxScroll();
         return { type: "none" };
       }
       if (matchesKey(data, "+") || matchesKey(data, "=")) {
         state.height = Math.min(MAX_VIEWER_HEIGHT, state.height + 5);
+        clampScroll();
         return { type: "none" };
       }
       if (matchesKey(data, "-") || matchesKey(data, "_")) {
         state.height = Math.max(MIN_PANEL_HEIGHT, state.height - 5);
+        clampScroll();
         return { type: "none" };
       }
       if (matchesKey(data, "d") && state.mode !== "select" && state.file.gitStatus && !isUntrackedStatus(state.file.gitStatus)) {

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -12,7 +12,7 @@ import {
 import { loadFileContent } from "./file-viewer";
 import type { FileNode } from "./types";
 import { isUntrackedStatus } from "./utils";
-import { getTextInput } from "./input-utils";
+import { createTextInputBuffer } from "./input-utils";
 
 export interface CommentPayload {
   relPath: string;
@@ -61,6 +61,8 @@ export function createViewer(
   theme: Theme,
   requestComment: (payload: CommentPayload, comment: string) => void
 ): ViewerController {
+  const textInput = createTextInputBuffer();
+
   const state: ViewerState = {
     file: null,
     content: [],
@@ -95,6 +97,10 @@ export function createViewer(
   }
 
   function setMode(mode: ViewerMode): void {
+    if (mode !== state.mode) {
+      textInput.reset();
+    }
+
     state.mode = mode;
     if (mode !== "search") resetSearch();
     if (mode !== "comment") resetComment();
@@ -324,7 +330,8 @@ export function createViewer(
     render(width: number): string[] {
       if (!state.file) return [];
 
-      if (state.lastRenderWidth !== width || state.content.length === 0 || hasFileChangedOnDisk()) {
+      const shouldAutoRefresh = state.mode !== "select" && state.mode !== "comment";
+      if (state.lastRenderWidth !== width || state.content.length === 0 || (shouldAutoRefresh && hasFileChangedOnDisk())) {
         reloadContent(width);
       }
 
@@ -368,9 +375,9 @@ export function createViewer(
         } else if (matchesKey(data, Key.backspace)) {
           state.commentText = state.commentText.slice(0, -1);
         } else {
-          const textInput = getTextInput(data);
-          if (textInput) {
-            state.commentText += textInput;
+          const text = textInput.push(data);
+          if (text) {
+            state.commentText += text;
           }
         }
         return { type: "none" };
@@ -385,9 +392,9 @@ export function createViewer(
           state.searchQuery = state.searchQuery.slice(0, -1);
           updateSearchMatches();
         } else {
-          const textInput = getTextInput(data);
-          if (textInput) {
-            state.searchQuery += textInput;
+          const text = textInput.push(data);
+          if (text) {
+            state.searchQuery += text;
             updateSearchMatches();
           }
         }

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -143,11 +143,19 @@ export function createViewer(
     state.content = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width);
     state.lastRenderWidth = width;
     clampScroll();
+    if (state.searchQuery) {
+      updateSearchMatches({ preserveActiveMatch: true });
+    }
   }
 
-  function updateSearchMatches(): void {
+  function updateSearchMatches(options: { preserveActiveMatch?: boolean } = {}): void {
+    const activeMatch = options.preserveActiveMatch ? state.searchMatches[state.searchIndex] : undefined;
+
     state.searchMatches = [];
-    if (!state.searchQuery) return;
+    if (!state.searchQuery) {
+      state.searchIndex = 0;
+      return;
+    }
 
     const q = state.searchQuery.toLowerCase();
     const rawLines = state.rawContent.split("\n");
@@ -156,12 +164,29 @@ export function createViewer(
         state.searchMatches.push(i);
       }
     }
-    state.searchIndex = 0;
 
-    if (state.searchMatches.length > 0) {
-      state.scroll = Math.max(0, state.searchMatches[0] - SEARCH_SCROLL_OFFSET);
-      clampScroll();
+    if (state.searchMatches.length === 0) {
+      state.searchIndex = 0;
+      return;
     }
+
+    if (activeMatch === undefined) {
+      state.searchIndex = 0;
+    } else {
+      let nearestIndex = 0;
+      let nearestDistance = Number.POSITIVE_INFINITY;
+      for (let i = 0; i < state.searchMatches.length; i++) {
+        const distance = Math.abs(state.searchMatches[i] - activeMatch);
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearestIndex = i;
+        }
+      }
+      state.searchIndex = nearestIndex;
+    }
+
+    state.scroll = Math.max(0, state.searchMatches[state.searchIndex] - SEARCH_SCROLL_OFFSET);
+    clampScroll();
   }
 
   function jumpToNextMatch(direction: 1 | -1): void {


### PR DESCRIPTION
## Summary
- fix `/readfiles` browser search so `j`/`k` are treated as text while searching
- fix viewer bottom-of-file scrolling, `G` navigation, and live refresh when the file changes on disk
- accept pasted and multi-character input in browser search and the inline comment prompt

## Validation
- `tsc --noCheck --noEmit --moduleResolution nodenext --module nodenext --target ES2022 files-widget/*.ts`
- reviewed the changed code paths against the Discord feedback notes in `.research/files-widget-discord-feedback-2026-04-19.md`