### PR TITLE
feat(files-widget): add a raw/render markdown toggle

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this extension will be documented in this file.
 
 ### Changed
 - Make the inline comment editor multiline with wrapped footer rendering, `Enter` for a new line, and `Ctrl+Enter`/`Ctrl+D` to send.
+- Add an `m` toggle for rendered vs raw Markdown in the viewer, and fall back to raw mode before line-based search or selection.
 
 ## [0.1.16] - 2026-04-19
 

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -113,6 +113,7 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 - `PgUp/PgDn`: page up/down
 - `g/G`: top/bottom
 - `d`: toggle diff (tracked files only)
+- `m`: toggle rendered/raw view for Markdown files
 - `/`: search (type to search)
 - `n` / `N`: next/prev match
 - `v`: select mode (line selection)
@@ -126,6 +127,7 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 ## Notes
 
 - Untracked files show as `[UNTRACKED]` and open in normal view.
+- Searching or selecting in rendered Markdown switches to raw mode first so line-based matches and comments stay aligned with the source file.
 - Folder LOCs are shown only when the folder is collapsed (expanded folders would duplicate counts).
 - Line counts load asynchronously; the header shows activity while counts are computed.
 - Large non-git folders load progressively and may show `[partial]` while loading in safe mode.

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -127,7 +127,7 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 ## Notes
 
 - Untracked files show as `[UNTRACKED]` and open in normal view.
-- Searching or selecting in rendered Markdown switches to raw mode first so line-based matches and comments stay aligned with the source file.
+- Searching in rendered Markdown switches to raw mode first, and selecting from rendered Markdown first switches you back to raw so line-based matches and comments stay aligned with the source file.
 - Folder LOCs are shown only when the folder is collapsed (expanded folders would duplicate counts).
 - Line counts load asynchronously; the header shows activity while counts are computed.
 - Large non-git folders load progressively and may show `[partial]` while loading in safe mode.

--- a/files-widget/TODO.md
+++ b/files-widget/TODO.md
@@ -46,7 +46,7 @@
 ### Markdown Rendering
 - [x] Detect `glow` availability
 - [x] Shell out to `glow` for .md files
-- [ ] Toggle between rendered and raw (`m` key?)
+- [x] Toggle between rendered and raw (`m`)
 - [x] Fallback to syntax-highlighted raw
 
 ### Diff View

--- a/files-widget/file-viewer.ts
+++ b/files-widget/file-viewer.ts
@@ -157,7 +157,8 @@ export function loadFileContent(
   cwd: string,
   diffMode: boolean,
   hasChanges: boolean,
-  width?: number
+  width?: number,
+  renderMarkdown = true
 ): string[] {
   const isMarkdown = filePath.endsWith(".md");
   const termWidth = width || process.stdout.columns || 80;
@@ -223,7 +224,7 @@ export function loadFileContent(
       }
     }
 
