### PR TITLE
chore(deps-dev): align all @earendil-works dev deps at ^0.80.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .research/
 control/
 review/
+node_modules/
+package-lock.json

--- a/agent-guidance/package.json
+++ b/agent-guidance/package.json
@@ -23,6 +23,6 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8"
+    "@earendil-works/pi-coding-agent": "^0.80.3"
   }
 }

--- a/arcade/package.json
+++ b/arcade/package.json
@@ -29,7 +29,7 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   }
 }

--- a/code-actions/package.json
+++ b/code-actions/package.json
@@ -25,7 +25,7 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   }
 }

--- a/files-widget/package.json
+++ b/files-widget/package.json
@@ -28,7 +28,7 @@
     "video": "https://raw.githubusercontent.com/tmustier/pi-extensions/main/files-widget/demo.mp4"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.79.8",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-agent-core": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   }
 }

--- a/pi-ralph-wiggum/package.json
+++ b/pi-ralph-wiggum/package.json
@@ -27,6 +27,6 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8"
+    "@earendil-works/pi-coding-agent": "^0.80.3"
   }
 }

--- a/raw-paste/package.json
+++ b/raw-paste/package.json
@@ -24,6 +24,6 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8"
+    "@earendil-works/pi-coding-agent": "^0.80.3"
   }
 }

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -25,7 +25,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.79.8"
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3"
   }
 }

--- a/tab-status/package.json
+++ b/tab-status/package.json
@@ -26,8 +26,8 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.79.8"
+    "@earendil-works/pi-agent-core": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3"
   }
 }

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -25,7 +25,7 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   }
 }

--- a/weather/package.json
+++ b/weather/package.json
@@ -50,7 +50,7 @@
     "video": "https://raw.githubusercontent.com/tmustier/pi-extensions/main/weather/assets/weather-demo.mp4"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.8",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #47. That bump only moved `pi-coding-agent` to `^0.79.8` and left `pi-tui` / `pi-ai` / `pi-agent-core` at `^0.74.0`. Since 0.x caret ranges don't cross minor versions, `^0.79.8` also excluded the current 0.80.x line. This aligns all four `@earendil-works` dev deps at `^0.80.3` (current latest for all four) so editor types match the current runtime.

Also adds `node_modules/` and `package-lock.json` to `.gitignore` — they were previously unignored.

Peer deps (`"*"`) untouched.

## Verification
- `npm install` at root, then spot-typechecked:
  - `pi-ralph-wiggum/index.ts` — clean against 0.80.3.
  - `arcade/tetris.ts` — one error (`TetrisComponent` missing `Component.invalidate`), confirmed **pre-existing**: `invalidate()` is required in pi-tui 0.74.0 too. Tracked separately from this chore.