### PR TITLE
feat(files-widget): make the comment editor multiline

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this extension will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Make the inline comment editor multiline with wrapped footer rendering, `Enter` for a new line, and `Ctrl+Enter` to send.
+
 ## [0.1.16] - 2026-04-19
 
 ### Fixed

--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this extension will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Make the inline comment editor multiline with wrapped footer rendering, `Enter` for a new line, and `Ctrl+Enter` to send.
+- Make the inline comment editor multiline with wrapped footer rendering, `Enter` for a new line, and `Ctrl+Enter`/`Ctrl+D` to send.
 
 ## [0.1.16] - 2026-04-19
 

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -118,7 +118,7 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 - `v`: select mode (line selection)
 - `c`: comment on selected lines (inline prompt)
 - `Enter`: new line in the comment editor
-- `Ctrl+Enter`: send the comment
+- `Ctrl+Enter` or `Ctrl+D`: send the comment (`Alt+Enter` also works when supported)
 - `]` / `[`: next/prev changed file
 - `+` / `-`: increase/decrease viewer height
 - `q`: back to browser

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -117,6 +117,8 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 - `n` / `N`: next/prev match
 - `v`: select mode (line selection)
 - `c`: comment on selected lines (inline prompt)
+- `Enter`: new line in the comment editor
+- `Ctrl+Enter`: send the comment
 - `]` / `[`: next/prev changed file
 - `+` / `-`: increase/decrease viewer height
 - `q`: back to browser

--- a/files-widget/TODO.md
+++ b/files-widget/TODO.md
@@ -67,7 +67,7 @@
 ### Comment Dialog
 - [x] `c` to open comment input
 - [x] Multi-line text input
-- [x] `Enter` for newline and `Ctrl+Enter` to confirm
+- [x] `Enter` for newline and `Ctrl+Enter` / `Ctrl+D` to confirm
 - [x] `Esc` to cancel
 
 ### Send to Agent

--- a/files-widget/TODO.md
+++ b/files-widget/TODO.md
@@ -66,8 +66,8 @@
 
 ### Comment Dialog
 - [x] `c` to open comment input
-- [ ] Multi-line text input
-- [x] `Enter` or `Ctrl+Enter` to confirm
+- [x] Multi-line text input
+- [x] `Enter` for newline and `Ctrl+Enter` to confirm
 - [x] `Esc` to cancel
 
 ### Send to Agent

--- a/files-widget/input-utils.ts
+++ b/files-widget/input-utils.ts
@@ -4,17 +4,22 @@ const CONTROL_CHARS = /[\u0000-\u0008\u000B-\u001F\u007F]/g;
 const BRACKETED_PASTE_START = "\u001b[200~";
 const BRACKETED_PASTE_END = "\u001b[201~";
 