-    if (isMarkdown && hasCommand("glow")) {
+    if (isMarkdown && renderMarkdown && hasCommand("glow")) {
       try {
         const output = execSync(`glow -s dark -w ${termWidth} "${filePath}"`, { encoding: "utf-8", timeout: 10000 });
         if (output.trim()) {

--- a/files-widget/file-viewer.ts
+++ b/files-widget/file-viewer.ts
@@ -3,7 +3,7 @@ import { execSync } from "node:child_process";
 import { readFileSync, statSync } from "node:fs";
 
 import { isGitRepo } from "./git";
-import { hasCommand, stripLeadingEmptyLines } from "./utils";
+import { hasCommand, isMarkdownPath, stripLeadingEmptyLines } from "./utils";
 
 const DIFF_CONTENT_PREFIXES = new Set(["+", "-", " "]);
 
@@ -160,7 +160,7 @@ export function loadFileContent(
   width?: number,
   renderMarkdown = true
 ): string[] {
-  const isMarkdown = filePath.endsWith(".md");
+  const isMarkdown = isMarkdownPath(filePath);
   const termWidth = width || process.stdout.columns || 80;
 
   try {

--- a/files-widget/file-viewer.ts
+++ b/files-widget/file-viewer.ts
@@ -152,6 +152,11 @@ function wrapDeltaLines(lines: string[], width: number): string[] {
   return wrapped;
 }
 
+export interface LoadedFileContent {
+  lines: string[];
+  renderedMarkdown: boolean;
+}
+
 export function loadFileContent(
   filePath: string,
   cwd: string,
@@ -159,7 +164,7 @@ export function loadFileContent(
   hasChanges: boolean,
   width?: number,
   renderMarkdown = true
-): string[] {
+): LoadedFileContent {
   const isMarkdown = isMarkdownPath(filePath);
   const termWidth = width || process.stdout.columns || 80;
 
@@ -196,7 +201,7 @@ export function loadFileContent(
         }
 
         if (!diffOutput.trim()) {
-          return ["No diff available - file may be untracked or unchanged"];
+          return { lines: ["No diff available - file may be untracked or unchanged"], renderedMarkdown: false };
         }
 
         if (hasCommand("delta")) {
@@ -212,15 +217,15 @@ export function loadFileContent(
                 stdio: ["pipe", "pipe", "pipe"],
               }
             );
-            return wrapDeltaLines(stripLeadingEmptyLines(deltaOutput.split("\n")), termWidth);
+            return { lines: wrapDeltaLines(stripLeadingEmptyLines(deltaOutput.split("\n")), termWidth), renderedMarkdown: false };
           } catch {
             // Fall back to raw diff
           }
         }
 
-        return wrapDiffLines(stripLeadingEmptyLines(diffOutput.split("\n")), termWidth);
+        return { lines: wrapDiffLines(stripLeadingEmptyLines(diffOutput.split("\n")), termWidth), renderedMarkdown: false };
       } catch (e: any) {
-        return [`Diff error: ${e.message}`];
+        return { lines: [`Diff error: ${e.message}`], renderedMarkdown: false };
       }
     }
 
@@ -228,7 +233,7 @@ export function loadFileContent(
       try {
         const output = execSync(`glow -s dark -w ${termWidth} "${filePath}"`, { encoding: "utf-8", timeout: 10000 });
         if (output.trim()) {
-          return stripLeadingEmptyLines(output.split("\n"));
+          return { lines: stripLeadingEmptyLines(output.split("\n")), renderedMarkdown: true };
         }
       } catch {
         // Fall through to bat
@@ -237,16 +242,22 @@ export function loadFileContent(
 
     if (hasCommand("bat")) {
       try {
-        return execSync(
-          `bat --style=numbers --color=always --paging=never --wrap=auto --terminal-width=${termWidth} "${filePath}"`,
-          { encoding: "utf-8", timeout: 10000 }
-        ).split("\n");
+        return {
+          lines: execSync(
+            `bat --style=numbers --color=always --paging=never --wrap=auto --terminal-width=${termWidth} "${filePath}"`,
+            { encoding: "utf-8", timeout: 10000 }
+          ).split("\n"),
+          renderedMarkdown: false,
+        };
       } catch {
         try {
-          return execSync(
-            `bat --style=numbers --color=always --paging=never --terminal-width=${termWidth} "${filePath}"`,
-            { encoding: "utf-8", timeout: 10000 }
-          ).split("\n");
+          return {
+            lines: execSync(
+              `bat --style=numbers --color=always --paging=never --terminal-width=${termWidth} "${filePath}"`,
+              { encoding: "utf-8", timeout: 10000 }
+            ).split("\n"),
+            renderedMarkdown: false,
+          };
         } catch {
           // Fall through to raw file read
         }
@@ -254,8 +265,11 @@ export function loadFileContent(
     }
 
     const raw = readFileSync(filePath, "utf-8");
-    return raw.split("\n").map((line, i) => `${String(i + 1).padStart(4)} │ ${line}`);
+    return {
+      lines: raw.split("\n").map((line, i) => `${String(i + 1).padStart(4)} │ ${line}`),
+      renderedMarkdown: false,
+    };
   } catch (e: any) {
-    return [`Error loading file: ${e.message}`];
+    return { lines: [`Error loading file: ${e.message}`], renderedMarkdown: false };
   }
 }

--- a/files-widget/utils.ts
+++ b/files-widget/utils.ts
@@ -17,6 +17,10 @@ export function isIgnoredStatus(status?: string): boolean {
   return status === "!" || status === "!!";
 }
 
+export function isMarkdownPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".md");
+}
+
 export function stripLeadingEmptyLines(lines: string[]): string[] {
   let startIdx = 0;
   while (startIdx < lines.length && !lines[startIdx].trim()) {

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -11,7 +11,7 @@ import {
 } from "./constants";
 import { loadFileContent } from "./file-viewer";
 import type { FileNode } from "./types";
-import { isUntrackedStatus } from "./utils";
+import { isMarkdownPath, isUntrackedStatus } from "./utils";
 import { createTextInputBuffer } from "./input-utils";
 
 const COMMENT_EDITOR_MAX_VISIBLE_LINES = 4;
@@ -87,18 +87,19 @@ export function createViewer(
   };
 
   function isMarkdownFile(): boolean {
-    return !!state.file && state.file.name.toLowerCase().endsWith(".md");
+    return !!state.file && isMarkdownPath(state.file.path);
   }
 
   function isRenderedMarkdownMode(): boolean {
     return isMarkdownFile() && !state.diffMode && state.renderMarkdown;
   }
 
-  function switchMarkdownToRaw(): void {
-    if (!isRenderedMarkdownMode()) return;
+  function switchMarkdownToRaw(): boolean {
+    if (!isRenderedMarkdownMode()) return false;
     state.renderMarkdown = false;
-    state.lastRenderWidth = 0;
-    clampScroll();
+    const width = state.lastRenderWidth || process.stdout.columns || 80;
+    reloadContent(width);
+    return true;
   }
 
   function toggleMarkdownMode(): void {
@@ -372,7 +373,7 @@ export function createViewer(
       state.file = file;
       state.scroll = 0;
       state.diffMode = !!file.gitStatus && !isUntrackedStatus(file.gitStatus);
-      state.renderMarkdown = file.name.toLowerCase().endsWith(".md");
+      state.renderMarkdown = isMarkdownPath(file.path);
       setMode("normal");
       state.content = [];
       state.lastRenderWidth = 0;
@@ -548,7 +549,9 @@ export function createViewer(
         return { type: "none" };
       }
       if (matchesKey(data, "v") && state.mode !== "select") {
-        switchMarkdownToRaw();
+        if (switchMarkdownToRaw()) {
+          return { type: "none" };
+        }
         state.mode = "select";
         state.selectStart = state.scroll;
         state.selectEnd = state.scroll;

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -177,7 +177,9 @@ export function createViewer(
     if (!state.file) return;
     refreshRawContent();
     const hasChanges = !!state.file.gitStatus;
-    state.content = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width, state.renderMarkdown);
+    const result = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width, state.renderMarkdown);
+    state.content = result.lines;
+    state.renderMarkdown = result.renderedMarkdown;
     state.lastRenderWidth = width;
     clampScroll();
     if (state.searchQuery) {

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -36,6 +36,7 @@ interface ViewerState {
   rawContent: string;
   scroll: number;
   diffMode: boolean;
+  renderMarkdown: boolean;
   mode: ViewerMode;
   selectStart: number;
   selectEnd: number;
@@ -72,6 +73,7 @@ export function createViewer(
     rawContent: "",
     scroll: 0,
     diffMode: false,
+    renderMarkdown: true,
     mode: "normal",
     selectStart: 0,
     selectEnd: 0,
@@ -83,6 +85,30 @@ export function createViewer(
     lastLoadedMtimeMs: null,
     height: DEFAULT_VIEWER_HEIGHT,
   };
+
+  function isMarkdownFile(): boolean {
+    return !!state.file && state.file.name.toLowerCase().endsWith(".md");
+  }
+
+  function isRenderedMarkdownMode(): boolean {
+    return isMarkdownFile() && !state.diffMode && state.renderMarkdown;
+  }
+
+  function switchMarkdownToRaw(): void {
+    if (!isRenderedMarkdownMode()) return;
+    state.renderMarkdown = false;
+    state.lastRenderWidth = 0;
+    clampScroll();
+  }
+
+  function toggleMarkdownMode(): void {
+    if (!isMarkdownFile() || state.diffMode) return;
+    state.renderMarkdown = !state.renderMarkdown;
+    state.lastRenderWidth = 0;
+    resetSearch();
+    setMode("normal");
+    clampScroll();
+  }
 
   function resetSearch(): void {
     state.searchQuery = "";
@@ -150,7 +176,7 @@ export function createViewer(
     if (!state.file) return;
     refreshRawContent();
     const hasChanges = !!state.file.gitStatus;
-    state.content = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width);
+    state.content = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width, state.renderMarkdown);
     state.lastRenderWidth = width;
     clampScroll();
     if (state.searchQuery) {
@@ -239,6 +265,8 @@ export function createViewer(
       header += theme.fg("dim", " [UNTRACKED]");
     } else if (state.diffMode) {
       header += theme.fg("warning", " [DIFF]");
+    } else if (isMarkdownFile()) {
+      header += theme.fg("accent", state.renderMarkdown ? " [RENDERED]" : " [RAW]");
     }
     if (state.mode === "select" || state.mode === "comment") {
       header += theme.fg("accent", ` [SELECT ${state.selectStart + 1}-${state.selectEnd + 1}]`);
@@ -320,9 +348,10 @@ export function createViewer(
       help = theme.fg("dim", "Type to search  Enter: confirm  Esc: cancel");
     } else {
       const isUntracked = state.file && isUntrackedStatus(state.file.gitStatus);
+      const markdownHelp = isMarkdownFile() && !state.diffMode ? "m: raw/render  " : "";
       help = theme.fg(
         "dim",
-        `j/k: scroll  /: search  n/N: next/prev match  []: files  ${state.file?.gitStatus && !isUntracked ? "d: diff  " : ""}q: back  ${pct}%`
+        `j/k: scroll  /: search  n/N: next/prev match  ${markdownHelp}[]: files  ${state.file?.gitStatus && !isUntracked ? "d: diff  " : ""}q: back  ${pct}%`
       );
     }
     lines.push(truncateToWidth(help, width));
@@ -343,6 +372,7 @@ export function createViewer(
       state.file = file;
       state.scroll = 0;
       state.diffMode = !!file.gitStatus && !isUntrackedStatus(file.gitStatus);
+      state.renderMarkdown = file.name.toLowerCase().endsWith(".md");
       setMode("normal");
       state.content = [];
       state.lastRenderWidth = 0;
@@ -358,6 +388,7 @@ export function createViewer(
       state.file = null;
       state.content = [];
       state.rawContent = "";
+      state.renderMarkdown = true;
       state.lastLoadedMtimeMs = null;
       setMode("normal");
     },
@@ -452,6 +483,7 @@ export function createViewer(
         return { type: "none" };
       }
       if (matchesKey(data, "/") && state.mode !== "select") {
+        switchMarkdownToRaw();
         setMode("search");
         return { type: "none" };
       }
@@ -511,7 +543,12 @@ export function createViewer(
         state.scroll = 0;
         return { type: "none" };
       }
+      if (matchesKey(data, "m") && state.mode !== "select" && state.mode !== "comment") {
+        toggleMarkdownMode();
+        return { type: "none" };
+      }
       if (matchesKey(data, "v") && state.mode !== "select") {
+        switchMarkdownToRaw();
         state.mode = "select";
         state.selectStart = state.scroll;
         state.selectEnd = state.scroll;


### PR DESCRIPTION
## Summary
- add an `m` toggle to switch between rendered and raw Markdown in the viewer
- keep line-based search and selection aligned by switching rendered Markdown back to raw first
- document the new Markdown viewer behavior in the README and TODO

## Validation
- `tsc --noCheck --noEmit --moduleResolution nodenext --module nodenext --target ES2022 files-widget/*.ts`
- compiled CommonJS smoke test for Markdown viewer toggle/search/select behavior