### PR TITLE
feat(files-widget): browse outside the current working directory

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `/readfiles` now supports browsing outside the current working directory. Press `u` to re-root to the parent, `.` to jump back to where you started, or pass an explicit starting path (`/readfiles <path>` or `/readfiles ~/somewhere`). The browser header shows the current root so you always know where you are, and comments on files outside the project use absolute paths so the agent can still find them.
+
 ## [0.1.18] - 2026-04-19
 
 ### Changed

--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this extension will be documented in this file.
 - `/readfiles` now supports browsing outside the current working directory. Press `u` to re-root to the parent, `.` to jump back to where you started, or pass an explicit starting path (`/readfiles <path>` or `/readfiles ~/somewhere`). The browser header shows the current root so you always know where you are, and comments on files outside the project use absolute paths so the agent can still find them.
 
 ### Fixed
+- Git status, diff stats, and untracked-file discovery now work when the browser root is a subdirectory of the git repository (e.g. after `u`, `.`, or `/readfiles <subdir>`, or when pi runs from a repo subdirectory). Previously repo-root-relative git paths were mixed with root-relative node keys, producing phantom tree entries, missing statuses, and unopenable nested paths.
+- Re-rooting the browser while a background directory scan or line-count batch is in flight no longer lets the stale batch mutate the new root's tree, node index, or scan state.
 - Use `where` instead of `which` on Windows to detect `bat`, `delta`, and `glow`, so the dependency check works when running from PowerShell or cmd.exe.
 
 ## [0.1.21] - 2026-05-07

--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `/readfiles` now supports browsing outside the current working directory. Press `u` to re-root to the parent, `.` to jump back to where you started, or pass an explicit starting path (`/readfiles <path>` or `/readfiles ~/somewhere`). The browser header shows the current root so you always know where you are, and comments on files outside the project use absolute paths so the agent can still find them.
+
 ### Fixed
 - Use `where` instead of `which` on Windows to detect `bat`, `delta`, and `glow`, so the dependency check works when running from PowerShell or cmd.exe.
 

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -81,7 +81,8 @@ The `/readfiles` browser requires these tools and will refuse to open until they
 
 ## Commands
 
-- `/readfiles` - open the file browser
+- `/readfiles` - open the file browser in the current directory
+- `/readfiles <path>` - open the file browser rooted at `<path>` (absolute, relative, or `~`-prefixed)
 - `/review` - open tuicr review flow
 - `/diff` - open critique (bunx critique)
 
@@ -106,6 +107,8 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 - `c`: toggle changed-only view
 - `]` / `[`: next/prev changed file
 - `/`: search (type to filter, `Esc` to exit)
+- `u`: go up one directory (re-root to parent)
+- `.`: jump back to the starting directory
 - `+` / `-`: increase/decrease browser height
 - `q`: close
 
@@ -130,6 +133,7 @@ If missing, `/review` or `/diff` will show a clear install prompt.
 
 - Untracked files show as `[UNTRACKED]` and open in normal view.
 - Searching in rendered Markdown switches to raw mode first, and selecting from rendered Markdown first switches you back to raw so line-based matches and comments stay aligned with the source file.
+- When you browse outside the current project directory, inline comments on those files use absolute paths so the agent can still locate them. Files inside the project continue to use project-relative paths.
 - Folder LOCs are shown only when the folder is collapsed (expanded folders would duplicate counts).
 - Line counts load asynchronously; the header shows activity while counts are computed.
 - Large non-git folders load progressively and may show `[partial]` while loading in safe mode.

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -81,7 +81,8 @@ The `/readfiles` browser requires these tools and will refuse to open until they
 
 ## Commands
 
-- `/readfiles` - open the file browser and viewer
+- `/readfiles` - open the file browser in the current directory
+- `/readfiles <path>` - open the file browser rooted at `<path>` (absolute, relative, or `~`-prefixed)
 
 Diff viewing is built into the file viewer: open a changed tracked file and press `d` to toggle the git diff view.
 
@@ -94,6 +95,8 @@ Diff viewing is built into the file viewer: open a changed tracked file and pres
 - `c`: toggle changed-only view
 - `]` / `[`: next/prev changed file
 - `/`: search (type to filter, `Esc` to exit)
+- `u`: go up one directory (re-root to parent)
+- `.`: jump back to the starting directory
 - `+` / `-`: increase/decrease browser height
 - `q`: close
 
@@ -118,6 +121,7 @@ Diff viewing is built into the file viewer: open a changed tracked file and pres
 
 - Untracked files show as `[UNTRACKED]` and open in normal view.
 - Searching in rendered Markdown switches to raw mode first, and selecting from rendered Markdown first switches you back to raw so line-based matches and comments stay aligned with the source file.
+- When you browse outside the current project directory, inline comments on those files use absolute paths so the agent can still locate them. Files inside the project continue to use project-relative paths.
 - Folder LOCs are shown only when the folder is collapsed (expanded folders would duplicate counts).
 - Line counts load asynchronously; the header shows activity while counts are computed.
 - Large non-git folders load progressively and may show `[partial]` while loading in safe mode.

--- a/files-widget/TODO.md
+++ b/files-widget/TODO.md
@@ -17,6 +17,7 @@
 - [x] Collapse/expand directories
 - [x] Navigation with `j/k` and arrow keys
 - [x] Enter to expand dir or open file
+- [x] Browse outside the current working directory (`u` to go up, `.` to reset, `/readfiles <path>` to start elsewhere)
 
 ### Git Integration
 - [x] Parse `git status --porcelain` output

