### PR TITLE
chore: bump root pi-extensions to 0.1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "MIT",
   "private": false,
   "keywords": [


### PR DESCRIPTION
0.1.29 was already consumed by `files-widget/v0.1.16` (merged in parallel with #25). Bump root to 0.1.30 so the skill-creator 0.3.1 / extending-pi 0.1.1 release (#25, closes #20) can ship in a fresh repo-wide tarball. No other changes.