### PR TITLE
fix(skill-creator): make validate_skill.py self-contained via uv (#20)

### DIFF
--- a/extending-pi/CHANGELOG.md
+++ b/extending-pi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.1 - 2026-04-19
+- Pick up `skill-creator@0.3.1`: self-contained `validate_skill.py` via PEP 723 + `uv run` (no more system PyYAML requirement). Thanks to @tekumara for reporting ([#20](https://github.com/tmustier/pi-extensions/issues/20)).
+
 ## 0.1.0 - 2026-02-05
 - Initial release: decision table for skill vs extension vs prompt template vs theme vs context file vs custom model vs package.
 - Nested skill-creator sub-skill for detailed skill creation guidance.

--- a/extending-pi/package.json
+++ b/extending-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/extending-pi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Guide for extending Pi — skills, extensions, prompt templates, themes, and packaging.",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/extending-pi/skill-creator/CHANGELOG.md
+++ b/extending-pi/skill-creator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.1 - 2026-04-19
+- `validate_skill.py` is now self-contained: uses a PEP 723 `uv run --script` shebang so PyYAML is provisioned in an ephemeral environment instead of requiring a system-wide install. Thanks to @tekumara for reporting ([#20](https://github.com/tmustier/pi-extensions/issues/20)).
+
 ## 0.3.0 - 2026-02-05
 - Moved under `extending-pi/skill-creator/` (nested skill structure).
 - Renamed skill from `pi-skill-creator` to `skill-creator` to match new directory.

--- a/extending-pi/skill-creator/README.md
+++ b/extending-pi/skill-creator/README.md
@@ -4,3 +4,15 @@ Guidelines and templates for creating Pi skills that follow the Agent Skills for
 
 ## Installation
 `pi install npm:@tmustier/pi-skill-creator`
+
+## Validator script
+
+`scripts/validate_skill.py` uses a [PEP 723](https://peps.python.org/pep-0723/) `uv run --script` shebang so PyYAML is provisioned in an ephemeral environment — no system-wide Python packages required.
+
+Prerequisite: install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) (e.g. `brew install uv` or `curl -LsSf https://astral.sh/uv/install.sh | sh`), then:
+
+```bash
+scripts/validate_skill.py /path/to/my-skill
+# or, equivalently:
+uv run scripts/validate_skill.py /path/to/my-skill
+```

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -102,10 +102,12 @@ SKILL.md is the agent's interface to the skill — usage examples and input/outp
 
 ### 8) Validate and test
 
-- Run the validator script:
+- Run the validator script (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed):
 
 ```bash
 scripts/validate_skill.py /path/to/my-skill
+# or, equivalently:
+uv run scripts/validate_skill.py /path/to/my-skill
 ```
 
 - Load only the skill to spot warnings:

--- a/extending-pi/skill-creator/package.json
+++ b/extending-pi/skill-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-skill-creator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Detailed guidance for creating Pi skills (Agent Skills format).",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/extending-pi/skill-creator/scripts/validate_skill.py
+++ b/extending-pi/skill-creator/scripts/validate_skill.py
@@ -1,9 +1,19 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6"]
+# ///
 """
 Validate a Pi skill directory for Agent Skills + README requirements.
 
 Usage:
   scripts/validate_skill.py <skill_directory>
+
+Requires `uv` (https://docs.astral.sh/uv/). The shebang above runs the script
+in an ephemeral uv-managed environment with PyYAML, so nothing is installed
+into the system Python. You can also invoke it explicitly:
+
+  uv run scripts/validate_skill.py <skill_directory>
 """
 
 from __future__ import annotations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "MIT",
   "private": false,
   "keywords": [


### PR DESCRIPTION
Fixes #20.

`validate_skill.py` previously hard-required PyYAML in whatever Python happened to resolve via `#!/usr/bin/env python3`, so `scripts/validate_skill.py …` failed with `ModuleNotFoundError: No module named 'yaml'` on any machine without a system-level PyYAML install.

This PR switches the script to a self-contained [PEP 723](https://peps.python.org/pep-0723/) inline-metadata form executed by [`uv`](https://docs.astral.sh/uv/):

```python
#!/usr/bin/env -S uv run --script
# /// script
# requires-python = ">=3.10"
# dependencies = ["pyyaml>=6"]
# ///
```

`uv` provisions PyYAML in an ephemeral environment — nothing lands in the user's system Python, and `scripts/validate_skill.py <dir>` works out of the box (assuming `uv` is installed, which is already common in this ecosystem).

### Verified
```bash
$ ./extending-pi/skill-creator/scripts/validate_skill.py ./extending-pi/skill-creator
Installed 1 package in 3ms
Skill is valid!
```

### Changes
- `extending-pi/skill-creator/scripts/validate_skill.py` — new shebang + PEP 723 block, small docstring note
- `extending-pi/skill-creator/SKILL.md` §8 — mention the uv/PEP 723 mechanism + `uv run` equivalent
- `extending-pi/skill-creator` → 0.3.1
- `extending-pi` → 0.1.1 (repackage)
- root `pi-extensions` → 0.1.29

Credit: thanks to @tekumara for reporting in #20.
