### PR TITLE
fix(files-widget): use 'where' instead of 'which' on Windows for dep detection

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Use `where` instead of `which` on Windows to detect `bat`, `delta`, and `glow`, so the dependency check works when running from PowerShell or cmd.exe.
+
 ## [0.1.21] - 2026-05-07
 
 ### Changed

--- a/files-widget/utils.ts
+++ b/files-widget/utils.ts
@@ -2,7 +2,8 @@ import { execSync } from "node:child_process";
 
 export function hasCommand(cmd: string): boolean {
   try {
-    execSync(`which ${cmd}`, { stdio: "ignore" });
+    const checkCmd = process.platform === "win32" ? "where" : "which";
+    execSync(`${checkCmd} ${cmd}`, { stdio: "ignore" });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

`hasCommand()` uses `which` via `execSync()` to detect whether `bat`, `delta`, and `glow` are installed. On Windows, Node.js's `execSync()` defaults to `cmd.exe` as the shell, where `which` is not a valid command. This causes the check to always fail, and the startup dependency warning fires even when all three tools are installed and on PATH.

Fixes dependency detection for `/readfiles` on Windows.

## Behavior

- On Windows (`process.platform === "win32"`), uses `where` — the Windows command available from the default `cmd.exe` shell used by Node.js's `execSync()`.
- On macOS/Linux, keeps `which` — no change for existing users.

## Implementation

Small change in `hasCommand()` inside `utils.ts`: platform-conditional command selection before the `execSync` call.

## Testing

- Verified `where bat` / `where delta` / `where glow` return exit code 0 from `cmd.exe` on Windows 11.
- Also verified that `bat`, `delta`, and `glow` are correctly found when `hasCommand` uses `where` from a Node.js `execSync()` context on Windows, regardless of whether pi is launched from PowerShell or Git Bash (on Windows, `process.platform` is always `"win32"`, so the `where` path is taken).
- The `which` fallback (macOS/Linux path) is kept unchanged; no behavioral regression expected.