-function sanitizeTextInput(data: string): string {
+interface SanitizeTextInputOptions {
+  preserveNewlines?: boolean;
+}
+
+function sanitizeTextInput(data: string, options: SanitizeTextInputOptions = {}): string {
   const normalized = decodeKittyPrintable(data) ?? data;
   if (!normalized || normalized.includes("\u001b")) {
     return "";
   }
 
-  return normalized
-    .replace(/\r\n?/g, "\n")
-    .replace(/\n/g, " ")
-    .replace(/\t/g, " ")
-    .replace(CONTROL_CHARS, "");
+  const withNewlines = normalized.replace(/\r\n?/g, "\n");
+  const withoutTabs = options.preserveNewlines
+    ? withNewlines.replace(/\t/g, "  ")
+    : withNewlines.replace(/\n/g, " ").replace(/\t/g, " ");
+
+  return withoutTabs.replace(CONTROL_CHARS, "");
 }
 
 function getPendingStartSuffix(data: string): string {
@@ -33,7 +38,11 @@ export interface TextInputBuffer {
   reset(): void;
 }
 
-export function createTextInputBuffer(): TextInputBuffer {
+interface TextInputBufferOptions {
+  preserveNewlines?: boolean;
+}
+
+export function createTextInputBuffer(options: TextInputBufferOptions = {}): TextInputBuffer {
   let isInPaste = false;
   let pasteBuffer = "";
   let pendingStart = "";
@@ -52,14 +61,14 @@ export function createTextInputBuffer(): TextInputBuffer {
         const pendingSuffix = getPendingStartSuffix(combined);
         const completeText = pendingSuffix ? combined.slice(0, combined.length - pendingSuffix.length) : combined;
         pendingStart = pendingSuffix;
-        return sanitizeTextInput(completeText);
+        return sanitizeTextInput(completeText, options);
       }
 
       const beforePaste = combined.slice(0, startIndex);
       const afterStart = combined.slice(startIndex + BRACKETED_PASTE_START.length);
       isInPaste = true;
       pasteBuffer = "";
-      return sanitizeTextInput(beforePaste) + push(afterStart);
+      return sanitizeTextInput(beforePaste, options) + push(afterStart);
     }
 
     pasteBuffer += combined;
@@ -73,7 +82,7 @@ export function createTextInputBuffer(): TextInputBuffer {
     isInPaste = false;
     pasteBuffer = "";
 
-    return sanitizeTextInput(pastedText) + push(remaining);
+    return sanitizeTextInput(pastedText, options) + push(remaining);
   };
 
   return {

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
-import { Key, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
+import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import { readFileSync, statSync } from "node:fs";
 import { relative } from "node:path";
 
@@ -13,6 +13,8 @@ import { loadFileContent } from "./file-viewer";
 import type { FileNode } from "./types";
 import { isUntrackedStatus } from "./utils";
 import { createTextInputBuffer } from "./input-utils";
+
+const COMMENT_EDITOR_MAX_VISIBLE_LINES = 4;
 
 export interface CommentPayload {
   relPath: string;
@@ -61,7 +63,8 @@ export function createViewer(
   theme: Theme,
   requestComment: (payload: CommentPayload, comment: string) => void
 ): ViewerController {
-  const textInput = createTextInputBuffer();
+  const searchInput = createTextInputBuffer();
+  const commentInput = createTextInputBuffer({ preserveNewlines: true });
 
   const state: ViewerState = {
     file: null,
@@ -98,7 +101,8 @@ export function createViewer(
 
   function setMode(mode: ViewerMode): void {
     if (mode !== state.mode) {
-      textInput.reset();
+      searchInput.reset();
+      commentInput.reset();
     }
 
     state.mode = mode;
@@ -264,6 +268,38 @@ export function createViewer(
     return truncateToWidth(header, width);
   }
 
+  function renderCommentEditor(width: number): string[] {
+    const contentWidth = Math.max(1, width - 2);
+    const wrappedLines: string[] = [];
+    const logicalLines = state.commentText.split("\n");
+
+    for (const line of logicalLines) {
+      if (line.length === 0) {
+        wrappedLines.push("");
+        continue;
+      }
+      wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
+    }
+
+    if (wrappedLines.length === 0) {
+      wrappedLines.push("");
+    }
+
+    const lastIndex = wrappedLines.length - 1;
+    wrappedLines[lastIndex] = `${wrappedLines[lastIndex]}█`;
+
+    const overflow = Math.max(0, wrappedLines.length - COMMENT_EDITOR_MAX_VISIBLE_LINES);
+    const visibleLines = wrappedLines.slice(-COMMENT_EDITOR_MAX_VISIBLE_LINES);
+    if (overflow > 0 && visibleLines.length > 0) {
+      visibleLines[0] = `…${visibleLines[0]}`;
+    }
+
+    return [
+      truncateToWidth(theme.fg("accent", "Comment:"), width),
+      ...visibleLines.map(line => truncateToWidth(`  ${line}`, width)),
+    ];
+  }
+
   function renderFooter(width: number): string[] {
     const lines: string[] = [];
     const pct = state.content.length > 0
@@ -271,14 +307,13 @@ export function createViewer(
       : 0;
 
     if (state.mode === "comment") {
-      const prompt = theme.fg("accent", `Comment: ${state.commentText}█`);
-      lines.push(truncateToWidth(prompt, width));
+      lines.push(...renderCommentEditor(width));
       lines.push(theme.fg("borderMuted", "─".repeat(width)));
     }
 
     let help: string;
     if (state.mode === "comment") {
-      help = theme.fg("dim", "Enter: send  Esc: cancel");
+      help = theme.fg("dim", "Enter: newline  Ctrl+Enter: send  Esc: cancel");
     } else if (state.mode === "select") {
       help = theme.fg("dim", "j/k: extend  c: comment  Esc: cancel");
     } else if (state.mode === "search") {
@@ -363,19 +398,21 @@ export function createViewer(
       if (!state.file) return { type: "none" };
 
       if (state.mode === "comment") {
-        if (matchesKey(data, Key.enter)) {
+        if (matchesKey(data, "ctrl+enter")) {
           const comment = state.commentText.trim();
           if (comment) {
             sendComment(comment);
           } else {
             setMode("normal");
           }
+        } else if (matchesKey(data, Key.enter) || matchesKey(data, "shift+enter")) {
+          state.commentText += "\n";
         } else if (matchesKey(data, Key.escape)) {
           setMode("normal");
         } else if (matchesKey(data, Key.backspace)) {
           state.commentText = state.commentText.slice(0, -1);
         } else {
-          const text = textInput.push(data);
+          const text = commentInput.push(data);
           if (text) {
             state.commentText += text;
           }
@@ -392,7 +429,7 @@ export function createViewer(
           state.searchQuery = state.searchQuery.slice(0, -1);
           updateSearchMatches();
         } else {
-          const text = textInput.push(data);
+          const text = searchInput.push(data);
           if (text) {
             state.searchQuery += text;
             updateSearchMatches();

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -313,7 +313,7 @@ export function createViewer(
 
     let help: string;
     if (state.mode === "comment") {
-      help = theme.fg("dim", "Enter: newline  Ctrl+Enter: send  Esc: cancel");
+      help = theme.fg("dim", "Enter: newline  Ctrl+Enter/Ctrl+D: send  Esc: cancel");
     } else if (state.mode === "select") {
       help = theme.fg("dim", "j/k: extend  c: comment  Esc: cancel");
     } else if (state.mode === "search") {
@@ -398,7 +398,7 @@ export function createViewer(
       if (!state.file) return { type: "none" };
 
       if (state.mode === "comment") {
-        if (matchesKey(data, "ctrl+enter")) {
+        if (matchesKey(data, "ctrl+enter") || matchesKey(data, "ctrl+d") || matchesKey(data, "alt+enter")) {
           const comment = state.commentText.trim();
           if (comment) {
             sendComment(comment);


### PR DESCRIPTION
## Summary
- make the inline comment editor multiline with wrapped footer rendering
- use `Enter` for a new line and `Ctrl+Enter` to send the comment
- preserve pasted newlines in comment mode while keeping search input single-line

## Validation
- `tsc --noCheck --noEmit --moduleResolution nodenext --module nodenext --target ES2022 files-widget/*.ts`
- targeted Node check for `createTextInputBuffer({ preserveNewlines: true })`