--- a/files-widget/browser.ts
+++ b/files-widget/browser.ts
@@ -3,7 +3,7 @@ import { Key, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
 import { lstatSync, realpathSync, statSync } from "node:fs";
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 
 import {
   DEFAULT_BROWSER_HEIGHT,
@@ -98,11 +98,19 @@ function indexNodes(root: FileNode | null, map: Map<string, FileNode>): void {
   }
 }
 
-function getNodeDepth(node: FileNode, cwd: string): number {
-  if (node.path === cwd) return 0;
-  const rel = relative(cwd, node.path);
+function getNodeDepth(node: FileNode, root: string): number {
+  if (node.path === root) return 0;
+  const rel = relative(root, node.path);
   if (!rel) return 0;
   return rel.split(sep).length;
+}
+
+function formatRootPath(path: string): string {
+  const home = homedir();
+  if (!home) return path;
+  if (path === home) return "~";
+  if (path.startsWith(home + sep)) return "~" + path.slice(home.length);
+  return path;
 }
 
 function safeRealPathSync(path: string): string {
@@ -150,8 +158,8 @@ function hasAncestorRealPath(node: FileNode | undefined, realPath: string): bool
   return false;
 }
 
-function shouldSafeMode(cwd: string): boolean {
-  const resolved = resolve(cwd);
+function shouldSafeMode(path: string): boolean {
+  const resolved = resolve(path);
   const home = resolve(homedir());
   const root = resolve(sep);
   return resolved === home || resolved === root;
@@ -256,48 +264,39 @@ function collapseAllExcept(node: FileNode, keep: Set<FileNode>): void {
 }
 
 export function createFileBrowser(
-  cwd: string,
+  initialPath: string,
   agentModifiedFiles: Set<string>,
   theme: Theme,
   onClose: () => void,
   requestComment: (payload: CommentPayload, comment: string) => void,
-  requestRender: () => void
+  requestRender: () => void,
+  projectCwd: string = initialPath
 ): BrowserController {
   const ignored = getIgnoredNames();
-  const repo = isGitRepo(cwd);
-  let gitStatus = repo ? getGitStatus(cwd) : new Map<string, string>();
-  let diffStats = repo ? getGitDiffStats(cwd) : new Map<string, DiffStats>();
-  const gitBranch = repo ? getGitBranch(cwd) : "";
 
-  const viewer = createViewer(cwd, theme, requestComment);
+  let rootPath = resolve(initialPath);
+  const initialRoot = rootPath;
+  let repo = false;
+  let gitStatus = new Map<string, string>();
+  let diffStats = new Map<string, DiffStats>();
+  let gitBranch = "";
+
+  const viewer = createViewer({ getRoot: () => rootPath, projectCwd }, theme, requestComment);
   const textInput = createTextInputBuffer();
 
-  const root = repo
-    ? buildFileTreeFromPaths(cwd, getGitFileList(cwd), gitStatus, diffStats, ignored, agentModifiedFiles)
-    : {
-      name: ".",
-      path: cwd,
-      isDirectory: true,
-      realPath: safeRealPathSync(cwd),
-      children: undefined,
-      expanded: true,
-      hasChangedChildren: false,
-    };
-
-  const safeMode = !repo && shouldSafeMode(cwd);
   const scanState: ScanState = {
-    mode: repo ? "none" : safeMode ? "safe" : "full",
+    mode: "none",
     isScanning: false,
-    isPartial: safeMode,
+    isPartial: false,
     pending: 0,
     spinnerIndex: 0,
   };
 
   const browser: BrowserState = {
-    root,
+    root: null,
     flatList: [],
     fullList: [],
-    stats: getTreeStats(root),
+    stats: { totalLines: undefined, additions: 0, deletions: 0 },
     nodeByPath: new Map<string, FileNode>(),
     scanState,
     selectedIndex: 0,
@@ -307,10 +306,6 @@ export function createFileBrowser(
     browserHeight: DEFAULT_BROWSER_HEIGHT,
     lastPollTime: Date.now(),
   };
-
-  indexNodes(browser.root, browser.nodeByPath);
-  browser.flatList = browser.root ? flattenTree(browser.root) : [];
-  browser.fullList = browser.root ? flattenTree(browser.root, 0, true, true) : [];
 
   const lineCountCache = new Map<string, { size: number; mtimeMs: number; count: number }>();
   const lineCountQueue: FileNode[] = [];
@@ -446,7 +441,7 @@ export function createFileBrowser(
       const entries = await readdir(node.path, { withFileTypes: true });
       const sorted = [...entries].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
-      if (node.path === cwd && browser.scanState.mode === "full" && sorted.length >= SAFE_MODE_ENTRY_THRESHOLD) {
+      if (node.path === rootPath && browser.scanState.mode === "full" && sorted.length >= SAFE_MODE_ENTRY_THRESHOLD) {
         browser.scanState.mode = "safe";
         browser.scanState.isPartial = true;
         scanQueue.length = 0;
@@ -586,7 +581,7 @@ export function createFileBrowser(
 
   function applyGitUpdates(): void {
     for (const node of browser.nodeByPath.values()) {
-      const relPath = normalizeGitPath(relative(cwd, node.path));
+      const relPath = normalizeGitPath(relative(rootPath, node.path));
       node.gitStatus = gitStatus.get(relPath);
       node.diffStats = diffStats.get(relPath);
     }
@@ -611,7 +606,7 @@ export function createFileBrowser(
       const part = parts[i];
       if (ignored.has(part) || part.startsWith(".")) return null;
       currentRel = currentRel ? `${currentRel}/${part}` : part;
-      const dirPath = join(cwd, currentRel);
+      const dirPath = join(rootPath, currentRel);
       let dirNode = browser.nodeByPath.get(dirPath);
       if (!dirNode) {
         const depth = i + 1;
@@ -636,7 +631,7 @@ export function createFileBrowser(
     const fileName = parts[parts.length - 1];
     if (ignored.has(fileName) || fileName.startsWith(".")) return null;
 
-    const filePath = join(cwd, normalized);
+    const filePath = join(rootPath, normalized);
     const existing = browser.nodeByPath.get(filePath);
     if (existing) return existing;
 
@@ -704,8 +699,8 @@ export function createFileBrowser(
     const viewingFilePath = viewingFile?.path;
 
     if (repo) {
-      gitStatus = getGitStatus(cwd);
-      diffStats = getGitDiffStats(cwd);
+      gitStatus = getGitStatus(rootPath);
+      diffStats = getGitDiffStats(rootPath);
       applyGitUpdates();
       addUntrackedNodes();
     }
@@ -736,11 +731,65 @@ export function createFileBrowser(
     }
   }
 
-  if (repo) {
-    queueLineCountsForTree(browser.root);
-  } else if (browser.root) {
-    enqueueScan(browser.root, 0, true);
+  function loadRoot(newRoot: string): void {
+    rootPath = resolve(newRoot);
+
+    repo = isGitRepo(rootPath);
+    gitStatus = repo ? getGitStatus(rootPath) : new Map<string, string>();
+    diffStats = repo ? getGitDiffStats(rootPath) : new Map<string, DiffStats>();
+    gitBranch = repo ? getGitBranch(rootPath) : "";
+
+    const newRootNode: FileNode = repo
+      ? buildFileTreeFromPaths(rootPath, getGitFileList(rootPath), gitStatus, diffStats, ignored, agentModifiedFiles)
+      : {
+        name: ".",
+        path: rootPath,
+        isDirectory: true,
+        realPath: safeRealPathSync(rootPath),
+        children: undefined,
+        expanded: true,
+        hasChangedChildren: false,
+      };
+
+    browser.root = newRootNode;
+
+    const safeMode = !repo && shouldSafeMode(rootPath);
+    browser.scanState.mode = repo ? "none" : safeMode ? "safe" : "full";
+    browser.scanState.isScanning = false;
+    browser.scanState.isPartial = safeMode;
+    browser.scanState.pending = 0;
+
+    indexNodes(browser.root, browser.nodeByPath);
+    refreshLists();
+    browser.stats = getTreeStats(browser.root);
+
+    browser.selectedIndex = 0;
+    browser.searchQuery = "";
+    browser.searchMode = false;
+    textInput.reset();
+    browser.lastPollTime = Date.now();
+
+    if (repo) {
+      queueLineCountsForTree(browser.root);
+    } else if (browser.root) {
+      enqueueScan(browser.root, 0, true);
+    }
   }
+
+  function setRoot(newRoot: string): void {
+    if (viewer.isOpen()) {
+      viewer.close();
+    }
+    stopBackgroundTasks();
+    scanQueue.length = 0;
+    scanQueued.clear();
+    lineCountQueue.length = 0;
+    lineCountPending.clear();
+    loadRoot(newRoot);
+    requestRender();
+  }
+
+  loadRoot(initialRoot);
 
   function getDisplayList(): FlatNode[] {
     let list = browser.searchQuery ? browser.fullList : browser.flatList;
@@ -806,7 +855,7 @@ export function createFileBrowser(
     if (node.isDirectory) {
       node.expanded = !node.expanded;
       if (node.expanded && node.children === undefined) {
-        enqueueScan(node, getNodeDepth(node, cwd), true);
+        enqueueScan(node, getNodeDepth(node, rootPath), true);
       }
       refreshLists();
     }
@@ -818,7 +867,7 @@ export function createFileBrowser(
 
   function renderBrowser(width: number): string[] {
     const lines: string[] = [];
-    const pathDisplay = basename(cwd);
+    const pathDisplay = formatRootPath(rootPath);
     const branchDisplay = gitBranch ? theme.fg("accent", ` (${gitBranch})`) : "";
     const stats = browser.stats;
 
@@ -902,7 +951,7 @@ export function createFileBrowser(
     const changedIndicator = browser.showOnlyChanged ? theme.fg("warning", " [changed only]") : "";
     const help = browser.searchMode
       ? theme.fg("dim", "Type to search  ↑↓: nav  Enter: confirm  Esc: cancel")
-      : theme.fg("dim", "j/k: nav  []: next/prev change  c: toggle changed  /: search  q: close") + changedIndicator;
+      : theme.fg("dim", "j/k: nav  u: up  .: home  []: next/prev change  c: toggle changed  /: search  q: close") + changedIndicator;
     lines.push(truncateToWidth(help, width));
 
     return lines;
@@ -971,6 +1020,19 @@ export function createFileBrowser(
           browser.searchQuery += text;
           browser.selectedIndex = 0;
         }
+      }
+      return;
+    }
+    if (matchesKey(data, "u")) {
+      const parent = resolve(rootPath, "..");
+      if (parent !== rootPath) {
+        setRoot(parent);
+      }
+      return;
+    }
+    if (matchesKey(data, ".")) {
+      if (rootPath !== initialRoot) {
+        setRoot(initialRoot);
       }
       return;
     }

--- a/files-widget/browser.ts
+++ b/files-widget/browser.ts
@@ -3,7 +3,7 @@ import { Key, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
 import { lstatSync, realpathSync, statSync } from "node:fs";
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 
 import {
   DEFAULT_BROWSER_HEIGHT,
@@ -98,11 +98,19 @@ function indexNodes(root: FileNode | null, map: Map<string, FileNode>): void {
   }
 }
 
-function getNodeDepth(node: FileNode, cwd: string): number {
-  if (node.path === cwd) return 0;
-  const rel = relative(cwd, node.path);
+function getNodeDepth(node: FileNode, root: string): number {
+  if (node.path === root) return 0;
+  const rel = relative(root, node.path);
   if (!rel) return 0;
   return rel.split(sep).length;
+}
+
+function formatRootPath(path: string): string {
+  const home = homedir();
+  if (!home) return path;
+  if (path === home) return "~";
+  if (path.startsWith(home + sep)) return "~" + path.slice(home.length);
+  return path;
 }
 
 function safeRealPathSync(path: string): string {
@@ -150,8 +158,8 @@ function hasAncestorRealPath(node: FileNode | undefined, realPath: string): bool
   return false;
 }
 
-function shouldSafeMode(cwd: string): boolean {
-  const resolved = resolve(cwd);
+function shouldSafeMode(path: string): boolean {
+  const resolved = resolve(path);
   const home = resolve(homedir());
   const root = resolve(sep);
   return resolved === home || resolved === root;
@@ -256,48 +264,39 @@ function collapseAllExcept(node: FileNode, keep: Set<FileNode>): void {
 }
 
 export function createFileBrowser(
-  cwd: string,
+  initialPath: string,
   agentModifiedFiles: Set<string>,
   theme: Theme,
   onClose: () => void,
   requestComment: (payload: CommentPayload, comment: string) => void,
-  requestRender: () => void
+  requestRender: () => void,
+  projectCwd: string = initialPath
 ): BrowserController {
   const ignored = getIgnoredNames();
-  const repo = isGitRepo(cwd);
-  let gitStatus = repo ? getGitStatus(cwd) : new Map<string, string>();
-  let diffStats = repo ? getGitDiffStats(cwd) : new Map<string, DiffStats>();
-  const gitBranch = repo ? getGitBranch(cwd) : "";
 
-  const viewer = createViewer(cwd, theme, requestComment);
+  let rootPath = resolve(initialPath);
+  const initialRoot = rootPath;
+  let repo = false;
+  let gitStatus = new Map<string, string>();
+  let diffStats = new Map<string, DiffStats>();
+  let gitBranch = "";
+
+  const viewer = createViewer({ getRoot: () => rootPath, projectCwd }, theme, requestComment);
   const textInput = createTextInputBuffer();
 
-  const root = repo
-    ? buildFileTreeFromPaths(cwd, getGitFileList(cwd), gitStatus, diffStats, ignored, agentModifiedFiles)
-    : {
-      name: ".",
-      path: cwd,
-      isDirectory: true,
-      realPath: safeRealPathSync(cwd),
-      children: undefined,
-      expanded: true,
-      hasChangedChildren: false,
-    };
-
-  const safeMode = !repo && shouldSafeMode(cwd);
   const scanState: ScanState = {
-    mode: repo ? "none" : safeMode ? "safe" : "full",
+    mode: "none",
     isScanning: false,
-    isPartial: safeMode,
+    isPartial: false,
     pending: 0,
     spinnerIndex: 0,
   };
 
   const browser: BrowserState = {
-    root,
+    root: null,
     flatList: [],
     fullList: [],
-    stats: getTreeStats(root),
+    stats: { totalLines: undefined, additions: 0, deletions: 0 },
     nodeByPath: new Map<string, FileNode>(),
     scanState,
     selectedIndex: 0,
@@ -307,10 +306,6 @@ export function createFileBrowser(
     browserHeight: DEFAULT_BROWSER_HEIGHT,
     lastPollTime: Date.now(),
   };
-
-  indexNodes(browser.root, browser.nodeByPath);
-  browser.flatList = browser.root ? flattenTree(browser.root) : [];
-  browser.fullList = browser.root ? flattenTree(browser.root, 0, true, true) : [];
 
   const lineCountCache = new Map<string, { size: number; mtimeMs: number; count: number }>();
   const lineCountQueue: FileNode[] = [];
@@ -446,7 +441,7 @@ export function createFileBrowser(
       const entries = await readdir(node.path, { withFileTypes: true });
       const sorted = [...entries].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
-      if (node.path === cwd && browser.scanState.mode === "full" && sorted.length >= SAFE_MODE_ENTRY_THRESHOLD) {
+      if (node.path === rootPath && browser.scanState.mode === "full" && sorted.length >= SAFE_MODE_ENTRY_THRESHOLD) {
         browser.scanState.mode = "safe";
         browser.scanState.isPartial = true;
         scanQueue.length = 0;
@@ -586,7 +581,7 @@ export function createFileBrowser(
 
   function applyGitUpdates(): void {
     for (const node of browser.nodeByPath.values()) {
-      const relPath = normalizeGitPath(relative(cwd, node.path));
+      const relPath = normalizeGitPath(relative(rootPath, node.path));
       node.gitStatus = gitStatus.get(relPath);
       node.diffStats = diffStats.get(relPath);
     }
@@ -611,7 +606,7 @@ export function createFileBrowser(
       const part = parts[i];
       if (ignored.has(part) || part.startsWith(".")) return null;
       currentRel = currentRel ? `${currentRel}/${part}` : part;
-      const dirPath = join(cwd, currentRel);
+      const dirPath = join(rootPath, currentRel);
       let dirNode = browser.nodeByPath.get(dirPath);
       if (!dirNode) {
         const depth = i + 1;
@@ -636,7 +631,7 @@ export function createFileBrowser(
     const fileName = parts[parts.length - 1];
     if (ignored.has(fileName) || fileName.startsWith(".")) return null;
 
-    const filePath = join(cwd, normalized);
+    const filePath = join(rootPath, normalized);
     const existing = browser.nodeByPath.get(filePath);
     if (existing) return existing;
 
@@ -704,8 +699,8 @@ export function createFileBrowser(
     const viewingFilePath = viewingFile?.path;
 
     if (repo) {
-      gitStatus = getGitStatus(cwd);
-      diffStats = getGitDiffStats(cwd);
+      gitStatus = getGitStatus(rootPath);
+      diffStats = getGitDiffStats(rootPath);
       applyGitUpdates();
       addUntrackedNodes();
     }
@@ -736,11 +731,65 @@ export function createFileBrowser(
     }
   }
 
-  if (repo) {
-    queueLineCountsForTree(browser.root);
-  } else if (browser.root) {
-    enqueueScan(browser.root, 0, true);
+  function loadRoot(newRoot: string): void {
+    rootPath = resolve(newRoot);
+
+    repo = isGitRepo(rootPath);
+    gitStatus = repo ? getGitStatus(rootPath) : new Map<string, string>();
+    diffStats = repo ? getGitDiffStats(rootPath) : new Map<string, DiffStats>();
+    gitBranch = repo ? getGitBranch(rootPath) : "";
+
+    const newRootNode: FileNode = repo
+      ? buildFileTreeFromPaths(rootPath, getGitFileList(rootPath), gitStatus, diffStats, ignored, agentModifiedFiles)
+      : {
+        name: ".",
+        path: rootPath,
+        isDirectory: true,
+        realPath: safeRealPathSync(rootPath),
+        children: undefined,
+        expanded: true,
+        hasChangedChildren: false,
+      };
+
+    browser.root = newRootNode;
+
+    const safeMode = !repo && shouldSafeMode(rootPath);
+    browser.scanState.mode = repo ? "none" : safeMode ? "safe" : "full";
+    browser.scanState.isScanning = false;
+    browser.scanState.isPartial = safeMode;
+    browser.scanState.pending = 0;
+
+    indexNodes(browser.root, browser.nodeByPath);
+    refreshLists();
+    browser.stats = getTreeStats(browser.root);
+
+    browser.selectedIndex = 0;
+    browser.searchQuery = "";
+    browser.searchMode = false;
+    textInput.reset();
+    browser.lastPollTime = Date.now();
+
+    if (repo) {
+      queueLineCountsForTree(browser.root);
+    } else if (browser.root) {
+      enqueueScan(browser.root, 0, true);
+    }
   }
+
+  function setRoot(newRoot: string): void {
+    if (viewer.isOpen()) {
+      viewer.close();
+    }
+    stopBackgroundTasks();
+    scanQueue.length = 0;
+    scanQueued.clear();
+    lineCountQueue.length = 0;
+    lineCountPending.clear();
+    loadRoot(newRoot);
+    requestRender();
+  }
+
+  loadRoot(initialRoot);
 
   function getDisplayList(): FlatNode[] {
     let list = browser.searchQuery ? browser.fullList : browser.flatList;
@@ -806,7 +855,7 @@ export function createFileBrowser(
     if (node.isDirectory) {
       node.expanded = !node.expanded;
       if (node.expanded && node.children === undefined) {
-        enqueueScan(node, getNodeDepth(node, cwd), true);
+        enqueueScan(node, getNodeDepth(node, rootPath), true);
       }
       refreshLists();
     }
@@ -818,7 +867,7 @@ export function createFileBrowser(
 
   function renderBrowser(width: number): string[] {
     const lines: string[] = [];
-    const pathDisplay = basename(cwd);
+    const pathDisplay = formatRootPath(rootPath);
     const branchDisplay = gitBranch ? theme.fg("accent", ` (${gitBranch})`) : "";
     const stats = browser.stats;
 
@@ -902,7 +951,7 @@ export function createFileBrowser(
     const changedIndicator = browser.showOnlyChanged ? theme.fg("warning", " [changed only]") : "";
     const help = browser.searchMode
       ? theme.fg("dim", "Type to search  ↑↓: nav  Enter: confirm  Esc: cancel")
-      : theme.fg("dim", "j/k: nav  []: next/prev change  c: toggle changed  /: search  q: close") + changedIndicator;
+      : theme.fg("dim", "j/k: nav  u: up  .: home  []: next/prev change  c: toggle changed  /: search  q: close") + changedIndicator;
     lines.push(truncateToWidth(help, width));
 
     return lines;
@@ -971,6 +1020,19 @@ export function createFileBrowser(
           browser.searchQuery += text;
           browser.selectedIndex = 0;
         }
+      }
+      return;
+    }
+    if (matchesKey(data, "u")) {
+      const parent = resolve(rootPath, "..");
+      if (parent !== rootPath) {
+        setRoot(parent);
+      }
+      return;
+    }
+    if (matchesKey(data, ".")) {
+      if (rootPath !== initialRoot) {
+        setRoot(initialRoot);
       }
       return;
     }

--- a/files-widget/browser.ts
+++ b/files-widget/browser.ts
@@ -315,6 +315,10 @@ export function createFileBrowser(
   const scanQueue: Array<{ node: FileNode; depth: number }> = [];
   const scanQueued = new Set<string>();
   let scanTimer: ReturnType<typeof setTimeout> | null = null;
+  // Incremented on every (re-)root. In-flight async scan/line-count batches
+  // capture the value when they start and bail after each await if it changed,
+  // so work belonging to an old root can never mutate state for the new one.
+  let rootGeneration = 0;
 
   const normalizeGitPath = (path: string): string => path.split(sep).join("/");
 
@@ -376,15 +380,19 @@ export function createFileBrowser(
   async function processLineCountBatch(): Promise<void> {
     lineCountTimer = null;
     if (!browser.root) return;
+    const generation = rootGeneration;
     const batch = lineCountQueue.splice(0, LINE_COUNT_BATCH_SIZE);
     if (batch.length === 0) return;
 
     await Promise.all(
       batch.map(async node => {
         await updateLineCount(node);
-        lineCountPending.delete(node.path);
+        if (generation === rootGeneration) {
+          lineCountPending.delete(node.path);
+        }
       })
     );
+    if (generation !== rootGeneration) return;
 
     updateTreeStats(browser.root);
     browser.stats = getTreeStats(browser.root);
@@ -436,9 +444,10 @@ export function createFileBrowser(
     }
   }
 
-  async function scanDirectory(node: FileNode, depth: number): Promise<void> {
+  async function scanDirectory(node: FileNode, depth: number, generation: number): Promise<void> {
     try {
       const entries = await readdir(node.path, { withFileTypes: true });
+      if (generation !== rootGeneration) return;
       const sorted = [...entries].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
       if (node.path === rootPath && browser.scanState.mode === "full" && sorted.length >= SAFE_MODE_ENTRY_THRESHOLD) {
@@ -457,11 +466,13 @@ export function createFileBrowser(
         const childDepth = depth + 1;
 
         if (entry.isDirectory()) {
+          const dirRealPath = await realpath(fullPath).catch(() => resolve(fullPath));
+          if (generation !== rootGeneration) return;
           const dirNode: FileNode = {
             name: entry.name,
             path: fullPath,
             isDirectory: true,
-            realPath: await realpath(fullPath).catch(() => resolve(fullPath)),
+            realPath: dirRealPath,
             parent: node,
             children: undefined,
             expanded: childDepth < 1,
@@ -477,6 +488,7 @@ export function createFileBrowser(
 
         if (entry.isSymbolicLink()) {
           const pathInfo = await getPathInfo(fullPath, true);
+          if (generation !== rootGeneration) return;
           if (pathInfo.isDirectory) {
             const isCycle = pathInfo.realPath ? hasAncestorRealPath(node, pathInfo.realPath) : false;
             const dirNode: FileNode = {
@@ -526,16 +538,21 @@ export function createFileBrowser(
 
       node.children = [...dirs, ...files];
     } catch {
-      node.children = [];
+      if (generation === rootGeneration) {
+        node.children = [];
+      }
     } finally {
-      node.loading = false;
-      scanQueued.delete(node.path);
+      if (generation === rootGeneration) {
+        node.loading = false;
+        scanQueued.delete(node.path);
+      }
     }
   }
 
   async function processScanBatch(): Promise<void> {
     scanTimer = null;
     if (!browser.root) return;
+    const generation = rootGeneration;
     const batch = scanQueue.splice(0, getScanBatchSize());
     if (batch.length === 0) {
       browser.scanState.isScanning = false;
@@ -544,7 +561,8 @@ export function createFileBrowser(
     }
 
     for (const item of batch) {
-      await scanDirectory(item.node, item.depth);
+      await scanDirectory(item.node, item.depth, generation);
+      if (generation !== rootGeneration) return;
     }
 
     browser.scanState.pending = scanQueue.length;
@@ -732,6 +750,7 @@ export function createFileBrowser(
   }
 
   function loadRoot(newRoot: string): void {
+    rootGeneration += 1;
     rootPath = resolve(newRoot);
 
     repo = isGitRepo(rootPath);

--- a/files-widget/git.ts
+++ b/files-widget/git.ts
@@ -11,6 +11,27 @@ export function isGitRepo(cwd: string): boolean {
   }
 }
 
+/**
+ * Path of `cwd` relative to the repository top-level (e.g. "app/"), or "" when
+ * `cwd` is the top-level itself. `git status --porcelain` reports paths relative
+ * to the repository root, while `git ls-files` (and this widget's node keys) are
+ * relative to `cwd` — this prefix lets us translate between the two.
+ */
+function getGitPathPrefix(cwd: string): string {
+  try {
+    return execSync("git rev-parse --show-prefix", { cwd, encoding: "utf-8", timeout: 2000, stdio: "pipe" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+/** Convert a repo-root-relative path to a cwd-relative one; null if outside cwd. */
+function stripPathPrefix(filePath: string, prefix: string): string | null {
+  if (!prefix) return filePath;
+  if (filePath.startsWith(prefix)) return filePath.slice(prefix.length);
+  return null;
+}
+
 export function getGitStatus(cwd: string, options: { includeIgnored?: boolean } = {}): Map<string, string> {
   const status = new Map<string, string>();
   try {
@@ -18,11 +39,13 @@ export function getGitStatus(cwd: string, options: { includeIgnored?: boolean } 
     if (options.includeIgnored !== false) {
       flags.push("--ignored");
     }
+    const prefix = getGitPathPrefix(cwd);
     const output = execSync(`git status ${flags.join(" ")}`, { cwd, encoding: "utf-8", timeout: 5000, stdio: "pipe" });
     for (const line of output.split("\n")) {
       if (line.length < 3) continue;
       const statusCode = line.slice(0, 2).trim() || "?";
-      const filePath = line.slice(3);
+      const filePath = stripPathPrefix(line.slice(3), prefix);
+      if (filePath === null || !filePath) continue;
       status.set(filePath, statusCode);
     }
   } catch {}
@@ -39,6 +62,7 @@ export function getGitFileList(cwd: string): string[] {
   } catch {}
 
   try {
+    const prefix = getGitPathPrefix(cwd);
     const statusOutput = execSync("git status --porcelain -uall -z", { cwd, encoding: "utf-8", timeout: 5000, stdio: "pipe" });
     const entries = statusOutput.split("\0");
     for (let i = 0; i < entries.length; i++) {
@@ -52,8 +76,9 @@ export function getGitFileList(cwd: string): string[] {
       } else if (filePath.includes(" -> ")) {
         filePath = filePath.split(" -> ").pop() || filePath;
       }
-      if (filePath) {
-        files.add(filePath);
+      const relPath = filePath ? stripPathPrefix(filePath, prefix) : null;
+      if (relPath) {
+        files.add(relPath);
       }
     }
   } catch {}
@@ -72,8 +97,10 @@ export function getGitBranch(cwd: string): string {
 export function getGitDiffStats(cwd: string): Map<string, DiffStats> {
   const stats = new Map<string, DiffStats>();
   try {
-    // Get diff stats for modified files
-    const output = execSync("git diff --numstat HEAD", { cwd, encoding: "utf-8", timeout: 5000, stdio: "pipe" });
+    // Get diff stats for modified files. --relative keeps paths relative to cwd
+    // (and scoped to it) so they match the widget's cwd-relative node keys even
+    // when cwd is a subdirectory of the repository.
+    const output = execSync("git diff --relative --numstat HEAD", { cwd, encoding: "utf-8", timeout: 5000, stdio: "pipe" });
     for (const line of output.split("\n")) {
       const parts = line.split("\t");
       if (parts.length >= 3) {
@@ -84,7 +111,7 @@ export function getGitDiffStats(cwd: string): Map<string, DiffStats> {
       }
     }
     // Also get stats for staged files
-    const stagedOutput = execSync("git diff --numstat --cached", { cwd, encoding: "utf-8", timeout: 5000, stdio: "pipe" });
+    const stagedOutput = execSync("git diff --relative --numstat --cached", { cwd, encoding: "utf-8", timeout: 5000, stdio: "pipe" });
     for (const line of stagedOutput.split("\n")) {
       const parts = line.split("\t");
       if (parts.length >= 3) {

--- a/files-widget/index.ts
+++ b/files-widget/index.ts
@@ -7,12 +7,35 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { execSync, spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 
 import { createFileBrowser } from "./browser";
 import { POLL_INTERVAL_MS } from "./constants";
 import { formatCommentMessage } from "./comment";
 import { hasCommand } from "./utils";
+
+function resolveInitialPath(arg: string | undefined, cwd: string): { path: string; error?: string } {
+  if (!arg) return { path: cwd };
+  let candidate = arg.trim();
+  if (!candidate) return { path: cwd };
+  const home = homedir();
+  if (candidate === "~") {
+    candidate = home;
+  } else if (candidate.startsWith("~/")) {
+    candidate = join(home, candidate.slice(2));
+  }
+  const absolute = isAbsolute(candidate) ? candidate : resolve(cwd, candidate);
+  try {
+    if (!statSync(absolute).isDirectory()) {
+      return { path: cwd, error: `${absolute} is not a directory` };
+    }
+  } catch {
+    return { path: cwd, error: `${absolute} is not accessible` };
+  }
+  return { path: absolute };
+}
 
 export default function editorExtension(pi: ExtensionAPI): void {
   const cwd = process.cwd();
@@ -21,13 +44,20 @@ export default function editorExtension(pi: ExtensionAPI): void {
   const getMissingDeps = () => requiredDeps.filter((dep) => !hasCommand(dep));
 
   pi.registerCommand("readfiles", {
-    description: "Open file browser",
-    handler: async (_args, ctx) => {
+    description: "Open file browser (optional: /readfiles <path> to start outside the current directory)",
+    handler: async (args, ctx) => {
       const missing = getMissingDeps();
       if (missing.length > 0) {
         ctx.ui.notify(`files-widget requires ${missing.join(", ")}. Install: brew install bat git-delta glow`, "error");
         return;
       }
+
+      const resolved = resolveInitialPath(args, cwd);
+      if (resolved.error) {
+        ctx.ui.notify(resolved.error, "error");
+        return;
+      }
+      const initialPath = resolved.path;
 
       await ctx.ui.custom<void>((tui, theme, _kb, done) => {
         let pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -52,7 +82,15 @@ export default function editorExtension(pi: ExtensionAPI): void {
         };
 
         const requestRender = () => tui.requestRender();
-        const browser = createFileBrowser(cwd, agentModifiedFiles, theme, cleanup, requestComment, requestRender);
+        const browser = createFileBrowser(
+          initialPath,
+          agentModifiedFiles,
+          theme,
+          cleanup,
+          requestComment,
+          requestRender,
+          cwd
+        );
 
         pollInterval = setInterval(() => {
           requestRender();

--- a/files-widget/index.ts
+++ b/files-widget/index.ts
@@ -6,12 +6,35 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { join } from "node:path";
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 
 import { createFileBrowser } from "./browser";
 import { POLL_INTERVAL_MS } from "./constants";
 import { formatCommentMessage } from "./comment";
 import { hasCommand } from "./utils";
+
+function resolveInitialPath(arg: string | undefined, cwd: string): { path: string; error?: string } {
+  if (!arg) return { path: cwd };
+  let candidate = arg.trim();
+  if (!candidate) return { path: cwd };
+  const home = homedir();
+  if (candidate === "~") {
+    candidate = home;
+  } else if (candidate.startsWith("~/")) {
+    candidate = join(home, candidate.slice(2));
+  }
+  const absolute = isAbsolute(candidate) ? candidate : resolve(cwd, candidate);
+  try {
+    if (!statSync(absolute).isDirectory()) {
+      return { path: cwd, error: `${absolute} is not a directory` };
+    }
+  } catch {
+    return { path: cwd, error: `${absolute} is not accessible` };
+  }
+  return { path: absolute };
+}
 
 export default function editorExtension(pi: ExtensionAPI): void {
   const cwd = process.cwd();
@@ -20,13 +43,20 @@ export default function editorExtension(pi: ExtensionAPI): void {
   const getMissingDeps = () => requiredDeps.filter((dep) => !hasCommand(dep));
 
   pi.registerCommand("readfiles", {
-    description: "Open file browser",
-    handler: async (_args, ctx) => {
+    description: "Open file browser (optional: /readfiles <path> to start outside the current directory)",
+    handler: async (args, ctx) => {
       const missing = getMissingDeps();
       if (missing.length > 0) {
         ctx.ui.notify(`files-widget requires ${missing.join(", ")}. Install: brew install bat git-delta glow`, "error");
         return;
       }
+
+      const resolved = resolveInitialPath(args, cwd);
+      if (resolved.error) {
+        ctx.ui.notify(resolved.error, "error");
+        return;
+      }
+      const initialPath = resolved.path;
 
       await ctx.ui.custom<void>((tui, theme, _kb, done) => {
         let pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -51,7 +81,15 @@ export default function editorExtension(pi: ExtensionAPI): void {
         };
 
         const requestRender = () => tui.requestRender();
-        const browser = createFileBrowser(cwd, agentModifiedFiles, theme, cleanup, requestComment, requestRender);
+        const browser = createFileBrowser(
+          initialPath,
+          agentModifiedFiles,
+          theme,
+          cleanup,
+          requestComment,
+          requestRender,
+          cwd
+        );
 
         pollInterval = setInterval(() => {
           requestRender();

--- a/files-widget/viewer.ts
+++ b/files-widget/viewer.ts
@@ -59,11 +59,17 @@ export interface ViewerController {
   handleInput(data: string): ViewerAction;
 }
 
+export interface ViewerConfig {
+  getRoot: () => string;
+  projectCwd: string;
+}
+
 export function createViewer(
-  cwd: string,
+  config: ViewerConfig,
   theme: Theme,
   requestComment: (payload: CommentPayload, comment: string) => void
 ): ViewerController {
+  const { getRoot, projectCwd } = config;
   const searchInput = createTextInputBuffer();
   const commentInput = createTextInputBuffer({ preserveNewlines: true });
 
@@ -177,7 +183,7 @@ export function createViewer(
     if (!state.file) return;
     refreshRawContent();
     const hasChanges = !!state.file.gitStatus;
-    const result = loadFileContent(state.file.path, cwd, state.diffMode, hasChanges, width, state.renderMarkdown);
+    const result = loadFileContent(state.file.path, getRoot(), state.diffMode, hasChanges, width, state.renderMarkdown);
     state.content = result.lines;
     state.renderMarkdown = result.renderedMarkdown;
     state.lastRenderWidth = width;
@@ -242,7 +248,8 @@ export function createViewer(
 
     const rawLines = state.rawContent.split("\n");
     const selectedText = rawLines.slice(state.selectStart, state.selectEnd + 1).join("\n");
-    const relPath = relative(cwd, state.file.path);
+    const rel = relative(projectCwd, state.file.path);
+    const relPath = !rel || rel.startsWith("..") ? state.file.path : rel;
     const lineRange = state.selectStart === state.selectEnd
       ? `line ${state.selectStart + 1}`
       : `lines ${state.selectStart + 1}-${state.selectEnd + 1}`;


### PR DESCRIPTION
## Summary
Support browsing and searching outside the current working directory in `/readfiles`. Resolves #34.

## Behavior
- `u` re-roots the browser to the parent directory (no-op at `/`).
- `.` jumps back to the starting directory.
- `/readfiles <path>` accepts an absolute, relative (to the agent's cwd), or `~`-prefixed starting path and validates it up front — invalid paths surface a clear error toast and keep the prior state.
- The browser header shows the current root (home-relative when possible) so you can see where you are at a glance.
- Re-rooting rebuilds git status, branch, diff stats, the tree, and scan state cleanly. Existing safe-mode behavior is preserved when re-rooting to `$HOME` or `/`.
- Comments on files outside the project cwd fall back to absolute paths so the agent can still find them. Files inside the project continue to use project-relative paths.

## Implementation
- `createFileBrowser` now takes `initialPath` + optional `projectCwd` (default: `initialPath`).
- Introduced internal mutable `rootPath` state plus `loadRoot(newRoot)` / `setRoot(newRoot)` that stop background tasks, clear queues, and rebuild the tree.
- Viewer constructor now takes a config object `{ getRoot, projectCwd }` so git/diff commands run against the current root while comment payloads stay anchored to the agent's cwd.
- Help footer and README updated to document `u`, `.`, and the path argument.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Testing
- Typecheck: `tsc --noEmit --strict ...` — no new errors introduced (remaining errors are pre-existing in `main`).
- Targeted smoke test exercising initial render, `u`, and `.` via a compiled Node script (all assertions passed).
- Manual **tmux** test with real `pi` running the modified `index.ts`:
  - `/readfiles` opens at the project root; header and footer help show the new keys.
  - `u` re-roots to the parent dir; tree lists the original project as a subfolder.
  - Continuing to press `u` eventually hits `/` and triggers `[partial]` safe-mode.
  - `.` returns to the initial project root.
  - `/readfiles /some/absolute/path` opens that path (including a git repo with correct branch/diff stats).
  - `/readfiles ../sibling` resolves the relative path against the agent's cwd.
  - `/readfiles /nope` surfaces an error toast and keeps prior state.
  - Git → non-git transitions show the correct root header, scan behavior, and stats.

Credits: prompted by Pi Discord feedback from avg8888.
