### PR TITLE
Keep files-widget focused on readfiles

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-04-24
+
+### Removed
+- Remove the external `/readfiles-review` and `/readfiles-diff` commands so files-widget stays focused on the `/readfiles` browser/viewer.
+
+
 ## [0.1.18] - 2026-04-19
 
 ### Changed

--- a/files-widget/README.md
+++ b/files-widget/README.md
@@ -81,21 +81,9 @@ The `/readfiles` browser requires these tools and will refuse to open until they
 
 ## Commands
 
-- `/readfiles` - open the file browser
-- `/review` - open tuicr review flow
-- `/diff` - open critique (bunx critique)
+- `/readfiles` - open the file browser and viewer
 
-### Review/Diff Dependencies
-
-```bash
-brew install agavra/tap/tuicr
-brew install oven-sh/bun/bun
-```
-
-- `tuicr` is required for `/review`
-- `bun` is required for `/diff`
-
-If missing, `/review` or `/diff` will show a clear install prompt.
+Diff viewing is built into the file viewer: open a changed tracked file and press `d` to toggle the git diff view.
 
 ## Browser Keybindings
 

--- a/files-widget/index.ts
+++ b/files-widget/index.ts
@@ -1,12 +1,11 @@
 /**
  * Pi Editor Extension
  *
- * Provides an in-terminal file browser, viewer, and review workflow.
- * Use /files to open the file browser, navigate with j/k, Enter to view.
+ * Provides an in-terminal file browser and viewer.
+ * Use /readfiles to open the file browser, navigate with j/k, Enter to view.
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { execSync, spawnSync } from "node:child_process";
 import { join } from "node:path";
 
 import { createFileBrowser } from "./browser";
@@ -67,60 +66,6 @@ export default function editorExtension(pi: ExtensionAPI): void {
           invalidate: () => browser.invalidate(),
         };
       });
-    },
-  });
-
-  pi.registerCommand("readfiles-review", {
-    description: "Open tuicr to review changes and send feedback to agent",
-    handler: async (_args, ctx) => {
-      if (!hasCommand("tuicr")) {
-        ctx.ui.notify("Install tuicr: brew install agavra/tap/tuicr", "error");
-        return;
-      }
-
-      ctx.ui.notify("Opening tuicr... Press :wq or y to copy review", "info");
-
-      try {
-        spawnSync("tuicr", [], { cwd, stdio: "inherit" });
-
-        try {
-          const clipboard = execSync(
-            process.platform === "darwin" ? "pbpaste" : "xclip -selection clipboard -o",
-            { encoding: "utf-8", timeout: 5000 }
-          );
-
-          if (
-            clipboard.includes("## Review") ||
-            clipboard.includes("```") ||
-            clipboard.includes("[Issue]") ||
-            clipboard.includes("[Suggestion]")
-          ) {
-            pi.sendUserMessage(clipboard, { deliverAs: "steer" });
-            ctx.ui.notify("Review sent to agent", "success");
-          }
-        } catch {}
-      } catch (e: any) {
-        ctx.ui.notify(`tuicr error: ${e.message}`, "error");
-      }
-    },
-  });
-
-  pi.registerCommand("readfiles-diff", {
-    description: "Open critique to view diffs",
-    handler: async (args, ctx) => {
-      if (!hasCommand("bun")) {
-        ctx.ui.notify("critique requires Bun: brew install oven-sh/bun/bun", "error");
-        return;
-      }
-
-      const critiqueArgs = args ? args.split(" ") : [];
-      ctx.ui.notify("Opening critique...", "info");
-
-      try {
-        spawnSync("bunx", ["critique", ...critiqueArgs], { cwd, stdio: "inherit" });
-      } catch (e: any) {
-        ctx.ui.notify(`critique error: ${e.message}`, "error");
-      }
     },
   });
 

--- a/files-widget/package.json
+++ b/files-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-files-widget",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "In-terminal file browser and viewer for Pi.",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "MIT",
   "private": false,
   "keywords": [


### PR DESCRIPTION
## Summary\n- remove external /readfiles-review and /readfiles-diff commands from files-widget\n- document /readfiles as the sole command, with in-viewer diff toggle\n- bump package patch versions for release\n\n## Validation\n- npm pack --dry-run --workspace files-widget