### PR TITLE
Refresh extending-pi skill guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.42] - 2026-05-13
+
+### Changed
+- Refresh `extending-pi` and nested `skill-creator` guidance for current Pi docs, extension-first customization, and Agent Skills terminology.
+
 ## [0.1.40] - 2026-05-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Personal extensions for the [Pi coding agent](https://github.com/badlogic/pi-mon
 | [session-recap](session-recap/) | One-line recap above the editor when you refocus the terminal (or after idle). Keeps you in flow while multi-clauding |
 | [arcade](arcade/) | Play minigames while your tests run: 👾 sPIce-invaders, 👻 picman, 🏓 ping, 🧩 tetris, 🍄 mario-not |
 
-## Skills
+## Agent Skills
 
-| Skill | Description |
-|-------|-------------|
-| [extending-pi](extending-pi/) | Guide for extending Pi — decide between skills, extensions, prompt templates, themes, or packages. |
-| ↳ [skill-creator](extending-pi/skill-creator/) | Detailed guidance for creating Pi skills. |
-| [pi-ralph-wiggum](pi-ralph-wiggum/) | Skill instructions for long-running development loops. |
+| Agent Skill | Description |
+|-------------|-------------|
+| [extending-pi](extending-pi/) | Guide for extending Pi — decide between Agent Skills, extensions, prompt templates, themes, models/providers, or packages. |
+| ↳ [skill-creator](extending-pi/skill-creator/) | Detailed guidance for creating Agent Skills. |
+| [pi-ralph-wiggum](pi-ralph-wiggum/) | Agent Skill instructions for long-running development loops. |
 
 ## Install (pi package manager)
 

