### PR TITLE
Fix Ralph loop rehydration across unrelated Pi sessions

### DIFF
--- a/pi-ralph-wiggum/CHANGELOG.md
+++ b/pi-ralph-wiggum/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Bind active Ralph loops to their owning Pi session. Reloads and compaction restore only that session's loop; unrelated sessions sharing the same working directory no longer receive Ralph prompt injection or mutate the loop. `/ralph resume <name>` explicitly transfers ownership.
+
+Thanks to @juicetin for the detailed report, regression test, and implementation ([#50](https://github.com/tmustier/pi-extensions/issues/50), [#52](https://github.com/tmustier/pi-extensions/pull/52)).
+
+### Documentation
+- Clarify that Ralph iterations are turns within one Pi session and context window, with normal Pi compaction, rather than fresh sessions per iteration.
+
+Thanks to @rhossack and @RichardScottOZ for prompting the clarification ([#46](https://github.com/tmustier/pi-extensions/issues/46)).
+
 ## [0.2.2] - 2026-07-04
 
 ### Changed

--- a/pi-ralph-wiggum/README.md
+++ b/pi-ralph-wiggum/README.md
@@ -51,6 +51,12 @@ You ask Pi to set up a ralph-wiggum loop.
   - You hit `esc` (pausing the loop)
 If you hit `esc`, you can run `/ralph-stop` to clear the loop. Alternatively, just tell Pi to continue to keep going.
 
+## Iterations, sessions and context windows
+
+An iteration is a new agent turn in the same Pi session, not a fresh context window. `ralph_done` queues the next prompt and the task file carries durable progress, while Pi's normal compaction can summarise older conversation when the context grows. This extension deliberately uses that flat, in-session design; it does not launch a new Pi process or session for each iteration.
+
+Each active loop is owned by the Pi session that started or explicitly resumed it. Reloading or compacting that same session restores its loop automatically. A different session in the same working directory can see that active loops exist, but it does not receive Ralph prompt injection unless the user explicitly runs `/ralph resume <name>`, which transfers ownership.
+
 ## Completion gate
 
 For build/test/refactor tasks, Ralph prompts the agent not to complete based only on checked checklist items. Before sending `<promise>COMPLETE</promise>`, the agent should:

--- a/pi-ralph-wiggum/index.ts
+++ b/pi-ralph-wiggum/index.ts
@@ -177,6 +177,25 @@ export default function (pi: ExtensionAPI) {
 			.filter((s): s is LoopState => s !== null);
 	}
 
+	function isOwnedByCurrentSession(ctx: ExtensionContext, state: LoopState): boolean {
+		const currentSessionId = sessionId(ctx);
+		return Boolean(currentSessionId && state.ownerSessionId === currentSessionId);
+	}
+
+	function getCurrentOwnedState(ctx: ExtensionContext): LoopState | null {
+		if (!currentLoop) return null;
+		const state = loadState(ctx, currentLoop);
+		if (!state || !isOwnedByCurrentSession(ctx, state)) {
+			currentLoop = null;
+			return null;
+		}
+		return state;
+	}
+
+	function findActiveOwnedState(ctx: ExtensionContext): LoopState | undefined {
+		return listLoops(ctx).find((state) => state.status === "active" && isOwnedByCurrentSession(ctx, state));
+	}
+
 	// --- Loop state transitions ---
 
 	function pauseLoop(ctx: ExtensionContext, state: LoopState, message?: string): void {
@@ -219,7 +238,7 @@ export default function (pi: ExtensionAPI) {
 	function updateUI(ctx: ExtensionContext): void {
 		if (!ctx.hasUI) return;
 
-		const state = currentLoop ? loadState(ctx, currentLoop) : null;
+		const state = getCurrentOwnedState(ctx);
 		if (!state) {
 			ctx.ui.setStatus("ralph", undefined);
 			ctx.ui.setWidget("ralph", undefined);
@@ -367,20 +386,13 @@ export default function (pi: ExtensionAPI) {
 		},
 
 		stop(_rest, ctx) {
-			if (!currentLoop) {
-				// Check persisted state for any active loop
-				const active = listLoops(ctx).find((l) => l.status === "active");
-				if (active) {
-					pauseLoop(ctx, active, `Paused Ralph loop: ${active.name} (iteration ${active.iteration})`);
-				} else {
-					ctx.ui.notify("No active Ralph loop", "warning");
-				}
+			const state = getCurrentOwnedState(ctx) ?? findActiveOwnedState(ctx);
+			if (!state) {
+				ctx.ui.notify("No active Ralph loop owned by this session", "warning");
+				updateUI(ctx);
 				return;
 			}
-			const state = loadState(ctx, currentLoop);
-			if (state) {
-				pauseLoop(ctx, state, `Paused Ralph loop: ${currentLoop} (iteration ${state.iteration})`);
-			}
+			pauseLoop(ctx, state, `Paused Ralph loop: ${state.name} (iteration ${state.iteration})`);
 		},
 
 		resume(rest, ctx) {
@@ -400,9 +412,10 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			// Pause current loop if different
+			// Pause this session's current loop if different. A loop transferred to
+			// another session must not be mutated from the stale former owner.
 			if (currentLoop && currentLoop !== loopName) {
-				const curr = loadState(ctx, currentLoop);
+				const curr = getCurrentOwnedState(ctx);
 				if (curr) pauseLoop(ctx, curr);
 			}
 
@@ -608,18 +621,10 @@ Examples:
 				return;
 			}
 
-			let state = currentLoop ? loadState(ctx, currentLoop) : null;
+			const state = getCurrentOwnedState(ctx) ?? findActiveOwnedState(ctx);
 			if (!state) {
-				const active = listLoops(ctx).find((l) => l.status === "active");
-				if (!active) {
-					if (ctx.hasUI) ctx.ui.notify("No active Ralph loop", "warning");
-					return;
-				}
-				state = active;
-			}
-
-			if (state.status !== "active") {
-				if (ctx.hasUI) ctx.ui.notify(`Loop "${state.name}" is not active`, "warning");
+				if (ctx.hasUI) ctx.ui.notify("No active Ralph loop owned by this session", "warning");
+				updateUI(ctx);
 				return;
 			}
 
@@ -697,13 +702,10 @@ Examples:
 		],
 		parameters: Type.Object({}),
 		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-			if (!currentLoop) {
-				return { content: [{ type: "text", text: "No active Ralph loop." }], details: {} };
-			}
-
-			const state = loadState(ctx, currentLoop);
+			const state = getCurrentOwnedState(ctx);
 			if (!state || state.status !== "active") {
-				return { content: [{ type: "text", text: "Ralph loop is not active." }], details: {} };
+				updateUI(ctx);
+				return { content: [{ type: "text", text: "No active Ralph loop owned by this session." }], details: {} };
 			}
 
 			if (ctx.hasPendingMessages()) {
@@ -753,9 +755,11 @@ Examples:
 	// --- Event handlers ---
 
 	pi.on("before_agent_start", async (event, ctx) => {
-		if (!currentLoop) return;
-		const state = loadState(ctx, currentLoop);
-		if (!state || state.status !== "active") return;
+		const state = getCurrentOwnedState(ctx);
+		if (!state || state.status !== "active") {
+			updateUI(ctx);
+			return;
+		}
 
 		const iterStr = `${state.iteration}${state.maxIterations > 0 ? `/${state.maxIterations}` : ""}`;
 
@@ -776,9 +780,11 @@ Examples:
 	});
 
 	pi.on("agent_end", async (event, ctx) => {
-		if (!currentLoop) return;
-		const state = loadState(ctx, currentLoop);
-		if (!state || state.status !== "active") return;
+		const state = getCurrentOwnedState(ctx);
+		if (!state || state.status !== "active") {
+			updateUI(ctx);
+			return;
+		}
 
 		// Check for completion marker
 		const lastAssistant = [...event.messages].reverse().find((m) => m.role === "assistant");
@@ -819,8 +825,7 @@ Examples:
 
 	pi.on("session_start", async (_event, ctx) => {
 		const active = listLoops(ctx).filter((l) => l.status === "active");
-		const currentSessionId = sessionId(ctx);
-		const owned = currentSessionId ? active.filter((l) => l.ownerSessionId === currentSessionId) : [];
+		const owned = active.filter((state) => isOwnedByCurrentSession(ctx, state));
 
 		// Rehydrate only loops that are owned by this Pi session. Older state
 		// files do not have ownerSessionId, so a new unrelated session must use
@@ -844,9 +849,7 @@ Examples:
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
-		if (currentLoop) {
-			const state = loadState(ctx, currentLoop);
-			if (state) saveState(ctx, state);
-		}
+		const state = getCurrentOwnedState(ctx);
+		if (state) saveState(ctx, state);
 	});
 }

--- a/pi-ralph-wiggum/index.ts
+++ b/pi-ralph-wiggum/index.ts
@@ -77,6 +77,7 @@ interface LoopState {
 	startedAt: string;
 	completedAt?: string;
 	lastReflectionAt: number; // Last iteration we reflected at
+	ownerSessionId?: string; // Session that currently owns automatic prompt injection for this loop
 }
 
 const STATUS_ICONS: Record<LoopStatus, string> = { active: "▶", paused: "⏸", completed: "✓" };
@@ -89,6 +90,7 @@ export default function (pi: ExtensionAPI) {
 	const ralphDir = (ctx: ExtensionContext) => path.resolve(ctx.cwd, RALPH_DIR);
 	const archiveDir = (ctx: ExtensionContext) => path.join(ralphDir(ctx), "archive");
 	const sanitize = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, "_").replace(/_+/g, "_");
+	const sessionId = (ctx: ExtensionContext) => ctx.sessionManager?.getSessionId?.();
 
 	function getPath(ctx: ExtensionContext, name: string, ext: string, archived = false): string {
 		const dir = archived ? archiveDir(ctx) : ralphDir(ctx);
@@ -349,6 +351,7 @@ export default function (pi: ExtensionAPI) {
 				status: "active",
 				startedAt: existing?.startedAt || new Date().toISOString(),
 				lastReflectionAt: 0,
+				ownerSessionId: sessionId(ctx),
 			};
 
 			saveState(ctx, state);
@@ -405,6 +408,7 @@ export default function (pi: ExtensionAPI) {
 
 			state.status = "active";
 			state.active = true;
+			state.ownerSessionId = sessionId(ctx);
 			state.iteration++;
 			saveState(ctx, state);
 			currentLoop = loopName;
@@ -665,6 +669,7 @@ Examples:
 				status: "active",
 				startedAt: new Date().toISOString(),
 				lastReflectionAt: 0,
+				ownerSessionId: sessionId(ctx),
 			};
 
 			saveState(ctx, state);
@@ -814,14 +819,14 @@ Examples:
 
 	pi.on("session_start", async (_event, ctx) => {
 		const active = listLoops(ctx).filter((l) => l.status === "active");
+		const currentSessionId = sessionId(ctx);
+		const owned = currentSessionId ? active.filter((l) => l.ownerSessionId === currentSessionId) : [];
 
-		// Rehydrate currentLoop from disk. The module is re-initialized on
-		// session reload (including auto-compaction and /compact), which would
-		// otherwise leave `currentLoop` null and silently break ralph_done,
-		// agent_end, and before_agent_start. Pick the most-recently-updated
-		// active loop when there are multiple, using the state file mtime.
-		if (!currentLoop && active.length > 0) {
-			const mostRecent = active.reduce((best, candidate) => {
+		// Rehydrate only loops that are owned by this Pi session. Older state
+		// files do not have ownerSessionId, so a new unrelated session must use
+		// /ralph resume <name> before Ralph injects loop instructions.
+		if (!currentLoop && owned.length > 0) {
+			const mostRecent = owned.reduce((best, candidate) => {
 				const bestMtime = safeMtimeMs(getPath(ctx, best.name, ".state.json"));
 				const candidateMtime = safeMtimeMs(getPath(ctx, candidate.name, ".state.json"));
 				return candidateMtime > bestMtime ? candidate : best;

--- a/pi-ralph-wiggum/package.json
+++ b/pi-ralph-wiggum/package.json
@@ -27,6 +27,10 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.3"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@sinclair/typebox": "^0.34.50"
+  },
+  "scripts": {
+    "test": "node tests/session-boundary.test.mjs"
   }
 }

--- a/pi-ralph-wiggum/tests/session-boundary.test.mjs
+++ b/pi-ralph-wiggum/tests/session-boundary.test.mjs
@@ -1,102 +1,177 @@
-import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import ralphExtension from '../index.ts';
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import ralphExtension from "../index.ts";
 
-function makeCtx(cwd, sessionId = 'fresh-session') {
-  return {
-    cwd,
-    sessionManager: { getSessionId: () => sessionId },
-    hasUI: true,
-    ui: {
-      notify() {},
-      setStatus() {},
-      setWidget() {},
-      confirm: async () => false,
-      theme: {
-        fg(_name, text) { return text; },
-        bold(text) { return text; },
-      },
-    },
-    isIdle: () => true,
-    hasPendingMessages: () => false,
-  };
+function makeCtx(cwd, sessionId = "fresh-session") {
+	return {
+		cwd,
+		sessionManager: { getSessionId: () => sessionId },
+		hasUI: true,
+		ui: {
+			notify() {},
+			setStatus() {},
+			setWidget() {},
+			confirm: async () => false,
+			theme: {
+				fg(_name, text) {
+					return text;
+				},
+				bold(text) {
+					return text;
+				},
+			},
+		},
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+	};
 }
 
 function makePi() {
-  const events = new Map();
-  return {
-    events,
-    sentUserMessages: [],
-    commands: new Map(),
-    tools: new Map(),
-    on(name, handler) { events.set(name, handler); },
-    registerCommand(name, command) { this.commands.set(name, command); },
-    registerTool(tool) { this.tools.set(tool.name, tool); },
-    sendUserMessage(message, options) { this.sentUserMessages.push({ message, options }); },
-  };
+	const events = new Map();
+	return {
+		events,
+		sentUserMessages: [],
+		commands: new Map(),
+		tools: new Map(),
+		on(name, handler) {
+			events.set(name, handler);
+		},
+		registerCommand(name, command) {
+			this.commands.set(name, command);
+		},
+		registerTool(tool) {
+			this.tools.set(tool.name, tool);
+		},
+		sendUserMessage(message, options) {
+			this.sentUserMessages.push({ message, options });
+		},
+	};
 }
 
-const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-session-boundary-'));
-fs.mkdirSync(path.join(cwd, '.ralph'), { recursive: true });
-fs.writeFileSync(path.join(cwd, '.ralph', 'old-loop.md'), '# Old loop\n', 'utf8');
-fs.writeFileSync(path.join(cwd, '.ralph', 'old-loop.state.json'), JSON.stringify({
-  name: 'old-loop',
-  taskFile: '.ralph/old-loop.md',
-  iteration: 12,
-  maxIterations: 1000,
-  itemsPerIteration: 3,
-  reflectEvery: 10,
-  reflectInstructions: 'reflect',
-  active: true,
-  status: 'active',
-  startedAt: '2026-07-08T11:54:18.989Z',
-  lastReflectionAt: 0,
-}, null, 2), 'utf8');
+const tempDirs = [];
 
-const pi = makePi();
-ralphExtension(pi);
-const ctx = makeCtx(cwd);
+function makeTempDir(name) {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), name));
+	tempDirs.push(cwd);
+	fs.mkdirSync(path.join(cwd, ".ralph"), { recursive: true });
+	return cwd;
+}
 
-await pi.events.get('session_start')({}, ctx);
-const result = await pi.events.get('before_agent_start')({ systemPrompt: 'base prompt' }, ctx);
+function writeLoop(cwd, state) {
+	fs.writeFileSync(path.join(cwd, ".ralph", `${state.name}.md`), `# ${state.name}\n`, "utf8");
+	fs.writeFileSync(
+		path.join(cwd, ".ralph", `${state.name}.state.json`),
+		JSON.stringify(state, null, 2),
+		"utf8",
+	);
+}
 
-assert.equal(
-  result,
-  undefined,
-  'a fresh unrelated session must not bind repo-local active Ralph state or inject loop instructions before explicit /ralph resume',
-);
+function readLoop(cwd, name) {
+	return JSON.parse(fs.readFileSync(path.join(cwd, ".ralph", `${name}.state.json`), "utf8"));
+}
 
+const baseState = {
+	iteration: 1,
+	maxIterations: 50,
+	itemsPerIteration: 1,
+	reflectEvery: 0,
+	reflectInstructions: "reflect",
+	active: true,
+	status: "active",
+	startedAt: "2026-07-08T11:54:18.989Z",
+	lastReflectionAt: 0,
+};
 
-const ownedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-session-owned-'));
-fs.mkdirSync(path.join(ownedCwd, '.ralph'), { recursive: true });
-fs.writeFileSync(path.join(ownedCwd, '.ralph', 'owned-loop.md'), '# Owned loop\n', 'utf8');
-fs.writeFileSync(path.join(ownedCwd, '.ralph', 'owned-loop.state.json'), JSON.stringify({
-  name: 'owned-loop',
-  taskFile: '.ralph/owned-loop.md',
-  iteration: 4,
-  maxIterations: 50,
-  itemsPerIteration: 1,
-  reflectEvery: 0,
-  reflectInstructions: 'reflect',
-  active: true,
-  status: 'active',
-  startedAt: '2026-07-08T11:54:18.989Z',
-  lastReflectionAt: 0,
-  ownerSessionId: 'same-session',
-}, null, 2), 'utf8');
+try {
+	const legacyCwd = makeTempDir("ralph-session-boundary-");
+	writeLoop(legacyCwd, {
+		...baseState,
+		name: "old-loop",
+		taskFile: ".ralph/old-loop.md",
+		iteration: 12,
+		maxIterations: 1000,
+		itemsPerIteration: 3,
+		reflectEvery: 10,
+	});
 
-const ownedPi = makePi();
-ralphExtension(ownedPi);
-const ownedCtx = makeCtx(ownedCwd, 'same-session');
-await ownedPi.events.get('session_start')({}, ownedCtx);
-const ownedResult = await ownedPi.events.get('before_agent_start')({ systemPrompt: 'base prompt' }, ownedCtx);
+	const legacyPi = makePi();
+	ralphExtension(legacyPi);
+	const legacyCtx = makeCtx(legacyCwd);
+	await legacyPi.events.get("session_start")({}, legacyCtx);
+	const legacyResult = await legacyPi.events
+		.get("before_agent_start")({ systemPrompt: "base prompt" }, legacyCtx);
+	assert.equal(
+		legacyResult,
+		undefined,
+		"a fresh unrelated session must not bind legacy repo-local state before explicit resume",
+	);
 
-assert.match(
-  ownedResult?.systemPrompt ?? '',
-  /RALPH LOOP - owned-loop - Iteration 4\/50/,
-  'the originating session should still rehydrate its own active Ralph loop after reload or compaction',
-);
+	const ownedCwd = makeTempDir("ralph-session-owned-");
+	writeLoop(ownedCwd, {
+		...baseState,
+		name: "owned-loop",
+		taskFile: ".ralph/owned-loop.md",
+		iteration: 4,
+		ownerSessionId: "same-session",
+	});
 
-console.log('session boundary test passed');
+	const ownerPi = makePi();
+	ralphExtension(ownerPi);
+	const ownerCtx = makeCtx(ownedCwd, "same-session");
+	await ownerPi.events.get("session_start")({}, ownerCtx);
+	const ownedResult = await ownerPi.events
+		.get("before_agent_start")({ systemPrompt: "base prompt" }, ownerCtx);
+	assert.match(
+		ownedResult?.systemPrompt ?? "",
+		/RALPH LOOP - owned-loop - Iteration 4\/50/,
+		"the owning session should rehydrate its active loop after reload or compaction",
+	);
+
+	const claimantPi = makePi();
+	ralphExtension(claimantPi);
+	const claimantCtx = makeCtx(ownedCwd, "claimant-session");
+	await claimantPi.events.get("session_start")({}, claimantCtx);
+	await claimantPi.commands.get("ralph").handler("resume owned-loop", claimantCtx);
+
+	assert.equal(readLoop(ownedCwd, "owned-loop").ownerSessionId, "claimant-session");
+	assert.equal(readLoop(ownedCwd, "owned-loop").iteration, 5);
+
+	const formerOwnerResult = await ownerPi.events
+		.get("before_agent_start")({ systemPrompt: "base prompt" }, ownerCtx);
+	assert.equal(
+		formerOwnerResult,
+		undefined,
+		"the former owner must stop injecting prompts immediately after ownership transfers",
+	);
+
+	const formerOwnerDone = await ownerPi.tools.get("ralph_done").execute("call", {}, undefined, undefined, ownerCtx);
+	assert.match(formerOwnerDone.content[0].text, /No active Ralph loop owned by this session/);
+	await ownerPi.commands.get("ralph-stop").handler("", ownerCtx);
+	assert.equal(readLoop(ownedCwd, "owned-loop").status, "active");
+	assert.equal(readLoop(ownedCwd, "owned-loop").iteration, 5);
+
+	const claimantResult = await claimantPi.events
+		.get("before_agent_start")({ systemPrompt: "base prompt" }, claimantCtx);
+	assert.match(claimantResult?.systemPrompt ?? "", /RALPH LOOP - owned-loop - Iteration 5\/50/);
+	await claimantPi.tools.get("ralph_done").execute("call", {}, undefined, undefined, claimantCtx);
+	assert.equal(readLoop(ownedCwd, "owned-loop").iteration, 6);
+
+	const startedCwd = makeTempDir("ralph-session-start-");
+	const startedPi = makePi();
+	ralphExtension(startedPi);
+	const startedCtx = makeCtx(startedCwd, "starter-session");
+	await startedPi.tools.get("ralph_start").execute(
+		"call",
+		{ name: "started-loop", taskContent: "# Task\n", maxIterations: 3 },
+		undefined,
+		undefined,
+		startedCtx,
+	);
+	assert.equal(readLoop(startedCwd, "started-loop").ownerSessionId, "starter-session");
+
+	console.log("session boundary test passed");
+} finally {
+	for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+}

--- a/pi-ralph-wiggum/tests/session-boundary.test.mjs
+++ b/pi-ralph-wiggum/tests/session-boundary.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import ralphExtension from '../index.ts';
+
+function makeCtx(cwd, sessionId = 'fresh-session') {
+  return {
+    cwd,
+    sessionManager: { getSessionId: () => sessionId },
+    hasUI: true,
+    ui: {
+      notify() {},
+      setStatus() {},
+      setWidget() {},
+      confirm: async () => false,
+      theme: {
+        fg(_name, text) { return text; },
+        bold(text) { return text; },
+      },
+    },
+    isIdle: () => true,
+    hasPendingMessages: () => false,
+  };
+}
+
+function makePi() {
+  const events = new Map();
+  return {
+    events,
+    sentUserMessages: [],
+    commands: new Map(),
+    tools: new Map(),
+    on(name, handler) { events.set(name, handler); },
+    registerCommand(name, command) { this.commands.set(name, command); },
+    registerTool(tool) { this.tools.set(tool.name, tool); },
+    sendUserMessage(message, options) { this.sentUserMessages.push({ message, options }); },
+  };
+}
+
+const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-session-boundary-'));
+fs.mkdirSync(path.join(cwd, '.ralph'), { recursive: true });
+fs.writeFileSync(path.join(cwd, '.ralph', 'old-loop.md'), '# Old loop\n', 'utf8');
+fs.writeFileSync(path.join(cwd, '.ralph', 'old-loop.state.json'), JSON.stringify({
+  name: 'old-loop',
+  taskFile: '.ralph/old-loop.md',
+  iteration: 12,
+  maxIterations: 1000,
+  itemsPerIteration: 3,
+  reflectEvery: 10,
+  reflectInstructions: 'reflect',
+  active: true,
+  status: 'active',
+  startedAt: '2026-07-08T11:54:18.989Z',
+  lastReflectionAt: 0,
+}, null, 2), 'utf8');
+
+const pi = makePi();
+ralphExtension(pi);
+const ctx = makeCtx(cwd);
+
+await pi.events.get('session_start')({}, ctx);
+const result = await pi.events.get('before_agent_start')({ systemPrompt: 'base prompt' }, ctx);
+
+assert.equal(
+  result,
+  undefined,
+  'a fresh unrelated session must not bind repo-local active Ralph state or inject loop instructions before explicit /ralph resume',
+);
+
+
+const ownedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-session-owned-'));
+fs.mkdirSync(path.join(ownedCwd, '.ralph'), { recursive: true });
+fs.writeFileSync(path.join(ownedCwd, '.ralph', 'owned-loop.md'), '# Owned loop\n', 'utf8');
+fs.writeFileSync(path.join(ownedCwd, '.ralph', 'owned-loop.state.json'), JSON.stringify({
+  name: 'owned-loop',
+  taskFile: '.ralph/owned-loop.md',
+  iteration: 4,
+  maxIterations: 50,
+  itemsPerIteration: 1,
+  reflectEvery: 0,
+  reflectInstructions: 'reflect',
+  active: true,
+  status: 'active',
+  startedAt: '2026-07-08T11:54:18.989Z',
+  lastReflectionAt: 0,
+  ownerSessionId: 'same-session',
+}, null, 2), 'utf8');
+
+const ownedPi = makePi();
+ralphExtension(ownedPi);
+const ownedCtx = makeCtx(ownedCwd, 'same-session');
+await ownedPi.events.get('session_start')({}, ownedCtx);
+const ownedResult = await ownedPi.events.get('before_agent_start')({ systemPrompt: 'base prompt' }, ownedCtx);
+
+assert.match(
+  ownedResult?.systemPrompt ?? '',
+  /RALPH LOOP - owned-loop - Iteration 4\/50/,
+  'the originating session should still rehydrate its own active Ralph loop after reload or compaction',
+);
+
+console.log('session boundary test passed');


### PR DESCRIPTION
## Problem

`pi-ralph-wiggum` currently binds any repo-local active loop to a new Pi session during `session_start`.

The trigger is this path in `pi-ralph-wiggum/index.ts`:

1. `session_start` reads `.ralph/*.state.json`.
2. It filters to `status === "active"`.
3. If `currentLoop` is unset, it picks the most recently modified active loop.
4. `before_agent_start` then injects `[RALPH LOOP - ...]` into normal agent turns.

That works for reloading the same session after compaction. It breaks when two unrelated Pi sessions share the same cwd. A new session opened in a repo with an old active `.ralph/*.state.json` gets Ralph instructions even when the user never ran `/ralph resume`.

A real observed state file that caused this:

```json
{
  "name": "codex-michelle-iterative-skill-review",
  "taskFile": ".ralph/codex-michelle-iterative-skill-review.md",
  "iteration": 62,
  "maxIterations": 1000,
  "itemsPerIteration": 3,
  "reflectEvery": 10,
  "active": true,
  "status": "active",
  "startedAt": "2026-07-08T11:54:18.989Z",
  "lastReflectionAt": 61
}
```

Fixes #50

## Fix in this PR

This adds session ownership to Ralph loop state:

- New loops store `ownerSessionId` from `ctx.sessionManager.getSessionId()`.
- `/ralph resume <name>` claims the loop for the current session by updating `ownerSessionId`.
- `session_start` only auto-rehydrates loops whose `ownerSessionId` matches the current Pi session id.
- Old loop files without `ownerSessionId` stay visible in the UI notification, but they do not inject Ralph instructions into a new unrelated session. The user can still opt in with `/ralph resume <name>`.

This preserves the `0.1.7` reload/compaction fix for the same logical session while removing cross-session prompt pollution.

## Test

Added `pi-ralph-wiggum/tests/session-boundary.test.mjs`.

It checks two cases:

1. A fresh session in a cwd with an old active `.ralph/*.state.json` does not receive Ralph prompt injection.
2. The originating session, identified by matching `ownerSessionId`, still rehydrates its own active loop.

Command run:

```bash
npm test --prefix pi-ralph-wiggum
```

Result:

```text
session boundary test passed
```

Node prints the existing module-type warning for `index.ts`; the test still exits 0.

## If you prefer to implement this with your own agent

Prompt:

```text
Fix pi-ralph-wiggum so active Ralph loops are not automatically adopted by unrelated Pi sessions that share the same cwd.

Current bug:
- pi-ralph-wiggum/index.ts keeps `currentLoop` in module memory.
- On `session_start`, it scans `.ralph/*.state.json` for `status: "active"`.
- If `currentLoop` is null, it picks the most recently modified active loop and assigns `currentLoop = mostRecent.name`.
- On `before_agent_start`, any non-null `currentLoop` injects `[RALPH LOOP - <name>]` instructions into the system prompt.
- This means a brand-new Pi session in the same repo can inherit an old active Ralph loop without `/ralph resume`.

Required behavior:
- A new unrelated session must not bind old active Ralph state or inject loop instructions.
- Reload or compaction of the same logical session should still restore its own active loop.
- `/ralph resume <name>` should explicitly claim or transfer loop ownership to the current session.
- Existing old state files without ownership metadata should be safe by default: notify that active loops exist, but do not inject instructions until explicit resume.

Suggested implementation:
- Add `ownerSessionId?: string` to `LoopState`.
- Add helper `sessionId(ctx) => ctx.sessionManager?.getSessionId?.()`.
- When starting a loop through `/ralph start` or the `ralph_start` tool, write `ownerSessionId: sessionId(ctx)`.
- When `/ralph resume <name>` succeeds, set `state.ownerSessionId = sessionId(ctx)` before saving.
- In `session_start`, compute `owned = active.filter(l => l.ownerSessionId === sessionId(ctx))` and only auto-assign `currentLoop` from `owned`.
- Keep the existing UI notification for all active loops.
- Add a regression test that creates an active state file with no `ownerSessionId`, calls the extension's `session_start`, then calls `before_agent_start` and asserts the result is undefined.
- Add a second test with matching `ownerSessionId` and assert `before_agent_start` injects the Ralph loop prompt.
```