### PR TITLE
feat(files-widget): notify after sending inline comments

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this extension will be documented in this file.
 ### Changed
 - Make the inline comment editor multiline with wrapped footer rendering, `Enter` for a new line, and `Ctrl+Enter`/`Ctrl+D` to send.
 - Add an `m` toggle for rendered vs raw Markdown in the viewer, and fall back to raw mode before line-based search or selection.
-- Show a confirmation toast after sending an inline comment back to the agent.
+- Show a sent/queued confirmation toast after returning an inline comment to the agent.
 
 ## [0.1.16] - 2026-04-19
 

--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this extension will be documented in this file.
 ### Changed
 - Make the inline comment editor multiline with wrapped footer rendering, `Enter` for a new line, and `Ctrl+Enter`/`Ctrl+D` to send.
 - Add an `m` toggle for rendered vs raw Markdown in the viewer, and fall back to raw mode before line-based search or selection.
+- Show a confirmation toast after sending an inline comment back to the agent.
 
 ## [0.1.16] - 2026-04-19
 

--- a/files-widget/TODO.md
+++ b/files-widget/TODO.md
@@ -74,7 +74,7 @@
 - [x] Format message with file path, line range, code snippet, comment
 - [x] Use `pi.sendUserMessage()` with `deliverAs: "followUp"`
 - [x] Handle case when agent is idle vs streaming
-- [ ] Show confirmation notification
+- [x] Show confirmation notification
 
 ## Phase 4: tuicr Integration (Optional)
 

--- a/files-widget/index.ts
+++ b/files-widget/index.ts
@@ -41,11 +41,14 @@ export default function editorExtension(pi: ExtensionAPI): void {
         };
 
         const requestComment = (payload: { relPath: string; lineRange: string; ext: string; selectedText: string }, comment: string) => {
-          pi.sendUserMessage(formatCommentMessage(payload, comment), {
-            deliverAs: "followUp",
-            streamingBehavior: "followUp" as any,
-          } as any);
-          ctx.ui.notify(`Comment sent to agent for ${payload.relPath} (${payload.lineRange})`, "success");
+          const message = formatCommentMessage(payload, comment);
+          if (ctx.isIdle()) {
+            pi.sendUserMessage(message);
+            ctx.ui.notify(`Comment sent to agent for ${payload.relPath} (${payload.lineRange})`, "success");
+          } else {
+            pi.sendUserMessage(message, { deliverAs: "followUp" });
+            ctx.ui.notify(`Comment queued for agent for ${payload.relPath} (${payload.lineRange})`, "info");
+          }
         };
 
         const requestRender = () => tui.requestRender();

--- a/files-widget/index.ts
+++ b/files-widget/index.ts
@@ -45,6 +45,7 @@ export default function editorExtension(pi: ExtensionAPI): void {
             deliverAs: "followUp",
             streamingBehavior: "followUp" as any,
           } as any);
+          ctx.ui.notify(`Comment sent to agent for ${payload.relPath} (${payload.lineRange})`, "success");
         };
 
         const requestRender = () => tui.requestRender();


### PR DESCRIPTION
## Summary
- show a success toast after an inline comment is sent back to the agent
- include the file path and line range in the notification for quick confirmation
- mark the remaining comment-send notification TODO item as done

## Validation
- `tsc --noCheck --noEmit --moduleResolution nodenext --module nodenext --target ES2022 files-widget/*.ts`