### PR TITLE
fix(ralph-wiggum): restore currentLoop after compaction (#11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/ralph-wiggum/CHANGELOG.md
+++ b/ralph-wiggum/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.7 - 2026-04-19
+
+### Fixed
+- Ralph loops no longer silently stop after auto-compaction or `/compact`. On session reload, `currentLoop` is now rehydrated from the on-disk state (most-recently-updated active loop wins on ties), so `ralph_done`, `agent_end`, and `before_agent_start` continue to function. Thanks to @elecnix for the detailed report and proposed fix ([#11](https://github.com/tmustier/pi-extensions/issues/11)).
+
 ## 0.1.5 - 2026-02-03
 
 ### Added

--- a/ralph-wiggum/index.ts
+++ b/ralph-wiggum/index.ts
@@ -92,6 +92,14 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
+	function safeMtimeMs(filePath: string): number {
+		try {
+			return fs.statSync(filePath).mtimeMs;
+		} catch {
+			return 0;
+		}
+	}
+
 	function tryRemoveDir(dirPath: string): boolean {
 		try {
 			if (fs.existsSync(dirPath)) {
@@ -784,6 +792,21 @@ Examples:
 
 	pi.on("session_start", async (_event, ctx) => {
 		const active = listLoops(ctx).filter((l) => l.status === "active");
+
+		// Rehydrate currentLoop from disk. The module is re-initialized on
+		// session reload (including auto-compaction and /compact), which would
+		// otherwise leave `currentLoop` null and silently break ralph_done,
+		// agent_end, and before_agent_start. Pick the most-recently-updated
+		// active loop when there are multiple, using the state file mtime.
+		if (!currentLoop && active.length > 0) {
+			const mostRecent = active.reduce((best, candidate) => {
+				const bestMtime = safeMtimeMs(getPath(ctx, best.name, ".state.json"));
+				const candidateMtime = safeMtimeMs(getPath(ctx, candidate.name, ".state.json"));
+				return candidateMtime > bestMtime ? candidate : best;
+			});
+			currentLoop = mostRecent.name;
+		}
+
 		if (active.length > 0 && ctx.hasUI) {
 			const lines = active.map(
 				(l) => `  • ${l.name} (iteration ${l.iteration}${l.maxIterations > 0 ? `/${l.maxIterations}` : ""})`,

--- a/ralph-wiggum/package.json
+++ b/ralph-wiggum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-ralph-wiggum",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Long-running agent loops for iterative development in Pi.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
Fixes #11.

### Problem
Pi re-initializes the ralph-wiggum extension module on session reload (auto-compaction or `/compact`). The in-memory pointer

```typescript
let currentLoop: string | null = null;
```

resets to `null`, so after compaction `ralph_done` returns "No active Ralph loop" and `agent_end` / `before_agent_start` silently early-return. The on-disk state in `.ralph/<name>.state.json` is untouched — the extension just has no reference to it.

### Fix
Rehydrate `currentLoop` from disk in the `session_start` handler when nothing is active in memory. When multiple loops are active, pick the one whose state file mtime is newest — `saveState` rewrites on every iteration, so mtime naturally tracks real activity and is more robust than picking `active[0]`.

```typescript
if (!currentLoop && active.length > 0) {
  const mostRecent = active.reduce((best, candidate) => {
    const bestMtime = safeMtimeMs(getPath(ctx, best.name, ".state.json"));
    const candidateMtime = safeMtimeMs(getPath(ctx, candidate.name, ".state.json"));
    return candidateMtime > bestMtime ? candidate : best;
  });
  currentLoop = mostRecent.name;
}
```

### Changes
- `ralph-wiggum/index.ts` — add `safeMtimeMs` helper; rehydrate `currentLoop` in `session_start`
- `ralph-wiggum` → 0.1.7
- root `pi-extensions` → 0.1.31

Credit: thanks to @elecnix for the detailed root-cause analysis and proposed patch in #11.