--- a/extending-pi/CHANGELOG.md
+++ b/extending-pi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2 - 2026-05-13
+- Refresh guidance for current Pi extension architecture: extensions can be single TypeScript files or packaged resources, with `package.json`/`pi` manifests for sharing.
+- Add an explicit "extend first, patch last" audit workflow requiring docs, examples, and installed types/source review before considering Pi internal patches.
+- Broaden the skill trigger to cover any request to modify Pi behavior.
+- Rename skill terminology to Agent Skills and pick up `skill-creator@0.3.2`.
+
 ## 0.1.1 - 2026-04-19
 - Pick up `skill-creator@0.3.1`: self-contained `validate_skill.py` via PEP 723 + `uv run` (no more system PyYAML requirement). Thanks to @tekumara for reporting ([#20](https://github.com/tmustier/pi-extensions/issues/20)).
 

--- a/extending-pi/README.md
+++ b/extending-pi/README.md
@@ -1,9 +1,11 @@
 # extending-pi
 
-Guide for extending Pi — decide between skills, extensions, prompt templates, themes, context files, or custom models, then create and package them.
+Guide for extending Pi — decide between Agent Skills, extensions, prompt templates, themes, context files, custom models/providers, and Pi packages, then create and package them.
 
-Includes nested sub-skills:
-- **skill-creator** — detailed guidance for creating Pi skills
+The skill emphasizes Pi's extension-first architecture: when changing Pi behavior, inspect the extension docs, examples, and installed types/source before considering a Pi internal patch.
+
+Includes nested Agent Skills:
+- **skill-creator** — detailed guidance for creating Agent Skills
 
 ## Installation
 

--- a/extending-pi/SKILL.md
+++ b/extending-pi/SKILL.md
@@ -55,7 +55,7 @@ Examples:
 
 Use this when the chosen artifact is a Pi TypeScript extension or provider extension.
 
-Agents often miss existing Pi extension points by reading only the first matching section or doing a heading search. Before deciding a Pi patch is needed:
+Agents often miss existing Pi extension points by reading only the first matching section or doing a heading search. Do the full extension audit:
 
 1. **Read `docs/extensions.md` fully.** Extension capabilities are spread across hooks, tools, commands, keybindings, resource loaders, renderers, session/compaction events, settings, and linked docs.
 2. **Follow relevant linked docs** for the surface you are changing: `docs/tui.md`, `docs/themes.md`, `docs/models.md`, `docs/custom-provider.md`, `docs/packages.md`, `docs/keybindings.md`, `docs/session-format.md`, or `docs/compaction.md`.
@@ -79,7 +79,7 @@ Before working on a patch:
 
 1. **Pick the artifact type** from the table above.
 2. **Do the behavior-change triage** for any Pi behavior change before touching internals.
-3. **For TypeScript extensions, complete the extension workflow** before deciding a patch is required.
+3. **For TypeScript extensions, complete the extension workflow.**
 4. **Scaffold from current docs/examples**, not from stale snippets in this skill.
 5. **Validate locally**:
    - Agent Skills: load with `pi --no-skills --skill /path/to/skill` or invoke `/skill:name`; if it does not trigger, check `name` and `description` frontmatter.

--- a/extending-pi/SKILL.md
+++ b/extending-pi/SKILL.md
@@ -1,27 +1,28 @@
 ---
 name: extending-pi
-description: Guide for changing or extending Pi's behaviour without patching internals first. Use when someone wants to modify how Pi behaves, add capabilities, build or package an extension, create an Agent Skill, add prompt templates/themes/context/model providers, configure Pi resources, or asks whether a Pi internal patch is needed.
+description: Guide for changing or extending Pi's behaviour. Use when someone wants to modify how Pi behaves, add capabilities, decide which Pi extension point or artifact to use, build or package an extension, create an Agent Skill, add prompt templates/themes/context/model providers, configure Pi resources, or asks whether a Pi internal patch is needed.
 ---
 
 # Extending Pi
 
-Help the user choose the right extension point, scaffold the right artifact, and package it when useful.
+Help the user choose what to build, scaffold the right artifact, and package it when useful.
 
 This skill is intentionally **not** an API reference. Pi's docs, examples, and installed TypeScript types are the source of truth for exact signatures and current behavior.
 
-## Core principle: extend first, patch last
+## Core principle: choose an extension point first, patch last
 
-Pi is designed to be extended. Any request to change Pi's behavior should start by looking for an extension-based solution.
+Pi has multiple public extension points: Agent Skills, context files, prompt templates, themes, packages, model configuration, provider extensions, settings, and TypeScript extensions. Do not jump straight to a TypeScript extension or Pi internal patch.
 
 Before editing Pi internals:
 
 1. **State the desired user-visible behavior** in one sentence.
-2. **Read the current docs for the relevant surface**, starting with `docs/extensions.md` and `examples/extensions/README.md` for behavior changes.
-3. **Inspect at least one relevant working example** under `examples/extensions/` and adapt that pattern where possible.
-4. **Inspect installed types/source if the docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
-5. **Only consider a Pi internal patch after the extension audit fails.** If a patch is still needed, record the docs/examples/source checked and explain why no existing extension point can cover the case. Prefer proposing the smallest public extension API addition when the behavior should be user-extensible.
+2. **Choose what to build** from the table below. Ask whether the need is instructions, configuration, a reusable package, a runtime hook/tool/UI, or a core bug fix.
+3. **Read the current docs for the chosen surface.** Use `docs/extensions.md` and `examples/extensions/README.md` when the chosen surface is a TypeScript extension; otherwise start with the artifact-specific docs in the table.
+4. **Inspect at least one relevant working example** and adapt that pattern where possible.
+5. **Inspect installed types/source if the docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points for extensions include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
+6. **Only consider a Pi internal patch after the public-extension-point audit fails.** If a patch is still needed, record the docs/examples/source checked and explain why no existing extension point can cover the case. Prefer proposing the smallest public extension API addition when the behavior should be user-extensible.
 
-Patch-level changes are appropriate for core bugs, missing primitives, or behavior that genuinely cannot be expressed through extensions, Agent Skills, prompt templates, themes, packages, settings, or model/provider configuration.
+Patch-level changes are appropriate for core bugs, missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points such as extensions, Agent Skills, prompt templates, themes, packages, settings, or model/provider configuration.
 
 ## What to build
 
@@ -51,20 +52,21 @@ Examples:
 - "Pi should have a structured `db_query` tool" → **Extension**
 - "Pi should change the footer, add plan mode, add subagents, or alter compaction" → **Extension**
 
-## Extension API audit checklist
+## Behavior-change audit checklist
 
 Use this checklist whenever the request is to modify Pi's behavior:
 
-1. Map the request to a likely extension capability: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
-2. Read the relevant section of `docs/extensions.md` and any linked docs (`docs/tui.md`, `docs/themes.md`, `docs/models.md`, `docs/custom-provider.md`, `docs/packages.md`, etc.).
-3. Inspect a matching example in `examples/extensions/` and copy its structure rather than inventing from memory.
-4. If still unsure, grep/read the installed Pi types or source for the exact API.
-5. Build as an extension or package unless the audit produces concrete evidence that no extension point exists.
+1. Decide the lightest artifact that could satisfy the request: Agent Skill, context file, prompt template, theme, model config/provider, settings, package, TypeScript extension, docs-only guidance, or core patch.
+2. If the likely answer is a TypeScript extension, map it to a current extension capability: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
+3. Read the relevant docs for that artifact and any linked docs (`docs/extensions.md`, `docs/tui.md`, `docs/themes.md`, `docs/models.md`, `docs/custom-provider.md`, `docs/packages.md`, etc.).
+4. Inspect a matching example when one exists, especially under `examples/extensions/` for TypeScript extensions, and copy its structure rather than inventing from memory.
+5. If still unsure, grep/read the installed Pi types or source for the exact API.
+6. Build using a public extension point unless the audit produces concrete evidence that none can cover the request.
 
 ## Quick-start steps
 
 1. **Pick the artifact type** from the table above.
-2. **Do the extension-first audit** for any Pi behavior change before touching internals.
+2. **Do the behavior-change audit** for any Pi behavior change before touching internals.
 3. **Scaffold from current docs/examples**, not from stale snippets in this skill.
 4. **Validate locally**:
    - Agent Skills: load with `pi --no-skills --skill /path/to/skill` or invoke `/skill:name`; if it does not trigger, check `name` and `description` frontmatter.

--- a/extending-pi/SKILL.md
+++ b/extending-pi/SKILL.md
@@ -1,61 +1,73 @@
 ---
 name: extending-pi
-description: Guide for extending Pi — decide between skills, extensions, prompt templates, themes, context files, or custom models, then scaffold files, configure manifests, and package them. Use when someone wants to extend Pi, add capabilities, create a skill, build an extension, make a Pi package, scaffold extension files, or configure a manifest.json.
+description: Guide for changing or extending Pi's behaviour without patching internals first. Use when someone wants to modify how Pi behaves, add capabilities, build or package an extension, create an Agent Skill, add prompt templates/themes/context/model providers, configure Pi resources, or asks whether a Pi internal patch is needed.
 ---
 
 # Extending Pi
 
-Help the user decide what to build, scaffold the right files, and point to detailed guidance.
+Help the user choose the right extension point, scaffold the right artifact, and package it when useful.
+
+This skill is intentionally **not** an API reference. Pi's docs, examples, and installed TypeScript types are the source of truth for exact signatures and current behavior.
+
+## Core principle: extend first, patch last
+
+Pi is designed to be extended. Any request to change Pi's behavior should start by looking for an extension-based solution.
+
+Before editing Pi internals:
+
+1. **State the desired user-visible behavior** in one sentence.
+2. **Read the current docs for the relevant surface**, starting with `docs/extensions.md` and `examples/extensions/README.md` for behavior changes.
+3. **Inspect at least one relevant working example** under `examples/extensions/` and adapt that pattern where possible.
+4. **Inspect installed types/source if the docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
+5. **Only consider a Pi internal patch after the extension audit fails.** If a patch is still needed, record the docs/examples/source checked and explain why no existing extension point can cover the case. Prefer proposing the smallest public extension API addition when the behavior should be user-extensible.
+
+Patch-level changes are appropriate for core bugs, missing primitives, or behavior that genuinely cannot be expressed through extensions, Agent Skills, prompt templates, themes, packages, settings, or model/provider configuration.
 
 ## What to build
 
-| Goal | Build a… | Key files to create | Where |
-|------|----------|-------------------|-------|
-| Teach Pi a workflow or how to use a tool/API/CLI | **Skill** | `SKILL.md` with YAML frontmatter + markdown body | Read `skill-creator/SKILL.md` for detailed guidance |
-| Give Pi a new tool, command, or runtime behavior | **Extension** | `manifest.json` + `src/index.ts` entry point | Read Pi docs: `docs/extensions.md` |
-| Reuse a prompt pattern with variables | **Prompt template** | `.md` file with `{{variable}}` placeholders | Read Pi docs: `docs/prompt-templates.md` |
-| Set project-wide coding guidelines | **Context file** | `AGENTS.md` in project root or `.pi/agent/` — just markdown | No extra docs needed |
-| Change Pi's appearance | **Theme** | `theme.json` with color and font definitions | Read Pi docs: `docs/themes.md` |
-| Add a model or provider | **Custom model** | `models.json` or extension with provider registration | Read Pi docs: `docs/models.md` (JSON) or `docs/custom-provider.md` (extension) |
-| Share any of the above | **Package** | `manifest.json` with dependencies and entry points | Read Pi docs: `docs/packages.md` |
+| Goal | Build a… | Key files / locations | Detailed source of truth |
+|------|----------|-----------------------|--------------------------|
+| Teach an agent a workflow, domain, or how to use a tool/API/CLI | **Agent Skill** | `SKILL.md` plus optional `scripts/`, `references/`, `assets/` in `.agents/skills/`, `.pi/skills/`, or a package | Read `skill-creator/SKILL.md` and Pi docs `docs/skills.md` |
+| Change Pi runtime behavior, add a typed tool, command, keybinding, event hook, UI, resource loader, provider, renderer, safety gate, or session behavior | **Extension** | TypeScript extension file in `.pi/extensions/`, `~/.pi/agent/extensions/`, or a Pi package | Read Pi docs `docs/extensions.md` plus relevant `examples/extensions/` code first |
+| Reuse a prompt pattern with variables | **Prompt template** | Markdown file in `.pi/prompts/`, `~/.pi/agent/prompts/`, or a package | Read `docs/prompt-templates.md` |
+| Set project-wide or user-wide instructions | **Context file** | `AGENTS.md`, `CLAUDE.md`, `SYSTEM.md`, or `APPEND_SYSTEM.md` as appropriate | Read the README Context Files / System Prompt sections |
+| Change Pi's appearance | **Theme** | JSON theme in `.pi/themes/`, `~/.pi/agent/themes/`, or a package | Read `docs/themes.md` |
+| Add or route models/providers | **models.json** or a **provider extension** | `~/.pi/agent/models.json` for supported APIs; extension for OAuth, dynamic discovery, or custom streaming | Read `docs/models.md` and `docs/custom-provider.md` |
+| Share any of the above | **Pi package** | `package.json` with a `pi` key or conventional `extensions/`, `skills/`, `prompts/`, `themes/` directories | Read `docs/packages.md` |
 
-## Skill vs Extension — the fuzzy boundary
+## Agent Skill terminology
 
-If `bash` + instructions can do it, prefer a **Skill** (simpler, no code to maintain). If you need event hooks, typed tools, UI components, or policy enforcement, use an **Extension**.
+Use **Agent Skill** / **Agent Skills** when referring to the artifact, rather than client-specific names. Skills follow the Agent Skills standard and can be used by multiple agent clients. It is fine to say "Pi loads Agent Skills from…" when discussing Pi-specific discovery paths.
+
+## Agent Skill vs Extension
+
+If instructions plus normal tools are enough, prefer an **Agent Skill**. If the harness itself must change behavior, prefer an **Extension**.
 
 Examples:
-- "Pi should know our deploy process" → **Skill** (workflow instructions)
-- "Pi should confirm before `rm -rf`" → **Extension** (event interception)
-- "Pi should use Brave Search" → **Skill** (instructions + CLI scripts)
-- "Pi should have a structured `db_query` tool" → **Extension** (registerTool)
 
-## Minimal working examples
+- "Pi should know our deploy process" → **Agent Skill** (workflow instructions and maybe helper scripts)
+- "Pi should confirm before `rm -rf`" → **Extension** (intercept tool calls)
+- "Pi should use Brave Search" → **Agent Skill** if a CLI/script plus instructions is enough; **Extension** if it needs a typed tool, custom UI, or runtime integration
+- "Pi should have a structured `db_query` tool" → **Extension**
+- "Pi should change the footer, add plan mode, add subagents, or alter compaction" → **Extension**
 
-**Skill** — place in `.pi/skills/my-skill/SKILL.md`:
-```markdown
----
-name: my-skill
-description: Does X when the user asks to Y.
----
-# My Skill
-Step 1: ...
-Step 2: ...
-```
+## Extension API audit checklist
 
-**Extension** — create `manifest.json` + `src/index.ts`:
-```json
-{ "name": "my-extension", "version": "0.1.0", "entry": "src/index.ts" }
-```
-```typescript
-import { registerTool } from "@anthropic/pi-sdk";
-registerTool("my_tool", { description: "..." }, async (input) => { /* ... */ });
-```
+Use this checklist whenever the request is to modify Pi's behavior:
+
+1. Map the request to a likely extension capability: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
+2. Read the relevant section of `docs/extensions.md` and any linked docs (`docs/tui.md`, `docs/themes.md`, `docs/models.md`, `docs/custom-provider.md`, `docs/packages.md`, etc.).
+3. Inspect a matching example in `examples/extensions/` and copy its structure rather than inventing from memory.
+4. If still unsure, grep/read the installed Pi types or source for the exact API.
+5. Build as an extension or package unless the audit produces concrete evidence that no extension point exists.
 
 ## Quick-start steps
 
 1. **Pick the artifact type** from the table above.
-2. **Scaffold the files** — create the key files using the minimal examples above.
-3. **Validate locally**:
-   - Skills: place `SKILL.md` in `.pi/skills/<name>/` and invoke the skill — if it doesn't trigger, check that `name` and `description` in frontmatter are set correctly.
-   - Extensions: run `pi ext install .` — if it fails with "missing entry", verify the `entry` path in `manifest.json` points to an existing file.
-4. **Package and share** — follow `docs/packages.md` to bundle and publish.
+2. **Do the extension-first audit** for any Pi behavior change before touching internals.
+3. **Scaffold from current docs/examples**, not from stale snippets in this skill.
+4. **Validate locally**:
+   - Agent Skills: load with `pi --no-skills --skill /path/to/skill` or invoke `/skill:name`; if it does not trigger, check `name` and `description` frontmatter.
+   - Extensions: test with `pi -e ./path/to/extension.ts`; for iterative work, put the extension in `.pi/extensions/` or `~/.pi/agent/extensions/` so `/reload` picks it up.
+   - Themes/prompts/packages/models: use the relevant docs' validation/loading path, then `/reload` or restart where required.
+5. **Package and share** when the result should be reusable: use `package.json` with a `pi` manifest or conventional resource directories, then test with `pi install ./path` or a git/npm source.

--- a/extending-pi/SKILL.md
+++ b/extending-pi/SKILL.md
@@ -9,32 +9,31 @@ Help the user choose what to build, scaffold the right artifact, and package it 
 
 This skill is intentionally **not** an API reference. Pi's docs, examples, and installed TypeScript types are the source of truth for exact signatures and current behavior.
 
-## Core principle: choose an extension point first, patch last
+## Core principle: choose a public extension point first, patch last
 
-Pi has multiple public extension points: Agent Skills, context files, prompt templates, themes, packages, model configuration, provider extensions, settings, and TypeScript extensions. Do not jump straight to a TypeScript extension or Pi internal patch.
-
-Before editing Pi internals:
-
-1. **State the desired user-visible behavior** in one sentence.
-2. **Choose what to build** from the table below. Ask whether the need is instructions, configuration, a reusable package, a runtime hook/tool/UI, or a core bug fix.
-3. **Read the current docs for the chosen surface.** Use `docs/extensions.md` and `examples/extensions/README.md` when the chosen surface is a TypeScript extension; otherwise start with the artifact-specific docs in the table.
-4. **Inspect at least one relevant working example** and adapt that pattern where possible.
-5. **Inspect installed types/source if the docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points for extensions include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
-6. **Only consider a Pi internal patch after the public-extension-point audit fails.** If a patch is still needed, record the docs/examples/source checked and explain why no existing extension point can cover the case. Prefer proposing the smallest public extension API addition when the behavior should be user-extensible.
-
-Patch-level changes are appropriate for core bugs, missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points such as extensions, Agent Skills, prompt templates, themes, packages, settings, or model/provider configuration.
+Pi has multiple public extension points: Agent Skills, context files, prompt templates, themes, packages, model configuration, provider extensions, settings, and TypeScript extensions. Do not jump straight to a TypeScript extension or Pi internal patch. Patch-level changes are appropriate for core bugs, missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points.
 
 ## What to build
 
 | Goal | Build a… | Key files / locations | Detailed source of truth |
 |------|----------|-----------------------|--------------------------|
 | Teach an agent a workflow, domain, or how to use a tool/API/CLI | **Agent Skill** | `SKILL.md` plus optional `scripts/`, `references/`, `assets/` in `.agents/skills/`, `.pi/skills/`, or a package | Read `skill-creator/SKILL.md` and Pi docs `docs/skills.md` |
-| Change Pi runtime behavior, add a typed tool, command, keybinding, event hook, UI, resource loader, provider, renderer, safety gate, or session behavior | **Extension** | TypeScript extension file in `.pi/extensions/`, `~/.pi/agent/extensions/`, or a Pi package | Read Pi docs `docs/extensions.md` plus relevant `examples/extensions/` code first |
+| Change Pi runtime behavior, add a typed tool, command, keybinding, event hook, UI, resource loader, provider, renderer, safety gate, or session behavior | **Extension** | TypeScript extension file in `.pi/extensions/`, `~/.pi/agent/extensions/`, or a Pi package | Read Pi docs `docs/extensions.md` fully plus relevant `examples/extensions/` code first |
 | Reuse a prompt pattern with variables | **Prompt template** | Markdown file in `.pi/prompts/`, `~/.pi/agent/prompts/`, or a package | Read `docs/prompt-templates.md` |
 | Set project-wide or user-wide instructions | **Context file** | `AGENTS.md`, `CLAUDE.md`, `SYSTEM.md`, or `APPEND_SYSTEM.md` as appropriate | Read the README Context Files / System Prompt sections |
 | Change Pi's appearance | **Theme** | JSON theme in `.pi/themes/`, `~/.pi/agent/themes/`, or a package | Read `docs/themes.md` |
 | Add or route models/providers | **models.json** or a **provider extension** | `~/.pi/agent/models.json` for supported APIs; extension for OAuth, dynamic discovery, or custom streaming | Read `docs/models.md` and `docs/custom-provider.md` |
 | Share any of the above | **Pi package** | `package.json` with a `pi` key or conventional `extensions/`, `skills/`, `prompts/`, `themes/` directories | Read `docs/packages.md` |
+
+## Behavior-change triage
+
+Use this before touching Pi internals:
+
+1. **State the desired user-visible behavior** in one sentence.
+2. **Choose the lightest artifact** from the table above. Ask whether the need is instructions, configuration, a reusable package, a runtime hook/tool/UI, or a core bug fix.
+3. **Read the current docs for the chosen surface.** Use the table's source-of-truth column; this skill should route you, not replace the docs.
+4. **Inspect a relevant working example** when one exists and adapt that pattern where possible.
+5. **Only consider a Pi internal patch after the public-extension-point audit fails.** If a patch is still needed, record the docs/examples/source checked and explain why no existing extension point can cover the case. Prefer proposing the smallest public extension API addition when the behavior should be user-extensible.
 
 ## Agent Skill terminology
 
@@ -52,24 +51,27 @@ Examples:
 - "Pi should have a structured `db_query` tool" → **Extension**
 - "Pi should change the footer, add plan mode, add subagents, or alter compaction" → **Extension**
 
-## Behavior-change audit checklist
+## TypeScript extension workflow
 
-Use this checklist whenever the request is to modify Pi's behavior:
+Use this when the chosen artifact is a Pi TypeScript extension or provider extension.
 
-1. Decide the lightest artifact that could satisfy the request: Agent Skill, context file, prompt template, theme, model config/provider, settings, package, TypeScript extension, docs-only guidance, or core patch.
-2. If the likely answer is a TypeScript extension, map it to a current extension capability: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
-3. Read the relevant docs for that artifact and any linked docs (`docs/extensions.md`, `docs/tui.md`, `docs/themes.md`, `docs/models.md`, `docs/custom-provider.md`, `docs/packages.md`, etc.).
-4. Inspect a matching example when one exists, especially under `examples/extensions/` for TypeScript extensions, and copy its structure rather than inventing from memory.
-5. If still unsure, grep/read the installed Pi types or source for the exact API.
-6. Build using a public extension point unless the audit produces concrete evidence that none can cover the request.
+Agents often miss existing Pi extension points by reading only the first matching section or doing a heading search. Before deciding a Pi patch is needed:
+
+1. **Read `docs/extensions.md` fully.** Extension capabilities are spread across hooks, tools, commands, keybindings, resource loaders, renderers, session/compaction events, settings, and linked docs.
+2. **Follow relevant linked docs** for the surface you are changing: `docs/tui.md`, `docs/themes.md`, `docs/models.md`, `docs/custom-provider.md`, `docs/packages.md`, `docs/keybindings.md`, `docs/session-format.md`, or `docs/compaction.md`.
+3. **Read `examples/extensions/README.md` and at least one matching example** under `examples/extensions/`. Copy current structure rather than inventing from memory.
+4. **Map the request to a current extension capability**: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
+5. **Inspect installed types/source if docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
+6. **Build as an extension or package unless the audit produces concrete evidence that no public extension point exists.** If a patch is required, document what was checked and prefer adding the smallest public extension API that would make the behavior extensible.
 
 ## Quick-start steps
 
 1. **Pick the artifact type** from the table above.
-2. **Do the behavior-change audit** for any Pi behavior change before touching internals.
-3. **Scaffold from current docs/examples**, not from stale snippets in this skill.
-4. **Validate locally**:
+2. **Do the behavior-change triage** for any Pi behavior change before touching internals.
+3. **For TypeScript extensions, complete the extension workflow** before deciding a patch is required.
+4. **Scaffold from current docs/examples**, not from stale snippets in this skill.
+5. **Validate locally**:
    - Agent Skills: load with `pi --no-skills --skill /path/to/skill` or invoke `/skill:name`; if it does not trigger, check `name` and `description` frontmatter.
    - Extensions: test with `pi -e ./path/to/extension.ts`; for iterative work, put the extension in `.pi/extensions/` or `~/.pi/agent/extensions/` so `/reload` picks it up.
    - Themes/prompts/packages/models: use the relevant docs' validation/loading path, then `/reload` or restart where required.
-5. **Package and share** when the result should be reusable: use `package.json` with a `pi` manifest or conventional resource directories, then test with `pi install ./path` or a git/npm source.
+6. **Package and share** when the result should be reusable: use `package.json` with a `pi` manifest or conventional resource directories, then test with `pi install ./path` or a git/npm source.

--- a/extending-pi/SKILL.md
+++ b/extending-pi/SKILL.md
@@ -11,7 +11,9 @@ This skill is intentionally **not** an API reference. Pi's docs, examples, and i
 
 ## Core principle: choose a public extension point first, patch last
 
-Pi has multiple public extension points: Agent Skills, context files, prompt templates, themes, packages, model configuration, provider extensions, settings, and TypeScript extensions. Do not jump straight to a TypeScript extension or Pi internal patch. Patch-level changes are appropriate for core bugs, missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points.
+Pi has multiple public extension points: Agent Skills, context files, prompt templates, themes, packages, model configuration, provider extensions, settings, and TypeScript extensions. Assume one of those is the right answer until proven otherwise; do not jump straight to a TypeScript extension or Pi internal patch.
+
+Patch-level changes are extremely rare. They are appropriate only for core bugs, truly missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points. Pi maintainers receive many AI-generated PRs, so do not start a patch unless you can explain the change, its edge cases, and why a public extension point cannot solve it.
 
 ## What to build
 
@@ -33,7 +35,8 @@ Use this before touching Pi internals:
 2. **Choose the lightest artifact** from the table above. Ask whether the need is instructions, configuration, a reusable package, a runtime hook/tool/UI, or a core bug fix.
 3. **Read the current docs for the chosen surface.** Use the table's source-of-truth column; this skill should route you, not replace the docs.
 4. **Inspect a relevant working example** when one exists and adapt that pattern where possible.
-5. **Only consider a Pi internal patch after the public-extension-point audit fails.** If a patch is still needed, record the docs/examples/source checked and explain why no existing extension point can cover the case. Prefer proposing the smallest public extension API addition when the behavior should be user-extensible.
+5. **Strongly discourage Pi internal patches.** Only consider one after the public-extension-point audit fails with concrete evidence. If a patch still appears necessary, record the docs/examples/source checked, explain why no public extension point can cover the case, and prefer the smallest public API addition when the behavior should be user-extensible.
+6. **Before working on a patch, read upstream contributor guidance** in `earendil-works/pi`: `CONTRIBUTING.md` and `AGENTS.md`. Ensure the proposed solution is minimal and maintainer-friendly before writing code.
 
 ## Agent Skill terminology
 
@@ -62,7 +65,8 @@ Agents often miss existing Pi extension points by reading only the first matchin
 3. **Read `examples/extensions/README.md` and at least one matching example** under `examples/extensions/`. Copy current structure rather than inventing from memory.
 4. **Map the request to a current extension capability**: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
 5. **Inspect installed types/source if docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
-6. **Build as an extension or package unless the audit produces concrete evidence that no public extension point exists.** If a patch is required, document what was checked and prefer adding the smallest public extension API that would make the behavior extensible.
+6. **Build as an extension or package unless the audit produces concrete evidence that no public extension point exists.** Treat patching Pi internals as the exceptional path, not the fallback.
+7. **If a patch is truly required, pause before coding.** Read `CONTRIBUTING.md` and `AGENTS.md` in `earendil-works/pi`, then write down: the desired behavior, the public extension points considered, the docs/examples/types/source inspected, why each public route fails, and the minimal code/API change proposed. If you cannot do that clearly, do not patch.
 
 ## Quick-start steps
 

--- a/extending-pi/SKILL.md
+++ b/extending-pi/SKILL.md
@@ -13,8 +13,6 @@ This skill is intentionally **not** an API reference. Pi's docs, examples, and i
 
 Pi has multiple public extension points: Agent Skills, context files, prompt templates, themes, packages, model configuration, provider extensions, settings, and TypeScript extensions. Assume one of those is the right answer until proven otherwise; do not jump straight to a TypeScript extension or Pi internal patch.
 
-Patch-level changes are extremely rare. They are appropriate only for core bugs, truly missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points. Pi maintainers receive many AI-generated PRs, so do not start a patch unless you can explain the change, its edge cases, and why a public extension point cannot solve it.
-
 ## What to build
 
 | Goal | Build a… | Key files / locations | Detailed source of truth |
@@ -35,8 +33,7 @@ Use this before touching Pi internals:
 2. **Choose the lightest artifact** from the table above. Ask whether the need is instructions, configuration, a reusable package, a runtime hook/tool/UI, or a core bug fix.
 3. **Read the current docs for the chosen surface.** Use the table's source-of-truth column; this skill should route you, not replace the docs.
 4. **Inspect a relevant working example** when one exists and adapt that pattern where possible.
-5. **Strongly discourage Pi internal patches.** Only consider one after the public-extension-point audit fails with concrete evidence. If a patch still appears necessary, record the docs/examples/source checked, explain why no public extension point can cover the case, and prefer the smallest public API addition when the behavior should be user-extensible.
-6. **Before working on a patch, read upstream contributor guidance** in `earendil-works/pi`: `CONTRIBUTING.md` and `AGENTS.md`. Ensure the proposed solution is minimal and maintainer-friendly before writing code.
+5. **If the request appears to require a Pi internal patch, stop and follow the patch policy below before writing code.** A patch should be the rare exception after the public-extension-point audit fails with concrete evidence.
 
 ## Agent Skill terminology
 
@@ -65,8 +62,18 @@ Agents often miss existing Pi extension points by reading only the first matchin
 3. **Read `examples/extensions/README.md` and at least one matching example** under `examples/extensions/`. Copy current structure rather than inventing from memory.
 4. **Map the request to a current extension capability**: events, tools, commands, shortcuts, flags, UI, custom rendering, resource discovery, model/provider registration, session/compaction hooks, tool operations, or packaging.
 5. **Inspect installed types/source if docs or examples are ambiguous** rather than guessing API names or signatures. Useful starting points include `dist/core/extensions/types.d.ts`, `dist/core/index.d.ts`, and the matching `src/` files when available.
-6. **Build as an extension or package unless the audit produces concrete evidence that no public extension point exists.** Treat patching Pi internals as the exceptional path, not the fallback.
-7. **If a patch is truly required, pause before coding.** Read `CONTRIBUTING.md` and `AGENTS.md` in `earendil-works/pi`, then write down: the desired behavior, the public extension points considered, the docs/examples/types/source inspected, why each public route fails, and the minimal code/API change proposed. If you cannot do that clearly, do not patch.
+6. **Build as an extension or package unless the audit produces concrete evidence that no public extension point exists.** If no public route works, stop and follow the patch policy before writing code.
+
+## Patch policy
+
+Patch-level changes are extremely rare. They are appropriate only for core bugs, truly missing primitives, or behavior that genuinely cannot be expressed through public Pi extension points. Pi maintainers receive many AI-generated PRs; protect their time by avoiding speculative patches and only proposing changes you understand.
+
+Before working on a patch:
+
+1. Read upstream contributor guidance in `earendil-works/pi`: `CONTRIBUTING.md` and `AGENTS.md`.
+2. Write down the desired behavior, the public extension points considered, the docs/examples/types/source inspected, and why each public route fails.
+3. Prefer the smallest public extension API addition when the behavior should be user-extensible; otherwise propose the minimal core fix.
+4. Ensure you can explain the code path, edge cases, tests, and interaction with the rest of Pi. If you cannot explain it clearly, do not patch.
 
 ## Quick-start steps
 

--- a/extending-pi/package.json
+++ b/extending-pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tmustier/extending-pi",
-  "version": "0.1.1",
-  "description": "Guide for extending Pi — skills, extensions, prompt templates, themes, and packaging.",
+  "version": "0.1.2",
+  "description": "Guide for extending Pi — Agent Skills, extensions, prompt templates, themes, models, providers, and packaging.",
   "license": "MIT",
   "author": "Thomas Mustier",
   "keywords": [

--- a/extending-pi/skill-creator/CHANGELOG.md
+++ b/extending-pi/skill-creator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2 - 2026-05-13
+- Rename artifact terminology from Pi skills to Agent Skills while keeping Pi-specific discovery and packaging guidance where relevant.
+- Refresh Pi discovery notes to include `.agents/skills` compatibility paths.
+
 ## 0.3.1 - 2026-04-19
 - `validate_skill.py` is now self-contained: uses a PEP 723 `uv run --script` shebang so PyYAML is provisioned in an ephemeral environment instead of requiring a system-wide install. Thanks to @tekumara for reporting ([#20](https://github.com/tmustier/pi-extensions/issues/20)).
 

--- a/extending-pi/skill-creator/README.md
+++ b/extending-pi/skill-creator/README.md
@@ -1,6 +1,6 @@
-# pi-skill-creator
+# Agent Skill Creator
 
-Guidelines and templates for creating Pi skills that follow the Agent Skills format.
+Guidelines and templates for creating Agent Skills that follow the Agent Skills format and can be loaded by Pi and other compatible agent clients.
 
 ## Installation
 `pi install npm:@tmustier/pi-skill-creator`

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -105,7 +105,7 @@ SKILL.md is the agent's interface to the skill — usage examples and input/outp
 
 ### 8) Validate and test
 
-- Run the validator script (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed):
+- Run this skill's bundled validator script from the `skill-creator` directory (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed):
 
 ```bash
 scripts/validate_skill.py /path/to/my-skill

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -129,11 +129,11 @@ pi --no-skills --skill /path/to/my-skill
 
 ### 9) Publish (optional)
 
-To share with Pi users, publish as a Pi package (package.json-based, not a `.skill` archive). Agent Skills can also be shared as normal directories or repositories for other compatible clients.
+To share with Pi users, make the skill installable with `pi install`: publish it as an npm, git, or local source that either has a `package.json` `pi.skills` manifest or uses the conventional `skills/` directory. Pi does not use `.skill` archives. `pi update` updates non-pinned npm/git installs; pinned refs/versions and local paths are not auto-updated. Agent Skills can also be shared as normal directories or repositories for other compatible clients.
 
-- Add `package.json` with a `pi` manifest (or rely on the conventional `skills/` directory).
+- Add `package.json` with a `pi` manifest, or place skills under the conventional `skills/` directory.
 - Add `"keywords": ["pi-package"]` for Pi package gallery discoverability.
-- Publish to npm or host in git; install with `pi install <source>` and enable via `pi config` if needed.
+- Publish to npm or host in git; install with `pi install npm:<package>` or `pi install git:github.com/org/repo` and enable via `pi config` if needed.
 
 ```json
 {

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -5,12 +5,7 @@ description: Create or update Agent Skills (SKILL.md plus optional scripts, refe
 
 # Skill Creator
 
-Provide guidance for creating effective **Agent Skills** that Pi and other compatible agent clients can load.
-
-## Principles
-
-- **Activation**: in Pi, automatic skill loading is driven by the frontmatter `description`; "when to use" details in the body come too late for auto-triggering.
-- **Interoperability**: call these artifacts Agent Skills, not client-specific skill names. Keep Pi-specific discovery or packaging notes clearly scoped to Pi.
+Provide guidance for creating effective **Agent Skills** that Pi and other compatible agent clients can load. Use Agent Skill / Agent Skills terminology, and keep Pi-specific discovery or packaging notes clearly scoped to Pi.
 
 ## Agent Skills format (Pi-compatible)
 
@@ -71,7 +66,7 @@ Short summary for humans discovering the skill.
 
 ### 5) Write frontmatter
 
-Use only the fields you need.
+Use only the fields you need. In Pi, automatic loading is driven by `description`, so put when-to-use triggers there.
 
 ```markdown
 ---

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -94,11 +94,11 @@ disable-model-invocation: true
 
 ### 7) Add resources
 
-SKILL.md is the agent's interface to the skill — usage examples and input/output descriptions let it call scripts without needing to understand internals.
+SKILL.md is the agent's interface to the skill.
 
-- **scripts/**: usage examples in SKILL.md inform the agent how to call them; scripts should be executable.
-- **references/**: a table of contents helps the agent navigate files longer than ~100 lines. References work best one level deep from SKILL.md, and each fact should live in one place (SKILL.md or a reference, not both).
-- **assets/**: templates, boilerplate, or data used in final output — typically not loaded into context.
+- **scripts/**: document each command the agent may call, including inputs and outputs; scripts should be executable.
+- **references/**: link each file from SKILL.md with when to read it; keep references one level deep and avoid duplicating facts.
+- **assets/**: mention only when a workflow needs a specific template, boilerplate, or data file.
 
 ### 8) Validate and test
 

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -1,32 +1,33 @@
 ---
 name: skill-creator
-description: Create or update Pi skills (SKILL.md plus optional scripts, references, or assets). Use when someone asks to design a new Pi skill, refine an existing one, or structure skills for Pi discovery or packaging.
+description: Create or update Agent Skills (SKILL.md plus optional scripts, references, or assets). Use when someone asks to design a new Agent Skill, refine an existing one, or structure skills for Pi discovery, packaging, or other Agent Skills-compatible clients.
 ---
 
 # Skill Creator
 
-Provide guidance for creating effective Pi skills.
+Provide guidance for creating effective **Agent Skills** that Pi and other compatible agent clients can load.
 
 ## Principles
 
-- **Conciseness**: the agent is already very capable - only domain-specific knowledge, workflows, and tooling it can't infer earn their token cost.
-- **Progressive disclosure**: Pi loads skills in tiers - frontmatter (always in context), body (on trigger), bundled resources (on demand) - so splitting content across them keeps context lean.
-- **Activation**: Pi decides whether to load a skill based solely on the frontmatter `description`. "When to use" information in the body comes too late.
+- **Conciseness**: the agent is already very capable — only domain-specific knowledge, workflows, and tooling it cannot infer earn their token cost.
+- **Progressive disclosure**: Agent Skills load in tiers — frontmatter (always in context), body (on trigger), bundled resources (on demand) — so splitting content across them keeps context lean.
+- **Activation**: in Pi, automatic skill loading is driven by the frontmatter `description`. "When to use" information in the body comes too late for auto-triggering.
 - **Context over directives**: the agent makes better decisions when it understands why. For tasks requiring judgment, context like "X helps Y because Z" is more robust than instructions like "You MUST do X".
+- **Interoperability**: call these artifacts Agent Skills, not client-specific skill names. Keep Pi-specific discovery or packaging notes clearly scoped to Pi.
 
-## Pi Agent Skills format
+## Agent Skills format (Pi-compatible)
 
 - Required frontmatter: `name`, `description`. Directory name must equal `name`.
 - Name rules: 1–64 chars, lowercase letters/digits/hyphens, no leading/trailing/consecutive hyphens.
-- Optional frontmatter: `license`, `compatibility`, `metadata` (arbitrary key-value pairs for tooling), `allowed-tools` (restrict which tools the skill may invoke).
-- `disable-model-invocation`: when set, Pi won't auto-trigger the skill; the user must invoke it explicitly with `/skill:name`.
+- Optional frontmatter: `license`, `compatibility`, `metadata` (arbitrary key-value pairs for tooling), `allowed-tools` (experimental; support varies by client).
+- `disable-model-invocation`: when set, Pi will not auto-trigger the skill; the user must invoke it explicitly with `/skill:name`.
 - Paths are relative to the skill directory; `{baseDir}` placeholders are not supported.
-- Skill locations: `~/.pi/agent/skills/`, `.pi/skills/`, `skills/` in a package, settings `skills`, or `--skill <path>`.
+- Pi loads Agent Skills from `~/.pi/agent/skills/`, `~/.agents/skills/`, `.pi/skills/`, `.agents/skills/`, package `skills` entries, settings `skills`, or `--skill <path>`.
 
 ## Recommended structure
 
 ```
-pi-skill/
+agent-skill/
 ├── SKILL.md
 ├── README.md         # Optional: human summary + installation
 ├── scripts/          # Optional executables
@@ -38,7 +39,7 @@ pi-skill/
 
 ### 1) Clarify use cases
 
-2-4 concrete example requests usually suffice to scope triggers and functionality.
+2–4 concrete example requests usually suffice to scope triggers and functionality.
 
 ### 2) Plan reusable resources
 
@@ -49,12 +50,14 @@ For each example, decide if you need:
 
 ### 3) Create the skeleton
 
-A skill needs a directory containing a SKILL.md. Only add resource sub-directories that are actually needed.
+An Agent Skill needs a directory containing a `SKILL.md`. Only add resource sub-directories that are actually needed.
 
 ```bash
 mkdir -p ~/.pi/agent/skills/my-skill
 touch ~/.pi/agent/skills/my-skill/SKILL.md
 ```
+
+Use `.agents/skills/` when you want the same skill directory to be naturally discoverable by other Agent Skills-compatible clients too.
 
 ### 4) Optional: Write README.md (humans + installation)
 
@@ -80,7 +83,7 @@ description: What it does + when to use it.
 ---
 ```
 
-If you need to hide auto-invocation, set:
+If you need to hide auto-invocation in Pi, set:
 
 ```yaml
 disable-model-invocation: true
@@ -90,7 +93,7 @@ disable-model-invocation: true
 
 - Imperative phrasing works well for procedural instructions; context framing works better for guidance (see Principles).
 - ~500 lines is a practical ceiling for SKILL.md; beyond that, split content into references.
-- The agent won't know a reference file exists unless SKILL.md says when to read it.
+- The agent will not know a reference file exists unless SKILL.md says when to read it.
 
 ### 7) Add resources
 
@@ -110,7 +113,7 @@ scripts/validate_skill.py /path/to/my-skill
 uv run scripts/validate_skill.py /path/to/my-skill
 ```
 
-- Load only the skill to spot warnings:
+- Load only the skill in Pi to spot warnings:
 
 ```bash
 pi --no-skills --skill /path/to/my-skill
@@ -126,15 +129,15 @@ pi --no-skills --skill /path/to/my-skill
 
 ### 9) Publish (optional)
 
-To share beyond a single machine, publish as a Pi package (package.json-based, not a .skill archive).
+To share with Pi users, publish as a Pi package (package.json-based, not a `.skill` archive). Agent Skills can also be shared as normal directories or repositories for other compatible clients.
 
 - Add `package.json` with a `pi` manifest (or rely on the conventional `skills/` directory).
-- Add `"keywords": ["pi-package"]` for discoverability.
+- Add `"keywords": ["pi-package"]` for Pi package gallery discoverability.
 - Publish to npm or host in git; install with `pi install <source>` and enable via `pi config` if needed.
 
 ```json
 {
-  "name": "my-pi-skills",
+  "name": "my-agent-skills",
   "keywords": ["pi-package"],
   "pi": { "skills": ["./skills"] }
 }

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -9,10 +9,8 @@ Provide guidance for creating effective **Agent Skills** that Pi and other compa
 
 ## Principles
 
-- **Conciseness**: the agent is already very capable — only domain-specific knowledge, workflows, and tooling it cannot infer earn their token cost.
 - **Progressive disclosure**: Agent Skills load in tiers — frontmatter (always in context), body (on trigger), bundled resources (on demand) — so splitting content across them keeps context lean.
 - **Activation**: in Pi, automatic skill loading is driven by the frontmatter `description`. "When to use" information in the body comes too late for auto-triggering.
-- **Context over directives**: the agent makes better decisions when it understands why. For tasks requiring judgment, context like "X helps Y because Z" is more robust than instructions like "You MUST do X".
 - **Interoperability**: call these artifacts Agent Skills, not client-specific skill names. Keep Pi-specific discovery or packaging notes clearly scoped to Pi.
 
 ## Agent Skills format (Pi-compatible)
@@ -105,7 +103,7 @@ SKILL.md is the agent's interface to the skill — usage examples and input/outp
 
 ### 8) Validate and test
 
-- Run this skill's bundled validator script from the `skill-creator` directory (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed):
+- Run the bundled validator at `scripts/validate_skill.py` from this `skill-creator` directory (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed):
 
 ```bash
 scripts/validate_skill.py /path/to/my-skill

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -9,8 +9,7 @@ Provide guidance for creating effective **Agent Skills** that Pi and other compa
 
 ## Principles
 
-- **Progressive disclosure**: Agent Skills load in tiers — frontmatter (always in context), body (on trigger), bundled resources (on demand) — so splitting content across them keeps context lean.
-- **Activation**: in Pi, automatic skill loading is driven by the frontmatter `description`. "When to use" information in the body comes too late for auto-triggering.
+- **Activation**: in Pi, automatic skill loading is driven by the frontmatter `description`; "when to use" details in the body come too late for auto-triggering.
 - **Interoperability**: call these artifacts Agent Skills, not client-specific skill names. Keep Pi-specific discovery or packaging notes clearly scoped to Pi.
 
 ## Agent Skills format (Pi-compatible)
@@ -127,16 +126,4 @@ pi --no-skills --skill /path/to/my-skill
 
 ### 9) Publish (optional)
 
-To share with Pi users, make the skill installable with `pi install`: publish it as an npm, git, or local source that either has a `package.json` `pi.skills` manifest or uses the conventional `skills/` directory. Pi does not use `.skill` archives. `pi update` updates non-pinned npm/git installs; pinned refs/versions and local paths are not auto-updated. Agent Skills can also be shared as normal directories or repositories for other compatible clients.
-
-- Add `package.json` with a `pi` manifest, or place skills under the conventional `skills/` directory.
-- Add `"keywords": ["pi-package"]` for Pi package gallery discoverability.
-- Publish to npm or host in git; install with `pi install npm:<package>` or `pi install git:github.com/org/repo` and enable via `pi config` if needed.
-
-```json
-{
-  "name": "my-agent-skills",
-  "keywords": ["pi-package"],
-  "pi": { "skills": ["./skills"] }
-}
-```
+When the user wants to share an Agent Skill with Pi users, read `references/PUBLISHING.md`. In short: make it installable with `pi install` from npm, git, or a local source; use either a `package.json` `pi.skills` manifest or the conventional `skills/` directory; Pi does not use `.skill` archives.

--- a/extending-pi/skill-creator/package.json
+++ b/extending-pi/skill-creator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tmustier/pi-skill-creator",
-  "version": "0.3.1",
-  "description": "Detailed guidance for creating Pi skills (Agent Skills format).",
+  "version": "0.3.2",
+  "description": "Detailed guidance for creating Agent Skills (Pi-compatible Agent Skills format).",
   "license": "MIT",
   "author": "Thomas Mustier",
   "keywords": [
@@ -10,10 +10,10 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tmustier/pi-extensions.git",
-    "directory": "pi-creator/skill-creator"
+    "directory": "extending-pi/skill-creator"
   },
   "bugs": "https://github.com/tmustier/pi-extensions/issues",
-  "homepage": "https://github.com/tmustier/pi-extensions/tree/main/pi-creator/skill-creator",
+  "homepage": "https://github.com/tmustier/pi-extensions/tree/main/extending-pi/skill-creator",
   "pi": {
     "skills": [
       "SKILL.md"

--- a/extending-pi/skill-creator/references/PUBLISHING.md
+++ b/extending-pi/skill-creator/references/PUBLISHING.md
@@ -1,0 +1,34 @@
+# Publishing Agent Skills for Pi
+
+To share with Pi users, make the skill installable with `pi install` from an npm package, git repository, or local path.
+
+Pi can load skills from either:
+
+1. A `package.json` `pi.skills` manifest, or
+2. The conventional `skills/` directory.
+
+Pi does not use `.skill` archives.
+
+`pi update` updates non-pinned npm and git installs. Pinned refs/versions and local paths are not auto-updated.
+
+## Minimal package.json
+
+```json
+{
+  "name": "my-agent-skills",
+  "keywords": ["pi-package"],
+  "pi": { "skills": ["./skills"] }
+}
+```
+
+## Install examples
+
+```bash
+pi install npm:<package>
+pi install git:github.com/org/repo
+pi install ./local/path
+```
+
+Use `pi config` if the user needs to enable, disable, or filter resources after installation.
+
+Agent Skills can also be shared as normal directories or repositories for other compatible clients.

--- a/extending-pi/skill-creator/scripts/validate_skill.py
+++ b/extending-pi/skill-creator/scripts/validate_skill.py
@@ -4,7 +4,7 @@
 # dependencies = ["pyyaml>=6"]
 # ///
 """
-Validate a Pi skill directory for Agent Skills + README requirements.
+Validate an Agent Skill directory for Agent Skills + README requirements.
 
 Usage:
   scripts/validate_skill.py <skill_directory>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "MIT",
   "private": false,
   "keywords": [


### PR DESCRIPTION
## Summary
- update extending-pi to emphasize extension-first customization before Pi internal patches
- broaden triggers for behavior changes and remove stale extension scaffolding/API snippets
- rename Pi-specific skill wording to Agent Skills across the skill, nested skill, README, and package metadata

## Validation
- `extending-pi/skill-creator/scripts/validate_skill.py extending-pi`
- `extending-pi/skill-creator/scripts/validate_skill.py extending-pi/skill-creator`
- `python3 -m json.tool` on root and nested package manifests
- `git diff --check`
- `npm pack --dry-run --json` in `extending-pi` and `extending-pi/skill-creator`