### PR TITLE
feat: native cmux browser for Pi

### DIFF
--- a/.github/workflows/cmux-browser.yml
+++ b/.github/workflows/cmux-browser.yml
@@ -1,0 +1,48 @@
+name: cmux-browser
+
+on:
+  pull_request:
+    paths:
+      - "cmux-browser/**"
+      - "package.json"
+      - ".github/workflows/cmux-browser.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "cmux-browser/**"
+      - "package.json"
+      - ".github/workflows/cmux-browser.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: unit and typecheck
+    runs-on: macos-14
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install --no-package-lock --ignore-scripts
+
+      - name: Run deterministic tests
+        run: npm run test:cmux-browser
+
+      - name: Typecheck
+        run: npm run typecheck:cmux-browser
+
+      - name: Pi extension load smoke
+        run: |
+          isolated="$(mktemp -d)"
+          trap 'rm -rf "$isolated"' EXIT
+          PI_CODING_AGENT_DIR="$isolated" ./node_modules/.bin/pi --no-extensions -e ./cmux-browser/index.ts --list-models >/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- Add a native cmux browser extension for Pi with backgrounded browser surfaces, structured navigation/inspection/interaction/session tools, approval-gated uploads, screenshots, downloads, lifecycle recovery, tests, and rollback documentation.
+- Add a native cmux browser extension for Pi with one backgrounded, extension-owned surface; approved-origin navigation; bounded inspection; ref-only, value-free interaction; approval-gated screenshots/download waits; lifecycle cleanup; tests; and rollback documentation.
 
 ## [0.1.42] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Add a native cmux browser extension for Pi with backgrounded browser surfaces, structured navigation/inspection/interaction/session tools, approval-gated uploads, screenshots, downloads, lifecycle recovery, tests, and rollback documentation.
+
 ## [0.1.42] - 2026-05-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Personal extensions for the [Pi coding agent](https://github.com/badlogic/pi-mon
 | [/usage](usage-extension/) | 📊 Usage statistics dashboard. See cost, tokens, and messages by provider/model across Today, This Week, Last Week, and All Time — with a compact view for narrow terminals |
 | [/paste](raw-paste/) | Paste editable text, not [paste #1 +21 lines]. Running `/paste` with optional keybinding |
 | [/code](code-actions/) | Pick code blocks or inline snippets from assistant messages to copy, insert, or run with `/code` |
+| [cmux-browser](cmux-browser/) | Native in-workspace cmux browser panes for Pi: navigation, snapshots, interaction, tabs/auth state, files, screenshots, and debugging without focus theft |
 | [session-recap](session-recap/) | While-you-were-away recap above the editor when you return to a session. Keeps you in flow while multi-clauding |
 | [arcade](arcade/) | Play minigames while your tests run: 👾 sPIce-invaders, 👻 picman, 🏓 ping, 🧩 tetris, 🍄 mario-not |
 
@@ -51,6 +52,7 @@ If you keep a local clone, add extensions to your `~/.pi/agent/settings.json`:
 {
   "extensions": [
     "~/pi-extensions/files-widget",
+    "~/pi-extensions/cmux-browser/index.ts",
     "~/pi-extensions/tab-status/tab-status.ts",
     "~/pi-extensions/arcade/spice-invaders.ts",
     "~/pi-extensions/arcade/ping.ts",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal extensions for the [Pi coding agent](https://github.com/badlogic/pi-mon
 | [/usage](usage-extension/) | 📊 Usage statistics dashboard. See cost, tokens, and messages by provider/model across Today, This Week, Last Week, and All Time — with a compact view for narrow terminals |
 | [/paste](raw-paste/) | Paste editable text, not [paste #1 +21 lines]. Running `/paste` with optional keybinding |
 | [/code](code-actions/) | Pick code blocks or inline snippets from assistant messages to copy, insert, or run with `/code` |
-| [cmux-browser](cmux-browser/) | Native in-workspace cmux browser panes for Pi: navigation, snapshots, interaction, tabs/auth state, files, screenshots, and debugging without focus theft |
+| [cmux-browser](cmux-browser/) | Native in-workspace cmux browser pane for Pi: approved-origin navigation, bounded inspection, ref-only interaction, screenshots, downloads, and debugging without focus theft |
 | [session-recap](session-recap/) | While-you-were-away recap above the editor when you return to a session. Keeps you in flow while multi-clauding |
 | [arcade](arcade/) | Play minigames while your tests run: 👾 sPIce-invaders, 👻 picman, 🏓 ping, 🧩 tetris, 🍄 mario-not |
 

--- a/cmux-browser/ARCHITECTURE.md
+++ b/cmux-browser/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Issue: [#53](https://github.com/tmustier/pi-extensions/issues/53)
 
 ## Outcome and supported route
 
-A Pi session launched directly in a cmux terminal can open and operate a visible native cmux `WKWebView` pane while keyboard focus remains in Pi. The implementation uses only public extension and CLI surfaces:
+A Pi session launched directly in a cmux terminal can open, navigate, and inspect a visible native cmux `WKWebView` pane while keyboard focus remains in Pi. The implementation uses only public extension and CLI surfaces:
 
 ```text
 Pi command / model tool
@@ -16,10 +16,10 @@ strict TypeBox schema + origin/profile approval
 fixed argv builder (no shell or passthrough)
         │
         ▼
-pi.exec("cmux", argv, { signal, timeout })
-        │
+pi.exec(Node bounded runner, fixed script + argv)
+        │  combined stdout/stderr hard-capped at 10 MiB
         ▼
-documented cmux browser CLI → owned native WKWebView surface
+documented cmux 0.64.13 browser CLI → owned native WKWebView surface
 ```
 
 ## Route audit
@@ -34,7 +34,7 @@ Pi's documented extension API provides typed model tools, commands, renderers, c
 
 ### cmux
 
-cmux 0.64.13 documents a `cmux browser` CLI backed by the visible native pane. It supports background surface creation, navigation, accessibility snapshots and refs, DOM-level interaction, screenshots, downloads, console/errors, and other broader operations. This extension uses a security-reduced subset rather than exposing the CLI wholesale.
+cmux 0.64.13 documents a `cmux browser` CLI backed by the visible native pane. The extension requires exactly this version before every model operation because its close, snapshot, and redaction contracts are version-pinned; newer or older versions fail closed. It supports background surface creation, navigation, accessibility snapshots and refs, DOM-level interaction, screenshots, downloads, console/errors, and other broader operations. This extension uses a security-reduced subset rather than exposing the CLI wholesale.
 
 The WKWebView backend does not claim full CDP parity. Viewport/geolocation/offline emulation, tracing/screencast, network interception, and raw input remain explicit non-goals.
 
@@ -42,7 +42,7 @@ The WKWebView backend does not claim full CDP parity. Viewport/geolocation/offli
 
 ### Surface ownership
 
-`CmuxBrowserClient.open()` accepts only a documented top-level `surface_id` matching a strict UUID. Nested/fallback values are rejected. The client owns one surface at a time, never accepts caller-selected surface/workspace identifiers, never adopts an existing surface, and never restores a persisted handle. Close removes ownership before another surface can be used.
+`CmuxBrowserClient.open()` accepts only a documented top-level `surface_id` matching a strict UUID. Nested/fallback values are rejected. The client owns one surface at a time, never accepts caller-selected surface/workspace identifiers, never adopts an existing surface, and never restores a persisted handle. Every client operation passes through one promise queue, so concurrent opens cannot both pass the ownership check or orphan a second pane. Both Pi tools also declare `executionMode: "sequential"` so approval, origin revalidation, and execution stay ordered across sibling tool calls. A failed, aborted, interrupted, or malformed open permanently blocks further opens because cmux may have created a pane whose UUID was never learned. Close requires a non-interrupted zero exit and the cmux 0.64.13 public CLI result shape repeating the exact owned top-level `surface_id`; otherwise ownership is retained. A `globalThis` registry keyed with `Symbol.for` carries unresolved lifecycle state across extension module replacement, so `/reload`, `/new`, resume, or fork cannot sidestep the block. Only a Pi process restart resets it; the extension never adopts a possibly stale surface.
 
 ### Profile boundary
 
@@ -52,11 +52,11 @@ The extension does not expose profile listing/mutation, cookies, storage, state 
 
 ### Origin approval
 
-Navigation accepts only absolute `http:`/`https:` URLs or exactly `about:blank`. Userinfo and credential-like query keys are rejected. A slash-command URL is an explicit user authorization; model-originated new origins require Pi confirmation. Before inspect/interact actions, the extension reads the active URL internally, reduces it to an origin, and refuses unapproved, opaque, local, or custom-scheme origins. Cross-origin changes therefore stop automation until approved.
+Navigation accepts only an `http(s)` origin root (normalized to `/`) or exactly `about:blank`. Every non-root path, query, fragment, and URL userinfo value is rejected, so credentials, signed links, OAuth/OIDC/SAML artifacts, magic-link path tokens, and unknown future credential-key families cannot enter process arguments. A slash-command URL is an explicit user authorization; model-originated new origins require Pi confirmation. For inspection, cmux returns the accessibility snapshot and its top-level URL in one response. The extension privately reduces that URL to an origin before releasing text. If the origin is new, it obtains approval and requires a second snapshot reporting the same origin. This closes the cross-origin TOCTOU gap for reads. The public CLI has no atomic expected-origin precondition for actions or other read commands, so interactions, screenshots, generic property reads, console/errors, reload, and download wait are deliberately not registered as model tools.
 
-### Ref and input restrictions
+### Input restrictions
 
-Interaction and element inspection require fresh snapshot refs matching `^e[1-9][0-9]*$`. Arbitrary CSS selectors are rejected. Automated text/value entry, arbitrary keyboard input, selection, JavaScript evaluation, script injection, and upload are absent. Users enter sensitive values and choose files directly in the visible pane.
+The model has no interaction or ref-targeted inspection tool. Arbitrary selectors, automated text/value entry, keyboard input, selection, JavaScript evaluation, script injection, upload, screenshots, downloads, and debugging reads are absent. Users perform those operations directly in the visible pane.
 
 ### Output classification
 
@@ -65,34 +65,32 @@ Every `BrowserCommandResult` is classified as:
 - `captured`: bounded output from an explicit read operation and intentionally model-visible; or
 - `synthetic`: fixed extension metadata whose raw cmux stdout/stderr is discarded.
 
-Only snapshot/get/console/errors operations may request capture in the client. Synthetic tool output is rebuilt from a small boolean/number key allowlist. Failures include a fixed operation label and exit code only; raw stdout/stderr, selectors, URLs, paths, scripts, and values are never interpolated into errors or retained command metadata.
+The extension exposes capture only for snapshot. A fixed Node child runner streams cmux output through a combined 10 MiB cap before `pi.exec` can accumulate it, killing the child and returning failure at the boundary. Snapshot then has a dedicated projection: the bounded raw cmux JSON is privately parsed, its top-level URL is reduced to an internal origin, and output is reduced to 50 KiB of top-level accessibility `snapshot` text plus validated keys from the top-level `refs` map. `page.text`, `page.html`, full URL, the standalone title field, ref metadata, and every other raw field are discarded before the tool result is built. Because cmux 0.64.13 can use a live input value as an accessibility name even when an input declares a misleading explicit ARIA role, every quoted name on a ref-bearing line and the document title are stripped. The model receives structural roles/refs and body-text fallback, never element labels. Generic capture is forbidden for snapshots. The result type is a discriminated union: its synthetic variant has no stdout, stderr, or parsed subprocess JSON fields at all, only fixed extension-owned boolean metadata. Tool rendering rebuilds that metadata from a small key allowlist as an additional runtime boundary. This is redaction by construction, not pattern-based secret detection. Failures include a fixed operation label and exit code only; raw stdout/stderr, selectors, URLs, paths, scripts, and values are never interpolated into errors or retained command metadata.
 
 ### File boundary
 
-The extension creates a private `0700` per-session directory with `mkdtemp`. Screenshot names are extension-generated UUIDs under that root. Reads use `O_NOFOLLOW`, require a regular single-link file owned by the current user, restrict it to mode `0600`, and enforce a 10 MiB limit. The temporary file is removed after rendering and the root is removed on shutdown. Callers cannot provide screenshot, download, state, or upload host paths.
-
-Download wait requires explicit confirmation and returns readiness metadata only. cmux owns destination selection; no destination path or event payload enters model context.
+No exposed tool accepts or returns a host path. Screenshot, download, state, and upload operations are absent; the extension creates no browser-output files.
 
 ## Exposed capability map
 
 | User outcome | Exposed route |
 |---|---|
 | Native rendering | extension-owned cmux browser surface opened with `--focus false` |
-| Navigation | approved `http(s)`/`about:blank` open/goto; reload; approved-origin read; close |
-| Inspection | accessibility snapshot; ref-scoped text/safe attribute/count/box; screenshot; console/errors; highlight |
-| Interaction | fresh-ref click/double-click/hover/focus/check/uncheck/scroll; allowlisted key press; ref/load-state wait |
+| Navigation | approved `http(s)` origin-root/`about:blank` open/goto; current-origin read; close |
+| Inspection | bounded, element-name-redacted structural accessibility snapshot atomically bound to its reported origin |
+| Interaction | manual in the visible native pane only |
 | Authentication | manual entry in native pane; current cmux profile only after explicit shared-profile disclosure |
-| Downloads | native cmux wait with synthetic readiness result; no returned host path |
-| Lifecycle | one in-memory owned UUID; explicit open/close; best-effort shutdown cleanup |
+| Files/downloads | manual in the visible native pane; no model host paths |
+| Lifecycle | one owned UUID; exact close acknowledgement; process-wide fail-closed replacement marker; best-effort shutdown cleanup |
 | Rollback | remove/disable one Pi resource; no cmux/Codex/system mutation |
 
-Not exposed: eval/addscript/addinitscript, fill/type/select, arbitrary selectors/keys, tabs, profiles, cookies/storage, state files, upload, arbitrary paths/surfaces/workspaces, existing-surface adoption, or stale-handle recovery.
+Not exposed: actions, reload, ref/property reads, screenshots, console/errors, downloads, eval/addscript/addinitscript, fill/type/select, arbitrary selectors/keys, tabs, profiles, cookies/storage, state files, upload, arbitrary paths/surfaces/workspaces, existing-surface adoption, or stale-handle recovery.
 
 ## Verification strategy
 
-Deterministic client tests use a fake cmux executor to prove strict top-level UUID parsing, single-surface ownership, fixed failure diagnostics, pre-subprocess rejection of removed value-bearing capabilities, captured-output bounds, synthetic-output allowlisting, terminal close behavior, origin reduction, navigation policy, snapshot-ref grammar, and absence of dangerous tool-schema fields. Separate entrypoint-level tests load the real extension and invoke registered tools to verify approval denial, exact cmux argv, origin-change refusal, bounded private screenshot handling, and cleanup.
+Deterministic client tests use a fake cmux executor to prove strict top-level UUID parsing, single-surface ownership, interrupted/malformed close retention, exact close acknowledgement, fixed failure diagnostics, pre-subprocess rejection of value-bearing capabilities, captured-output bounds, snapshot projection that excludes raw page/HTML fields and editable names, authoritative ref-map validation, synthetic-output allowlisting, terminal close behavior, origin reduction, navigation policy, and absence of dangerous tool-schema fields. Separate entrypoint-level tests load the real extension and invoke registered tools to verify approval denial, atomically origin-bound snapshot release, origin-change refusal, element-name redaction (including misleading explicit roles), and fail-closed behavior after extension replacement.
 
-The real E2E must run from a fresh Pi process launched directly inside a healthy cmux workspace. It uses a local synthetic page to prove native open, load, snapshot/ref interaction, screenshot, console/errors, and cleanup. Passing fake-client tests alone is not end-to-end proof.
+The real E2E must run from a fresh Pi process launched directly inside a healthy cmux 0.64.13 workspace. It uses a local synthetic page to prove background native open, load, origin-bound structural accessibility snapshot, and exact close acknowledgement. Success is printed only after `closeAll()` reports no retained ownership. Passing fake-client tests alone is not end-to-end proof.
 
 ## Explicit non-goals
 

--- a/cmux-browser/ARCHITECTURE.md
+++ b/cmux-browser/ARCHITECTURE.md
@@ -2,101 +2,102 @@
 
 Issue: [#53](https://github.com/tmustier/pi-extensions/issues/53)
 
-## User-visible behavior
+## Outcome and supported route
 
-A Pi session running in a cmux terminal can create and operate cmux's real browser surfaces without moving focus away from Pi. The model gets structured navigation, snapshot/inspection, interaction, session/tab, upload/download, screenshot, and diagnostics tools; the user sees the same native `WKWebView` browser pane used by cmux itself.
-
-## Evidence and route audit
-
-### Codex surfaces inspected
-
-- Codex CLI 0.143.0 publicly reports stable `browser_use`, `browser_use_external`, `browser_use_full_cdp_access`, `computer_use`, and `in_app_browser` feature keys.
-- `codex app-server generate-json-schema` succeeds, but its public v2 protocol contains configuration requirements for computer use, not a public browser-control request surface.
-- Codex's browser implementation is delivered through Codex Desktop/plugin runtime machinery. Reusing private bundled plugin scripts, internal pipes, credentials, signatures, or app identity would be unsupported and would cross the issue's explicit safety boundary.
-
-Conclusion: there is no supported public Codex browser protocol that a Pi extension can directly embed today. This extension must not load Codex-private plugin files or imitate app identity.
-
-### Pi public extension points inspected
-
-The current Pi README, `docs/extensions.md`, `docs/tui.md`, `docs/keybindings.md`, `docs/packages.md`, extension examples, and installed types support:
-
-- typed model-callable tools (`registerTool`), custom renderers, commands, and status UI;
-- abort-aware child processes through `pi.exec`;
-- session reconstruction from persisted tool-result `details`;
-- startup/shutdown hooks and package installation.
-
-Pi's TUI can render terminal components and images, but cannot host an AppKit `WKWebView`. A TUI browser would therefore be a reduced imitation and fails the requested native rendering/interaction outcome.
-
-### cmux public browser route
-
-cmux 0.64.13 exposes a documented, supported `cmux browser` CLI backed by the browser pane the user actually sees. It includes:
-
-- native surface creation with `--focus false`;
-- navigation and full WebKit rendering;
-- accessibility/DOM snapshots and ref-based interaction;
-- tabs, profiles, cookies/storage, state save/load;
-- screenshots, downloads, console/errors, highlighting, and JavaScript evaluation.
-
-The browser defaults to the caller's `CMUX_WORKSPACE_ID`, which keeps the pane beside the originating Pi session even if another workspace is focused. Its browser profile/data store preserves authentication according to cmux's supported profile behavior.
-
-Known public cmux/WKWebView limits are reported honestly: viewport/geolocation/offline emulation, tracing/screencast, network interception, and raw low-level input currently return `not_supported`. The extension does not claim CDP parity for those operations.
-
-## Selected architecture
-
-A normal Pi package extension delegates only allowlisted operations to the public `cmux browser` CLI:
+A Pi session launched directly in a cmux terminal can open and operate a visible native cmux `WKWebView` pane while keyboard focus remains in Pi. The implementation uses only public extension and CLI surfaces:
 
 ```text
-Pi model / user command
+Pi command / model tool
         │
         ▼
-strict TypeBox tool schema
+strict TypeBox schema + origin/profile approval
         │
         ▼
-argument builder (no shell, no arbitrary passthrough)
+fixed argv builder (no shell or passthrough)
         │
         ▼
-pi.exec(cmux, argv, { signal, timeout })
+pi.exec("cmux", argv, { signal, timeout })
         │
         ▼
-cmux socket API → native browser surface / WKWebView
+documented cmux browser CLI → owned native WKWebView surface
 ```
 
-Design constraints:
+## Route audit
 
-1. **Native, not simulated.** Rendering and direct user interaction stay in cmux's browser pane.
-2. **No focus theft.** Every surface-creation path explicitly passes `--focus false`; automation never calls `focus-webview`.
-3. **Origin workspace.** New surfaces rely on `CMUX_WORKSPACE_ID` or an explicit workspace argument, never the currently focused workspace.
-4. **Supported auth.** The extension uses cmux profiles/state/cookies APIs. It never reads browser or Codex credential stores and never returns cookie values unless the caller explicitly invokes the cookie-read operation.
-5. **Safe execution.** Commands are spawned as argv, not through a shell. Output is truncated before entering model context. File paths are resolved; upload requires an explicit regular file plus interactive approval, and profile deletion is also confirmed.
-6. **Lifecycle and recovery.** The last successful surface UUID is stored in tool-result details and reconstructed on `session_start`; commands can override it. Stale/missing surfaces fail with a recovery instruction rather than silently opening or focusing a replacement.
-7. **Rollback.** Remove/disable only `cmux-browser/index.ts` (or filter it from the package) and restart/reload Pi. The extension does not modify cmux, Codex, browser profiles, Pi core, or system settings.
+### Codex
 
-## Upload approach
+Codex CLI 0.143.0 advertises browser/computer-use feature keys, but its public app-server v2 protocol does not expose a supported browser-control request surface. The browser implementation is part of Codex Desktop/plugin runtime machinery. Loading bundled private scripts, connecting to internal pipes, copying credentials, imitating app identity, or patching a binary would be unsupported and violates issue #53's safety boundary.
 
-cmux supports native user drag/drop into file inputs but currently has no documented `browser upload` automation command. For agent-driven uploads, the extension uses the supported `browser eval` command to construct a DOM `File`, assign it through `DataTransfer`, and dispatch `input`/`change` on an explicitly selected file input. Bytes are transferred in bounded base64 chunks and the temporary page global is cleared in `finally`.
+### Pi
 
-This is normal page-level WebKit automation, not a permission bypass. It may not work on sites that intentionally reject synthetic file-input events; the tool reports that boundary. It never prints file contents.
+Pi's documented extension API provides typed model tools, commands, renderers, confirmation UI, abort-aware `pi.exec`, and lifecycle hooks. Its terminal UI cannot embed AppKit `WKWebView`. A terminal-only imitation would not provide the requested native renderer.
 
-## Acceptance mapping
+### cmux
 
-| Requirement | Route |
+cmux 0.64.13 documents a `cmux browser` CLI backed by the visible native pane. It supports background surface creation, navigation, accessibility snapshots and refs, DOM-level interaction, screenshots, downloads, console/errors, and other broader operations. This extension uses a security-reduced subset rather than exposing the CLI wholesale.
+
+The WKWebView backend does not claim full CDP parity. Viewport/geolocation/offline emulation, tracing/screencast, network interception, and raw input remain explicit non-goals.
+
+## Security design
+
+### Surface ownership
+
+`CmuxBrowserClient.open()` accepts only a documented top-level `surface_id` matching a strict UUID. Nested/fallback values are rejected. The client owns one surface at a time, never accepts caller-selected surface/workspace identifiers, never adopts an existing surface, and never restores a persisted handle. Close removes ownership before another surface can be used.
+
+### Profile boundary
+
+cmux 0.64.13 has no documented profile selector on `browser open`. A new pane uses cmux's currently selected profile and may share its data store with other cmux panes. The extension discloses this and requires Pi TUI confirmation before first use. Users needing stronger isolation must select a dedicated cmux profile before opening.
+
+The extension does not expose profile listing/mutation, cookies, storage, state save/load, tabs, or browser-state import/export.
+
+### Origin approval
+
+Navigation accepts only absolute `http:`/`https:` URLs or exactly `about:blank`. Userinfo and credential-like query keys are rejected. A slash-command URL is an explicit user authorization; model-originated new origins require Pi confirmation. Before inspect/interact actions, the extension reads the active URL internally, reduces it to an origin, and refuses unapproved, opaque, local, or custom-scheme origins. Cross-origin changes therefore stop automation until approved.
+
+### Ref and input restrictions
+
+Interaction and element inspection require fresh snapshot refs matching `^e[1-9][0-9]*$`. Arbitrary CSS selectors are rejected. Automated text/value entry, arbitrary keyboard input, selection, JavaScript evaluation, script injection, and upload are absent. Users enter sensitive values and choose files directly in the visible pane.
+
+### Output classification
+
+Every `BrowserCommandResult` is classified as:
+
+- `captured`: bounded output from an explicit read operation and intentionally model-visible; or
+- `synthetic`: fixed extension metadata whose raw cmux stdout/stderr is discarded.
+
+Only snapshot/get/console/errors operations may request capture in the client. Synthetic tool output is rebuilt from a small boolean/number key allowlist. Failures include a fixed operation label and exit code only; raw stdout/stderr, selectors, URLs, paths, scripts, and values are never interpolated into errors or retained command metadata.
+
+### File boundary
+
+The extension creates a private `0700` per-session directory with `mkdtemp`. Screenshot names are extension-generated UUIDs under that root. Reads use `O_NOFOLLOW`, require a regular single-link file owned by the current user, restrict it to mode `0600`, and enforce a 10 MiB limit. The temporary file is removed after rendering and the root is removed on shutdown. Callers cannot provide screenshot, download, state, or upload host paths.
+
+Download wait requires explicit confirmation and returns readiness metadata only. cmux owns destination selection; no destination path or event payload enters model context.
+
+## Exposed capability map
+
+| User outcome | Exposed route |
 |---|---|
-| Navigation/rendering | cmux native browser surface + navigation operations |
-| Interaction | snapshot refs/CSS plus click, fill, type, key, select, check, scroll, wait |
-| Sessions/tabs | surface UUID recovery; tabs; profile/state APIs |
-| Auth-preserving behavior | cmux profile/data store; state/cookie/storage operations |
-| Uploads/downloads | bounded DOM file upload; native download wait/path result |
-| Screenshots | cmux browser screenshot to explicit/default path |
-| Debug/inspect | snapshot/get/eval/console/errors/highlight |
-| Lifecycle/recovery | persisted surface details, lazy validation, actionable stale-surface errors |
-| Background behavior | `--focus false`; no webview focus command |
-| Fresh install | package manifest entry, no runtime dependency |
-| Rollback | disable/remove one manifest resource; no external mutations |
-| E2E | real cmux browser smoke from fresh Pi plus deterministic fake-cmux tests |
+| Native rendering | extension-owned cmux browser surface opened with `--focus false` |
+| Navigation | approved `http(s)`/`about:blank` open/goto; reload; approved-origin read; close |
+| Inspection | accessibility snapshot; ref-scoped text/safe attribute/count/box; screenshot; console/errors; highlight |
+| Interaction | fresh-ref click/double-click/hover/focus/check/uncheck/scroll; allowlisted key press; ref/load-state wait |
+| Authentication | manual entry in native pane; current cmux profile only after explicit shared-profile disclosure |
+| Downloads | native cmux wait with synthetic readiness result; no returned host path |
+| Lifecycle | one in-memory owned UUID; explicit open/close; best-effort shutdown cleanup |
+| Rollback | remove/disable one Pi resource; no cmux/Codex/system mutation |
 
-## Explicit non-goals and blockers
+Not exposed: eval/addscript/addinitscript, fill/type/select, arbitrary selectors/keys, tabs, profiles, cookies/storage, state files, upload, arbitrary paths/surfaces/workspaces, existing-surface adoption, or stale-handle recovery.
 
-- No reuse of Codex-private plugin scripts, internal pipes, credentials, or signing identity.
-- No binary patching, injection, TCC changes, or protective-measure bypass.
-- No claim that WKWebView offers unsupported CDP-only features.
-- No private/customer-data E2E fixture; tests use local/public synthetic pages.
+## Verification strategy
+
+Deterministic client tests use a fake cmux executor to prove strict top-level UUID parsing, single-surface ownership, fixed failure diagnostics, pre-subprocess rejection of removed value-bearing capabilities, captured-output bounds, synthetic-output allowlisting, terminal close behavior, origin reduction, navigation policy, snapshot-ref grammar, and absence of dangerous tool-schema fields. Separate entrypoint-level tests load the real extension and invoke registered tools to verify approval denial, exact cmux argv, origin-change refusal, bounded private screenshot handling, and cleanup.
+
+The real E2E must run from a fresh Pi process launched directly inside a healthy cmux workspace. It uses a local synthetic page to prove native open, load, snapshot/ref interaction, screenshot, console/errors, and cleanup. Passing fake-client tests alone is not end-to-end proof.
+
+## Explicit non-goals
+
+- No Codex-private runtime, socket, plugin, credential, or identity reuse.
+- No binary patching, process injection, TCC/config bypass, or permission weakening.
+- No claim of unsupported CDP features.
+- No private/customer-data fixture.
+- No silent profile, surface, workspace, or filesystem access.

--- a/cmux-browser/ARCHITECTURE.md
+++ b/cmux-browser/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Native cmux browser for Pi — architecture
+
+Issue: [#53](https://github.com/tmustier/pi-extensions/issues/53)
+
+## User-visible behavior
+
+A Pi session running in a cmux terminal can create and operate cmux's real browser surfaces without moving focus away from Pi. The model gets structured navigation, snapshot/inspection, interaction, session/tab, upload/download, screenshot, and diagnostics tools; the user sees the same native `WKWebView` browser pane used by cmux itself.
+
+## Evidence and route audit
+
+### Codex surfaces inspected
+
+- Codex CLI 0.143.0 publicly reports stable `browser_use`, `browser_use_external`, `browser_use_full_cdp_access`, `computer_use`, and `in_app_browser` feature keys.
+- `codex app-server generate-json-schema` succeeds, but its public v2 protocol contains configuration requirements for computer use, not a public browser-control request surface.
+- Codex's browser implementation is delivered through Codex Desktop/plugin runtime machinery. Reusing private bundled plugin scripts, internal pipes, credentials, signatures, or app identity would be unsupported and would cross the issue's explicit safety boundary.
+
+Conclusion: there is no supported public Codex browser protocol that a Pi extension can directly embed today. This extension must not load Codex-private plugin files or imitate app identity.
+
+### Pi public extension points inspected
+
+The current Pi README, `docs/extensions.md`, `docs/tui.md`, `docs/keybindings.md`, `docs/packages.md`, extension examples, and installed types support:
+
+- typed model-callable tools (`registerTool`), custom renderers, commands, and status UI;
+- abort-aware child processes through `pi.exec`;
+- session reconstruction from persisted tool-result `details`;
+- startup/shutdown hooks and package installation.
+
+Pi's TUI can render terminal components and images, but cannot host an AppKit `WKWebView`. A TUI browser would therefore be a reduced imitation and fails the requested native rendering/interaction outcome.
+
+### cmux public browser route
+
+cmux 0.64.13 exposes a documented, supported `cmux browser` CLI backed by the browser pane the user actually sees. It includes:
+
+- native surface creation with `--focus false`;
+- navigation and full WebKit rendering;
+- accessibility/DOM snapshots and ref-based interaction;
+- tabs, profiles, cookies/storage, state save/load;
+- screenshots, downloads, console/errors, highlighting, and JavaScript evaluation.
+
+The browser defaults to the caller's `CMUX_WORKSPACE_ID`, which keeps the pane beside the originating Pi session even if another workspace is focused. Its browser profile/data store preserves authentication according to cmux's supported profile behavior.
+
+Known public cmux/WKWebView limits are reported honestly: viewport/geolocation/offline emulation, tracing/screencast, network interception, and raw low-level input currently return `not_supported`. The extension does not claim CDP parity for those operations.
+
+## Selected architecture
+
+A normal Pi package extension delegates only allowlisted operations to the public `cmux browser` CLI:
+
+```text
+Pi model / user command
+        │
+        ▼
+strict TypeBox tool schema
+        │
+        ▼
+argument builder (no shell, no arbitrary passthrough)
+        │
+        ▼
+pi.exec(cmux, argv, { signal, timeout })
+        │
+        ▼
+cmux socket API → native browser surface / WKWebView
+```
+
+Design constraints:
+
+1. **Native, not simulated.** Rendering and direct user interaction stay in cmux's browser pane.
+2. **No focus theft.** Every surface-creation path explicitly passes `--focus false`; automation never calls `focus-webview`.
+3. **Origin workspace.** New surfaces rely on `CMUX_WORKSPACE_ID` or an explicit workspace argument, never the currently focused workspace.
+4. **Supported auth.** The extension uses cmux profiles/state/cookies APIs. It never reads browser or Codex credential stores and never returns cookie values unless the caller explicitly invokes the cookie-read operation.
+5. **Safe execution.** Commands are spawned as argv, not through a shell. Output is truncated before entering model context. File paths are resolved; upload requires an explicit regular file plus interactive approval, and profile deletion is also confirmed.
+6. **Lifecycle and recovery.** The last successful surface UUID is stored in tool-result details and reconstructed on `session_start`; commands can override it. Stale/missing surfaces fail with a recovery instruction rather than silently opening or focusing a replacement.
+7. **Rollback.** Remove/disable only `cmux-browser/index.ts` (or filter it from the package) and restart/reload Pi. The extension does not modify cmux, Codex, browser profiles, Pi core, or system settings.
+
+## Upload approach
+
+cmux supports native user drag/drop into file inputs but currently has no documented `browser upload` automation command. For agent-driven uploads, the extension uses the supported `browser eval` command to construct a DOM `File`, assign it through `DataTransfer`, and dispatch `input`/`change` on an explicitly selected file input. Bytes are transferred in bounded base64 chunks and the temporary page global is cleared in `finally`.
+
+This is normal page-level WebKit automation, not a permission bypass. It may not work on sites that intentionally reject synthetic file-input events; the tool reports that boundary. It never prints file contents.
+
+## Acceptance mapping
+
+| Requirement | Route |
+|---|---|
+| Navigation/rendering | cmux native browser surface + navigation operations |
+| Interaction | snapshot refs/CSS plus click, fill, type, key, select, check, scroll, wait |
+| Sessions/tabs | surface UUID recovery; tabs; profile/state APIs |
+| Auth-preserving behavior | cmux profile/data store; state/cookie/storage operations |
+| Uploads/downloads | bounded DOM file upload; native download wait/path result |
+| Screenshots | cmux browser screenshot to explicit/default path |
+| Debug/inspect | snapshot/get/eval/console/errors/highlight |
+| Lifecycle/recovery | persisted surface details, lazy validation, actionable stale-surface errors |
+| Background behavior | `--focus false`; no webview focus command |
+| Fresh install | package manifest entry, no runtime dependency |
+| Rollback | disable/remove one manifest resource; no external mutations |
+| E2E | real cmux browser smoke from fresh Pi plus deterministic fake-cmux tests |
+
+## Explicit non-goals and blockers
+
+- No reuse of Codex-private plugin scripts, internal pipes, credentials, or signing identity.
+- No binary patching, injection, TCC changes, or protective-measure bypass.
+- No claim that WKWebView offers unsupported CDP-only features.
+- No private/customer-data E2E fixture; tests use local/public synthetic pages.

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -4,7 +4,7 @@ Control a real cmux `WKWebView` pane from Pi through cmux's documented CLI. The 
 
 ## Requirements
 
-- macOS with [cmux](https://cmux.com) 0.64.13 or newer
+- macOS with exactly [cmux](https://cmux.com) 0.64.13 (the extension checks this before every model operation)
 - cmux browser automation enabled (`cmux browser enable`)
 - Pi launched directly from a cmux terminal, with access to the live cmux workspace and socket
 
@@ -28,25 +28,18 @@ Then, from a fresh Pi session inside cmux:
 /browser https://example.com
 ```
 
-The user-supplied slash command authorizes that initial origin. Model-initiated origin changes require confirmation in Pi. Navigation permits only absolute `http:`/`https:` URLs or exactly `about:blank`; URL credentials and credential-like query parameters are rejected.
+The user-supplied slash command authorizes that initial origin. Model-initiated origin changes require confirmation in Pi. To keep all credentials and signed links out of process arguments by construction, navigation accepts only an `http(s)` origin root (for example, `https://example.com/`) or exactly `about:blank`. Any non-root path, query, fragment, or URL userinfo is rejected; navigate deeper manually in the visible pane.
 
 ## Model tools
 
 | Tool | Exposed operations |
 |---|---|
-| `browser_navigate` | Open, go to an approved URL, reload, read the approved origin, close |
-| `browser_inspect` | Accessibility snapshot; bounded text/count/box/safe-attribute reads; screenshot; console/errors; highlight |
-| `browser_interact` | Click/double-click/hover/focus, allowlisted key press, check/uncheck, bounded scroll, ref/load-state wait |
-| `browser_download` | Wait for a cmux-managed download; returns readiness only, never a host path |
+| `browser_navigate` | Open/go to an approved origin root, read the current origin, close |
+| `browser_inspect` | Bounded, element-name-redacted structural accessibility snapshot tied atomically to its reported origin |
 
-Recommended loop:
+The public cmux 0.64.13 CLI cannot atomically require an expected origin before an interaction, screenshot, generic property read, console/error read, reload, or download wait. A page could navigate between a separate origin check and those operations. They are therefore not model tools: perform interactions, reloads, credential entry, downloads, screenshots, and debugging manually in the visible native pane.
 
-1. Open or navigate.
-2. Request an interactive snapshot.
-3. Act on a fresh snapshot ref such as `e3`.
-4. Re-snapshot after navigation or a substantial DOM change.
-
-Arbitrary CSS selectors, JavaScript evaluation, automated text/value entry, file upload, tabs, cookie/storage access, state import/export, profile mutation, and caller-selected host paths are intentionally not exposed. Enter text, passwords, tokens, one-time codes, selections, and file choices directly in the visible native pane.
+Arbitrary selectors, JavaScript evaluation, automated text/value entry, file operations, tabs, cookie/storage access, state import/export, profile mutation, and caller-selected host paths are intentionally not exposed.
 
 ## Authentication and profile boundary
 
@@ -57,12 +50,12 @@ For stronger separation, cancel the prompt, select a dedicated profile in cmux, 
 ## Ownership, output, and files
 
 - A client may control only the strict top-level UUID returned by its own successful `browser open` call.
-- Only one extension-owned surface is active. There is no tab enumeration, arbitrary surface/workspace parameter, stale-handle recovery, or session resurrection.
+- Only one extension-owned surface is active. Client operations are queued and all model tools execute sequentially, preventing parallel opens or shared-state races. An uncertain/interrupted open blocks retries. Close discards ownership only after a non-interrupted cmux 0.64.13 response repeats the exact owned top-level `surface_id`; failure or malformed output retains ownership. A process-wide fail-closed marker carries unresolved lifecycle state across `/reload`, `/new`, resume, and fork. There is no tab enumeration, arbitrary surface/workspace parameter, stale-handle recovery, or session resurrection.
 - Command failures expose fixed operation/exit metadata only; raw cmux stdout/stderr and raw argv are never copied into tool errors or session details.
-- Successful mutation results are fixed synthetic metadata. Only explicit read operations can return bounded captured output.
-- Snapshot refs must match `e` followed by a positive decimal integer. Arbitrary selectors are rejected before cmux invocation.
-- Screenshots are written under a private per-session temporary directory, opened with `O_NOFOLLOW`, checked as a regular file with restrictive permissions, bounded to 10 MiB, and deleted after display.
-- Download waiting returns `{ "ok": true, "download_ready": true }`; destination handling remains in cmux and no path is returned to the model.
+- Successful mutation results use a synthetic result variant that cannot contain subprocess stdout, stderr, or parsed output; this is redaction by construction. Only explicit read operations can return bounded captured page output.
+- Raw cmux snapshot JSON is never forwarded: the extension projects only bounded accessibility snapshot text and authoritative ref keys, discarding `page.text`, `page.html`, full URL, the standalone title field, ref metadata, and other fields.
+- cmux 0.64.13 may use a live input value as an accessibility name even when an input declares a misleading ARIA role. Every ref-bearing accessible name and the document title are therefore removed before output. Structural roles and body-text fallback remain, but element labels are intentionally absent.
+- Each snapshot's top-level URL is privately reduced to an origin from the same cmux response. Unapproved origins require confirmation; after a new approval, a fresh same-origin snapshot is required before any text is released.
 
 ## Public cmux limits
 
@@ -70,7 +63,7 @@ The WKWebView backend reports several CDP-only operations as unsupported, includ
 
 ## Recovery and rollback
 
-The owned surface exists only for the current Pi extension instance. If cmux restarts, the pane closes, or the Pi session reloads, open a new surface explicitly. The extension never adopts an existing pane or silently opens a replacement.
+The owned surface exists only for the current Pi extension instance and is closed best-effort on shutdown. The extension never adopts an existing pane or silently opens a replacement. If an open is uncertain, or shutdown cannot confirm the exact surface closed, the process-wide lifecycle marker prevents replacement extension instances from opening another pane. Close any possibly unowned native pane manually and restart Pi to reset that fail-closed state.
 
 For socket failures:
 
@@ -101,4 +94,4 @@ From a fresh Pi launched directly inside a healthy cmux workspace:
 scripts/test-cmux-browser-e2e.sh
 ```
 
-The E2E uses a local synthetic page and a private temporary directory. See [ARCHITECTURE.md](ARCHITECTURE.md) for the route audit and security design.
+The E2E pins cmux 0.64.13 and uses a local synthetic page to prove background native open, atomically origin-bound structural accessibility snapshot, and exact acknowledged cleanup. See [ARCHITECTURE.md](ARCHITECTURE.md) for the route audit and security design.

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -1,123 +1,104 @@
 # Native cmux browser for Pi
 
-Control the real cmux browser pane from Pi. The extension opens native `WKWebView` surfaces beside the calling Pi terminal, keeps focus in Pi, and gives the model structured tools for navigation, page interaction, tabs/state, files, screenshots, and diagnostics.
+Control a real cmux `WKWebView` pane from Pi through cmux's documented CLI. The extension owns one browser surface at a time, opens it without moving keyboard focus from Pi, and exposes a deliberately narrow set of model tools.
 
 ## Requirements
 
 - macOS with [cmux](https://cmux.com) 0.64.13 or newer
 - cmux browser automation enabled (`cmux browser enable`)
-- Pi launched from a cmux terminal so `CMUX_WORKSPACE_ID` and the cmux socket are available
+- Pi launched directly from a cmux terminal, with access to the live cmux workspace and socket
 
-No Codex installation, browser extension, CDP port, or extra npm runtime dependency is required.
+No Codex installation, browser extension, CDP port, or extra runtime dependency is required.
 
-## Install
-
-Install the repository package:
+## Install and open
 
 ```bash
 pi install git:github.com/tmustier/pi-extensions
 ```
 
-Or test only this extension from a checkout:
+To test only this extension from a checkout:
 
 ```bash
 pi --no-extensions -e ./cmux-browser/index.ts
 ```
 
-On a fresh Pi session inside cmux:
+Then, from a fresh Pi session inside cmux:
 
 ```text
 /browser https://example.com
 ```
 
-The browser opens in the originating workspace with `--focus false`. Pi remains ready for keyboard input while the page renders in its native pane.
+The user-supplied slash command authorizes that initial origin. Model-initiated origin changes require confirmation in Pi. Navigation permits only absolute `http:`/`https:` URLs or exactly `about:blank`; URL credentials and credential-like query parameters are rejected.
 
 ## Model tools
 
-| Tool | Purpose |
+| Tool | Exposed operations |
 |---|---|
-| `browser_navigate` | Open, navigate, history, reload, URL/title/status, close |
-| `browser_inspect` | Snapshot, DOM inspection, page eval, PNG screenshot, console/errors, highlight |
-| `browser_interact` | Click/fill/type/keys/select/check/scroll/wait using refs or CSS |
-| `browser_session` | Tabs, profiles, state save/load, upload, download wait |
+| `browser_navigate` | Open, go to an approved URL, reload, read the approved origin, close |
+| `browser_inspect` | Accessibility snapshot; bounded text/count/box/safe-attribute reads; screenshot; console/errors; highlight |
+| `browser_interact` | Click/double-click/hover/focus, allowlisted key press, check/uncheck, bounded scroll, ref/load-state wait |
+| `browser_download` | Wait for a cmux-managed download; returns readiness only, never a host path |
 
 Recommended loop:
 
-1. `browser_navigate { action: "open", url: "…" }`
-2. `browser_interact { action: "wait", load_state: "complete" }`
-3. `browser_inspect { action: "snapshot", interactive: true }`
-4. Act on a fresh ref with `browser_interact`.
-5. Re-snapshot after navigation or major DOM changes.
+1. Open or navigate.
+2. Request an interactive snapshot.
+3. Act on a fresh snapshot ref such as `e3`.
+4. Re-snapshot after navigation or a substantial DOM change.
 
-### Authentication and profiles
+Arbitrary CSS selectors, JavaScript evaluation, automated text/value entry, file upload, tabs, cookie/storage access, state import/export, profile mutation, and caller-selected host paths are intentionally not exposed. Enter text, passwords, tokens, one-time codes, selections, and file choices directly in the visible native pane.
 
-The extension uses cmux's own browser profiles/data stores. Sign in normally in the visible native pane, or use `browser_session` state/profile operations for supported continuity. The extension never reads Chrome, Safari, Codex, or system credential stores.
+## Authentication and profile boundary
 
-Browser state, cookie/storage exports, and profile artifacts can contain authenticated site state, bearer material, or personal data. Store them outside repositories, restrict filesystem access, never paste them into prompts/logs/issues, and protect them like credentials. The extension redacts sensitive command arguments from failures and tool metadata, but it cannot make an exported artifact safe.
+cmux 0.64.13 does not provide a documented per-open profile selector. An automation-opened pane therefore uses cmux's currently selected browser profile, which may be shared with other cmux panes. Pi requires explicit confirmation before the extension opens its first surface.
 
-### Uploads
+For stronger separation, cancel the prompt, select a dedicated profile in cmux, and retry. The extension does not list, read, create, switch, clear, delete, export, or import profiles, cookies, local storage, or browser state. It never reads Chrome, Safari, Codex, or system credential stores.
 
-`browser_session { action: "upload", path, selector }` asks for interactive approval, then reads one explicit local regular file (maximum 25 MiB), creates a DOM `File` in the current page through cmux's supported eval operation, and dispatches `input`/`change` on the selected `<input type="file">`. Non-interactive uploads are rejected. File paths, contents, encoded chunks, and eval payloads are omitted from failures and tool-result metadata; only safe command/surface/exit diagnostics are retained.
+## Ownership, output, and files
 
-Some sites deliberately reject synthetic file-input events. For those sites, drag the file into the visible cmux browser pane; cmux supports native HTML5 file drop.
+- A client may control only the strict top-level UUID returned by its own successful `browser open` call.
+- Only one extension-owned surface is active. There is no tab enumeration, arbitrary surface/workspace parameter, stale-handle recovery, or session resurrection.
+- Command failures expose fixed operation/exit metadata only; raw cmux stdout/stderr and raw argv are never copied into tool errors or session details.
+- Successful mutation results are fixed synthetic metadata. Only explicit read operations can return bounded captured output.
+- Snapshot refs must match `e` followed by a positive decimal integer. Arbitrary selectors are rejected before cmux invocation.
+- Screenshots are written under a private per-session temporary directory, opened with `O_NOFOLLOW`, checked as a regular file with restrictive permissions, bounded to 10 MiB, and deleted after display.
+- Download waiting returns `{ "ok": true, "download_ready": true }`; destination handling remains in cmux and no path is returned to the model.
 
-### Downloads
+## Public cmux limits
 
-Start the page download, then call `browser_session { action: "download_wait" }`. cmux returns its native download event/path. Download save prompts and destinations follow the user's cmux settings.
+The WKWebView backend reports several CDP-only operations as unsupported, including viewport/geolocation/offline emulation, tracing/screencast, network interception, and raw low-level input. This extension does not expose or claim those operations.
 
-## Supported boundaries
+## Recovery and rollback
 
-cmux's WKWebView backend currently reports these CDP-only operations as `not_supported`:
+The owned surface exists only for the current Pi extension instance. If cmux restarts, the pane closes, or the Pi session reloads, open a new surface explicitly. The extension never adopts an existing pane or silently opens a replacement.
 
-- viewport/geolocation/offline emulation
-- tracing and screencast recording
-- network interception/mocking
-- low-level raw mouse/keyboard/touch injection
-
-This extension does not expose or claim those operations. High-level DOM/ref interaction, screenshots, downloads, tabs, profiles, console, and page errors are supported.
-
-## Recovery
-
-The last successful surface UUID is persisted in Pi tool-result details and restored when the session resumes/reloads. If cmux restarted or the surface was closed, open a replacement explicitly:
-
-```text
-browser_navigate { action: "open", url: "https://example.com" }
-```
-
-For socket errors:
+For socket failures:
 
 ```bash
 cmux ping
 cmux browser status
-cmux browser enable   # only if status is disabled
+cmux browser enable   # only when status is disabled
 ```
 
-The extension does not silently open a replacement because that can put automation in the wrong workspace/profile.
-
-## Rollback
-
-Disable only this resource in the Pi package configuration, remove the local `-e`/extension setting, or uninstall the package:
+To roll back:
 
 ```bash
 pi remove git:github.com/tmustier/pi-extensions
 ```
 
-Then `/reload` or restart Pi. No Pi core, cmux binary/config, Codex installation, browser profile, signing identity, or macOS permission is modified by installation.
+Then run `/reload` or restart Pi. Installation does not modify Pi core, cmux binaries/configuration, Codex, browser profiles, signing identity, or macOS permissions.
 
 ## Verification
 
-Deterministic client tests:
-
 ```bash
-npx tsx --test cmux-browser/client.test.ts
+npm run test:cmux-browser
+npm run typecheck:cmux-browser
 ```
 
-Real E2E from a clean Pi inside a live cmux workspace:
+From a fresh Pi launched directly inside a healthy cmux workspace:
 
 ```bash
 scripts/test-cmux-browser-e2e.sh
 ```
 
-The E2E uses only a local synthetic page and temporary files; it does not use private/customer data.
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the public-surface audit and acceptance mapping.
+The E2E uses a local synthetic page and a private temporary directory. See [ARCHITECTURE.md](ARCHITECTURE.md) for the route audit and security design.

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -1,0 +1,123 @@
+# Native cmux browser for Pi
+
+Control the real cmux browser pane from Pi. The extension opens native `WKWebView` surfaces beside the calling Pi terminal, keeps focus in Pi, and gives the model structured tools for navigation, page interaction, tabs/state, files, screenshots, and diagnostics.
+
+## Requirements
+
+- macOS with [cmux](https://cmux.com) 0.64.13 or newer
+- cmux browser automation enabled (`cmux browser enable`)
+- Pi launched from a cmux terminal so `CMUX_WORKSPACE_ID` and the cmux socket are available
+
+No Codex installation, browser extension, CDP port, or extra npm runtime dependency is required.
+
+## Install
+
+Install the repository package:
+
+```bash
+pi install git:github.com/tmustier/pi-extensions
+```
+
+Or test only this extension from a checkout:
+
+```bash
+pi --no-extensions -e ./cmux-browser/index.ts
+```
+
+On a fresh Pi session inside cmux:
+
+```text
+/browser https://example.com
+```
+
+The browser opens in the originating workspace with `--focus false`. Pi remains ready for keyboard input while the page renders in its native pane.
+
+## Model tools
+
+| Tool | Purpose |
+|---|---|
+| `browser_navigate` | Open, navigate, history, reload, URL/title/status, close |
+| `browser_inspect` | Snapshot, DOM inspection, page eval, PNG screenshot, console/errors, highlight |
+| `browser_interact` | Click/fill/type/keys/select/check/scroll/wait using refs or CSS |
+| `browser_session` | Tabs, profiles, state save/load, upload, download wait |
+
+Recommended loop:
+
+1. `browser_navigate { action: "open", url: "…" }`
+2. `browser_interact { action: "wait", load_state: "complete" }`
+3. `browser_inspect { action: "snapshot", interactive: true }`
+4. Act on a fresh ref with `browser_interact`.
+5. Re-snapshot after navigation or major DOM changes.
+
+### Authentication and profiles
+
+The extension uses cmux's own browser profiles/data stores. Sign in normally in the visible native pane, or use `browser_session` state/profile operations for supported continuity. The extension never reads Chrome, Safari, Codex, or system credential stores.
+
+Do not commit browser state files: they can contain authenticated site state. Store them outside repositories and protect them like credentials.
+
+### Uploads
+
+`browser_session { action: "upload", path, selector }` asks for interactive approval, then reads one explicit local regular file (maximum 25 MiB), creates a DOM `File` in the current page through cmux's supported eval operation, and dispatches `input`/`change` on the selected `<input type="file">`. Non-interactive uploads are rejected, and file contents are not included in the tool result.
+
+Some sites deliberately reject synthetic file-input events. For those sites, drag the file into the visible cmux browser pane; cmux supports native HTML5 file drop.
+
+### Downloads
+
+Start the page download, then call `browser_session { action: "download_wait" }`. cmux returns its native download event/path. Download save prompts and destinations follow the user's cmux settings.
+
+## Supported boundaries
+
+cmux's WKWebView backend currently reports these CDP-only operations as `not_supported`:
+
+- viewport/geolocation/offline emulation
+- tracing and screencast recording
+- network interception/mocking
+- low-level raw mouse/keyboard/touch injection
+
+This extension does not expose or claim those operations. High-level DOM/ref interaction, screenshots, downloads, tabs, profiles, console, and page errors are supported.
+
+## Recovery
+
+The last successful surface UUID is persisted in Pi tool-result details and restored when the session resumes/reloads. If cmux restarted or the surface was closed, open a replacement explicitly:
+
+```text
+browser_navigate { action: "open", url: "https://example.com" }
+```
+
+For socket errors:
+
+```bash
+cmux ping
+cmux browser status
+cmux browser enable   # only if status is disabled
+```
+
+The extension does not silently open a replacement because that can put automation in the wrong workspace/profile.
+
+## Rollback
+
+Disable only this resource in the Pi package configuration, remove the local `-e`/extension setting, or uninstall the package:
+
+```bash
+pi remove git:github.com/tmustier/pi-extensions
+```
+
+Then `/reload` or restart Pi. No Pi core, cmux binary/config, Codex installation, browser profile, signing identity, or macOS permission is modified by installation.
+
+## Verification
+
+Deterministic client tests:
+
+```bash
+npx tsx --test cmux-browser/client.test.ts
+```
+
+Real E2E from a clean Pi inside a live cmux workspace:
+
+```bash
+scripts/test-cmux-browser-e2e.sh
+```
+
+The E2E uses only a local synthetic page and temporary files; it does not use private/customer data.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the public-surface audit and acceptance mapping.

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -53,11 +53,11 @@ Recommended loop:
 
 The extension uses cmux's own browser profiles/data stores. Sign in normally in the visible native pane, or use `browser_session` state/profile operations for supported continuity. The extension never reads Chrome, Safari, Codex, or system credential stores.
 
-Do not commit browser state files: they can contain authenticated site state. Store them outside repositories and protect them like credentials.
+Browser state, cookie/storage exports, and profile artifacts can contain authenticated site state, bearer material, or personal data. Store them outside repositories, restrict filesystem access, never paste them into prompts/logs/issues, and protect them like credentials. The extension redacts sensitive command arguments from failures and tool metadata, but it cannot make an exported artifact safe.
 
 ### Uploads
 
-`browser_session { action: "upload", path, selector }` asks for interactive approval, then reads one explicit local regular file (maximum 25 MiB), creates a DOM `File` in the current page through cmux's supported eval operation, and dispatches `input`/`change` on the selected `<input type="file">`. Non-interactive uploads are rejected, and file contents are not included in the tool result.
+`browser_session { action: "upload", path, selector }` asks for interactive approval, then reads one explicit local regular file (maximum 25 MiB), creates a DOM `File` in the current page through cmux's supported eval operation, and dispatches `input`/`change` on the selected `<input type="file">`. Non-interactive uploads are rejected. File paths, contents, encoded chunks, and eval payloads are omitted from failures and tool-result metadata; only safe command/surface/exit diagnostics are retained.
 
 Some sites deliberately reject synthetic file-input events. For those sites, drag the file into the visible cmux browser pane; cmux supports native HTML5 file drop.
 

--- a/cmux-browser/client.test.ts
+++ b/cmux-browser/client.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { CmuxBrowserClient, type ExecCmux } from "./client.ts";
+
+function recorder(outputs: Array<{ stdout?: string; stderr?: string; code?: number }> = []) {
+	const calls: string[][] = [];
+	const exec: ExecCmux = async (args) => {
+		calls.push(args);
+		const next = outputs.shift() ?? {};
+		return { stdout: next.stdout ?? JSON.stringify({ ok: true }), stderr: next.stderr ?? "", code: next.code ?? 0 };
+	};
+	return { calls, exec };
+}
+
+test("open targets the caller workspace implicitly and never steals focus", async () => {
+	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface: { surface_id: "A-SURFACE-UUID" } }) }]);
+	const client = new CmuxBrowserClient(exec);
+	const result = await client.open("https://example.com", undefined);
+	assert.equal(result.surface, "A-SURFACE-UUID");
+	assert.equal(client.getActiveSurface(), "A-SURFACE-UUID");
+	assert.deepEqual(calls[0], [
+		"--json", "--id-format", "uuids", "browser", "open", "https://example.com", "--focus", "false",
+	]);
+	assert.equal(calls[0]?.includes("--workspace"), false);
+});
+
+test("open recovers a UUID from cmux's nested surface payload", async () => {
+	const { exec } = recorder([{ stdout: JSON.stringify({ surface: { id: "nested-surface-uuid" } }) }]);
+	const client = new CmuxBrowserClient(exec);
+	assert.equal((await client.open("about:blank", undefined)).surface, "nested-surface-uuid");
+});
+
+test("explicit workspace remains backgrounded", async () => {
+	const { calls, exec } = recorder();
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank", "workspace:7");
+	assert.deepEqual(calls[0]?.slice(-4), ["--focus", "false", "--workspace", "workspace:7"]);
+});
+
+test("later browser operations reuse the persisted surface without a shell", async () => {
+	const { calls, exec } = recorder();
+	const client = new CmuxBrowserClient(exec, "surface-uuid");
+	await client.browser(undefined, ["snapshot", "--interactive"]);
+	assert.deepEqual(calls[0], [
+		"--json", "--id-format", "uuids", "browser", "surface-uuid", "snapshot", "--interactive",
+	]);
+});
+
+test("a missing surface produces an actionable recovery error", async () => {
+	const { exec } = recorder();
+	const client = new CmuxBrowserClient(exec);
+	await assert.rejects(() => client.browser(undefined, ["get", "url"]), /action=open first/);
+});
+
+test("cmux socket failures are translated into lifecycle recovery guidance", async () => {
+	const { exec } = recorder([{ code: 1, stderr: "Error: Failed to write to socket (Broken pipe, errno 32)" }]);
+	const client = new CmuxBrowserClient(exec);
+	await assert.rejects(() => client.open("https://example.com", undefined), /cmux ping/);
+});
+
+test("upload sends bounded page-eval chunks, dispatches file events, and never emits file contents", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
+	const path = join(directory, "hello.txt");
+	const secretFixture = "synthetic-upload-fixture-not-private";
+	await writeFile(path, secretFixture);
+	const { calls, exec } = recorder();
+	const client = new CmuxBrowserClient(exec, "surface-uuid");
+	const result = await client.upload(undefined, "#upload", path, directory);
+	assert.equal(result.surface, "surface-uuid");
+	assert.ok(calls.length >= 3);
+	assert.ok(calls.every((call) => call[0] === "--json" && call.includes("eval")));
+	const scripts = calls.map((call) => call[call.indexOf("--script") + 1] ?? "");
+	assert.ok(scripts.some((script) => script.includes("new DataTransfer")));
+	assert.ok(scripts.some((script) => script.includes("dispatchEvent(new Event('change'")));
+	assert.ok(scripts.some((script) => script.includes("delete globalThis.__piCmuxUploadBase64")));
+	assert.equal(JSON.stringify(result).includes(secretFixture), false);
+});
+
+test("upload rejects directories and oversized files before browser execution", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
+	const { calls, exec } = recorder();
+	const client = new CmuxBrowserClient(exec, "surface-uuid");
+	await assert.rejects(() => client.upload(undefined, "#upload", directory, directory), /not a regular file/);
+	assert.equal(calls.length, 0);
+});

--- a/cmux-browser/client.test.ts
+++ b/cmux-browser/client.test.ts
@@ -187,7 +187,7 @@ test("explicit read capture bounds stdout, suppresses successful stderr, and doe
 	await client.open("about:blank");
 	const result = await client.browser(["snapshot"], undefined, 20_000, { capture: true });
 	assert.ok(Buffer.byteLength(result.stdout) < 52 * 1024);
-	assert.equal(result.stderr, "");
+	assert.equal("stderr" in result, false);
 	assert.equal(result.stdout.includes("END_SECRET"), false);
 	assert.equal(result.json, undefined);
 	assert.equal(result.exposure, "captured");
@@ -254,14 +254,15 @@ test("current origin refuses non-contract output without reflecting it into diag
 
 test("synthetic tool results persist only allowlisted metadata, never raw output or values", () => {
 	const secret = "PASSWORD_123456";
-	const result = toolResult("click", {
+	const hostileResult = {
 		command: ["browser", "<owned-surface>", "click"],
 		stdout: `raw-${secret}`,
 		stderr: `stderr-${secret}`,
 		json: { ok: true, interacted: true, diagnostic: `transformed-${secret}` },
 		surface: SURFACE_A,
 		exposure: "synthetic",
-	});
+	} as unknown as Parameters<typeof toolResult>[1];
+	const result = toolResult("click", hostileResult);
 	assert.deepEqual(Object.keys(result.details).sort(), ["action", "command", "output", "surface"].sort());
 	assert.deepEqual(result.details.command, ["browser", "<owned-surface>", "click"]);
 	assert.deepEqual(result.content, [{ type: "text", text: JSON.stringify({ ok: true, interacted: true }) }]);

--- a/cmux-browser/client.test.ts
+++ b/cmux-browser/client.test.ts
@@ -10,18 +10,18 @@ import { readPrivateImage } from "./private-image.ts";
 const SURFACE_A = "123e4567-e89b-42d3-a456-426614174000";
 const SURFACE_B = "123e4567-e89b-42d3-a456-426614174001";
 
-function recorder(outputs: Array<{ stdout?: string; stderr?: string; code?: number }> = []) {
+function recorder(outputs: Array<{ stdout?: string; stderr?: string; code?: number; killed?: boolean }> = []) {
 	const calls: string[][] = [];
 	const exec: ExecCmux = async (args) => {
 		calls.push(args);
 		const next = outputs.shift() ?? {};
-		return { stdout: next.stdout ?? JSON.stringify({ ok: true }), stderr: next.stderr ?? "", code: next.code ?? 0 };
+		return { stdout: next.stdout ?? JSON.stringify({ ok: true }), stderr: next.stderr ?? "", code: next.code ?? 0, killed: next.killed };
 	};
 	return { calls, exec };
 }
 
 test("open accepts only a documented top-level UUID, stays backgrounded, and retains no URL", async () => {
-	const secretUrl = "https://example.com/path?ordinary=TAB_SECRET_%31%32%33%34%35%36";
+	const secretUrl = "https://example.com/";
 	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A, url: secretUrl }) }]);
 	const client = new CmuxBrowserClient(exec);
 	const result = await client.open(secretUrl);
@@ -32,8 +32,10 @@ test("open accepts only a documented top-level UUID, stays backgrounded, and ret
 		"--json", "--id-format", "uuids", "browser", "open", secretUrl, "--focus", "false",
 	]);
 	assert.deepEqual(result.command, ["browser", "open"]);
-	assert.deepEqual(result.json, { ok: true, opened: true });
 	assert.equal(result.exposure, "synthetic");
+	assert.deepEqual(result.output, { ok: true, opened: true });
+	assert.equal("stdout" in result, false);
+	assert.equal("json" in result, false);
 	assert.equal(JSON.stringify(result).includes(secretUrl), false);
 });
 
@@ -44,35 +46,64 @@ test("nested or invalid attacker-controlled surface fields cannot poison the act
 		{ surface_id: "surface:1" },
 		{ surface_id: "not-a-uuid" },
 	]) {
-		const { exec } = recorder([{ stdout: JSON.stringify(payload) }]);
+		const { calls, exec } = recorder([{ stdout: JSON.stringify(payload) }]);
 		const client = new CmuxBrowserClient(exec);
 		await assert.rejects(() => client.open("about:blank"), /no valid top-level surface_id UUID/);
+		await assert.rejects(() => client.open("about:blank"), /open lifecycle is uncertain/);
+		assert.equal(calls.length, 1);
 		assert.equal(client.getActiveSurface(), undefined);
 		assert.equal(client.getOwnedSurfaceCount(), 0);
 	}
 });
 
 test("one session cannot target arbitrary surfaces or open a second inaccessible surface", async () => {
-	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }]);
+	const { calls, exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: JSON.stringify({ snapshot: "- document page", refs: {}, url: "about:blank" }) },
+	]);
 	const client = new CmuxBrowserClient(exec);
 	await assert.rejects(() => client.browser(["snapshot"]), /action=open first/);
 	await client.open("about:blank");
 	await assert.rejects(() => client.open("about:blank"), /already active/);
-	await client.browser(["snapshot"]);
+	await client.browser(["snapshot"], undefined, 20_000, { captureSnapshot: true });
 	assert.equal(calls[1]?.includes(SURFACE_A), true);
 	assert.equal(calls.flat().includes(SURFACE_B), false);
+});
+
+test("concurrent open calls serialize and cannot create an orphaned second surface", async () => {
+	const calls: string[][] = [];
+	let releaseFirst!: () => void;
+	const firstCanFinish = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	const exec: ExecCmux = async (args) => {
+		calls.push(args);
+		await firstCanFinish;
+		return { stdout: JSON.stringify({ surface_id: SURFACE_A }), stderr: "", code: 0 };
+	};
+	const client = new CmuxBrowserClient(exec);
+	const first = client.open("about:blank");
+	const second = client.open("about:blank");
+	const secondRejected = assert.rejects(second, /already active/);
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(calls.length, 1);
+	releaseFirst();
+	await Promise.all([first, secondRejected]);
+	assert.equal(calls.length, 1);
+	assert.equal(client.getOwnedSurfaceCount(), 1);
+	assert.equal(client.getActiveSurface(), SURFACE_A);
 });
 
 test("failures expose fixed metadata only, including transformed diagnostics", async () => {
 	const secret = "PASSWORD_%31%32%33%34%35%36";
 	const { exec } = recorder([
 		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
-		{ stdout: JSON.stringify({ snapshot: '- button "Continue" [ref=e1]' }) },
+		{ stdout: JSON.stringify({ snapshot: '- button "Continue" [ref=e1]', refs: { e1: { role: "button" } }, url: "about:blank" }) },
 		{ code: 17, stderr: `P\\u0041SSWORD transformed ${secret}\n${"x".repeat(80_000)}` },
 	]);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
-	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { captureSnapshot: true });
 	await assert.rejects(() => client.browser(["click", "e1"]), (error: Error) => {
 		assert.equal(error.message, "cmux browser <owned-surface> click failed (exit 17). Raw diagnostics were suppressed. If cmux may be unavailable, confirm Pi is running inside a live cmux workspace and run `cmux ping`.");
 		for (const fragment of [secret, "P\\u0041SSWORD", "transformed", "xxxxx"]) {
@@ -98,12 +129,25 @@ test("subprocess rejections expose fixed metadata without argv or exception diag
 		throw new Error(`spawn failed with argv https://example.com/${secret}`);
 	};
 	const client = new CmuxBrowserClient(exec);
-	await assert.rejects(() => client.open(`https://example.com/${secret}`), (error: Error) => {
+	await assert.rejects(() => client.open("https://example.com/"), (error: Error) => {
 		assert.match(error.message, /cmux browser open could not be invoked/);
 		assert.equal(error.message.includes(secret), false);
 		assert.equal(error.message.includes("https://"), false);
 		return true;
 	});
+});
+
+test("failed open invocation terminally blocks retries that could create a second pane", async () => {
+	let calls = 0;
+	const client = new CmuxBrowserClient(async () => {
+		calls += 1;
+		if (calls === 1) throw new Error("transport failed after an uncertain create");
+		return { stdout: JSON.stringify({ surface_id: SURFACE_B }), stderr: "", code: 0 };
+	});
+	await assert.rejects(() => client.open("about:blank"), /could not be invoked/);
+	await assert.rejects(() => client.open("about:blank"), /open lifecycle is uncertain/);
+	assert.equal(calls, 1);
+	assert.equal(client.getOwnedSurfaceCount(), 0);
 });
 
 test("value-bearing browser capabilities are rejected before subprocess invocation", async () => {
@@ -163,6 +207,15 @@ test("open rejects unsafe navigation before subprocess invocation", async () => 
 	for (const url of [
 		`https://user:${secret}@example.com/`,
 		`https://example.com/?apiKey=${secret}`,
+		`https://example.com/?SAMLResponse=${secret}`,
+		`https://example.com/?SAMLRequest=${secret}`,
+		`https://example.com/?RelayState=${secret}`,
+		`https://example.com/?clientState=${secret}`,
+		`https://example.com/?assertion=${secret}`,
+		`https://example.com/?jwt=${secret}`,
+		`https://example.com/?oauth=${secret}`,
+		`https://example.com/?oidc=${secret}`,
+		`https://example.com/?ticket=${secret}`,
 		`https://example.com/#/callback?refreshToken=${secret}`,
 		"https://example.com/#bad%ZZ",
 		"file:///private/secret",
@@ -185,16 +238,37 @@ test("explicit read capture bounds stdout, suppresses successful stderr, and doe
 	]);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
-	const result = await client.browser(["snapshot"], undefined, 20_000, { capture: true });
+	const result = await client.browser(["console", "list"], undefined, 20_000, { capture: true });
+	assert.equal(result.exposure, "captured");
+	if (result.exposure !== "captured") throw new Error("expected captured result");
 	assert.ok(Buffer.byteLength(result.stdout) < 52 * 1024);
 	assert.equal("stderr" in result, false);
 	assert.equal(result.stdout.includes("END_SECRET"), false);
 	assert.equal(result.json, undefined);
-	assert.equal(result.exposure, "captured");
+});
+
+test("successful non-read operations discard raw subprocess output by construction", async () => {
+	const secret = "SUCCESS_OUTPUT_SECRET_53";
+	const { exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A, diagnostic: secret }), stderr: `open-${secret}` },
+		{ stdout: JSON.stringify({ diagnostic: secret }), stderr: `reload-${secret}` },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	const opened = await client.open("about:blank");
+	const reloaded = await client.browser(["reload"], undefined, 20_000, { success: "navigated" });
+	for (const result of [opened, reloaded]) {
+		assert.equal(result.exposure, "synthetic");
+		assert.equal("stdout" in result, false);
+		assert.equal("json" in result, false);
+		assert.equal(JSON.stringify(result).includes(secret), false);
+	}
 });
 
 test("close is terminal, cannot resurrect the old handle, and shutdown closes all owned surfaces", async () => {
-	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }]);
+	const { calls, exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+	]);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
 	const closed = await client.closeActive();
@@ -204,25 +278,51 @@ test("close is terminal, cannot resurrect the old handle, and shutdown closes al
 	await assert.rejects(() => client.browser(["snapshot"]), /action=open first/);
 	assert.deepEqual(calls[1]?.slice(3), ["close-surface", "--surface", SURFACE_A]);
 
-	const second = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_B }) }]);
+	const second = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_B }) },
+		{ stdout: JSON.stringify({ surface_id: SURFACE_B }) },
+	]);
 	const shutdownClient = new CmuxBrowserClient(second.exec);
 	await shutdownClient.open("about:blank");
-	await shutdownClient.closeAll();
+	assert.equal(await shutdownClient.closeAll(), true);
 	assert.equal(shutdownClient.getOwnedSurfaceCount(), 0);
 	assert.deepEqual(second.calls[1]?.slice(3), ["close-surface", "--surface", SURFACE_B]);
 });
 
-test("a failed close still relinquishes the stale owned handle", async () => {
-	const { exec } = recorder([
+test("interrupted or malformed closes preserve ownership until an exact acknowledgement", async () => {
+	const { calls, exec } = recorder([
 		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
-		{ code: 1, stderr: "private close diagnostic" },
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }), code: 0, killed: true },
+		{ stdout: JSON.stringify({ ok: true }), code: 0 },
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }), code: 0 },
 	]);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
-	await assert.rejects(() => client.closeActive(), /Raw diagnostics were suppressed/);
+	await assert.rejects(() => client.closeActive(), /interrupted before completion could be confirmed/);
+	await assert.rejects(() => client.closeActive(), /without confirming the exact owned surface_id/);
+	assert.equal(client.getActiveSurface(), SURFACE_A);
+	assert.equal(client.getOwnedSurfaceCount(), 1);
+	await assert.rejects(() => client.open("about:blank"), /already active/);
+	assert.equal(calls.filter((args) => args.includes("open")).length, 1);
+	await client.closeActive();
 	assert.equal(client.getActiveSurface(), undefined);
 	assert.equal(client.getOwnedSurfaceCount(), 0);
-	await assert.rejects(() => client.browser(["snapshot"]), /action=open first/);
+});
+
+test("best-effort closeAll preserves ownership after failure for a later retry", async () => {
+	const { exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ code: 1, stderr: "first shutdown close failed" },
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	assert.equal(await client.closeAll(), false);
+	assert.equal(client.getActiveSurface(), SURFACE_A);
+	assert.equal(client.getOwnedSurfaceCount(), 1);
+	assert.equal(await client.closeAll(), true);
+	assert.equal(client.getActiveSurface(), undefined);
+	assert.equal(client.getOwnedSurfaceCount(), 0);
 });
 
 test("current origin keeps URL details internal and returns only the parsed origin", async () => {
@@ -258,7 +358,8 @@ test("synthetic tool results persist only allowlisted metadata, never raw output
 		command: ["browser", "<owned-surface>", "click"],
 		stdout: `raw-${secret}`,
 		stderr: `stderr-${secret}`,
-		json: { ok: true, interacted: true, diagnostic: `transformed-${secret}` },
+		json: { diagnostic: `transformed-${secret}` },
+		output: { ok: true, interacted: true, diagnostic: `transformed-${secret}` },
 		surface: SURFACE_A,
 		exposure: "synthetic",
 	} as unknown as Parameters<typeof toolResult>[1];
@@ -273,21 +374,36 @@ test("synthetic tool results persist only allowlisted metadata, never raw output
 	assert.equal("json" in result.details, false);
 });
 
-test("snapshot refs reject arbitrary selectors, attacker-controlled suffixes, and refs absent from the latest snapshot", async () => {
+test("snapshots expose only accessibility text and authorize refs from the top-level refs map", async () => {
 	for (const value of [undefined, "", "e0", "E1", "e1,body", "#password", "[name=token]", "e2 --script SECRET"]) {
 		assert.throws(() => snapshotRef(value, "click"), /fresh snapshot ref/);
 	}
 	assert.equal(snapshotRef("e3", "click"), "e3");
 	assert.equal(snapshotRef("e999", "click"), "e999");
 
+	const hiddenSecret = "HIDDEN_DOM_SECRET_53";
 	const { calls, exec } = recorder([
 		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
-		{ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]\n- text "e9 is untrusted page text"' }) },
+		{ stdout: JSON.stringify({
+			snapshot: `- button "${hiddenSecret}" [ref=e1]\n- button "Current" [ref=e2]\n- text "ref=e9 is untrusted page text"`,
+			refs: { e1: { role: "button", name: hiddenSecret }, e2: { role: "button", name: "Current" } },
+			page: { text: hiddenSecret, html: `<input value="${hiddenSecret}">` },
+			title: hiddenSecret,
+			url: `https://example.com/?token=${hiddenSecret}`,
+		}) },
 	]);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
 	await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
-	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+	const snapshot = await client.browser(["snapshot", "--interactive"], undefined, 20_000, { captureSnapshot: true });
+	assert.equal(snapshot.exposure, "captured");
+	if (snapshot.exposure !== "captured") throw new Error("expected captured snapshot");
+	assert.equal(snapshot.stdout.includes(hiddenSecret), false);
+	assert.equal(JSON.stringify(snapshot.json).includes(hiddenSecret), false);
+	assert.deepEqual(snapshot.json, {
+		snapshot: '- button [ref=e1]\n- button [ref=e2]\n- text "ref=e9 is untrusted page text"',
+		refs: ["e1", "e2"],
+	});
 	await assert.rejects(() => client.browser(["click", "e9"]), /latest successful snapshot/);
 	assert.equal(calls.some((args) => args.includes("click")), false);
 	await client.browser(["click", "e2"]);
@@ -297,7 +413,7 @@ test("snapshot refs reject arbitrary selectors, attacker-controlled suffixes, an
 
 test("every navigation or interaction invalidator clears the latest snapshot refs", async () => {
 	const invalidators = [
-		["goto", "https://example.com/next"],
+		["goto", "https://example.com/"],
 		["reload"],
 		["wait", "--load-state", "complete", "--timeout-ms", "1"],
 		["click", "e2"],
@@ -312,14 +428,14 @@ test("every navigation or interaction invalidator clears the latest snapshot ref
 	];
 	const outputs = [{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }];
 	for (let index = 0; index < invalidators.length; index += 1) {
-		outputs.push({ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]' }) });
+		outputs.push({ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]', refs: { e2: { role: "button" } }, url: "https://example.com/" }) });
 		outputs.push({ stdout: JSON.stringify({ ok: true }) });
 	}
 	const { calls, exec } = recorder(outputs);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
 	for (const args of invalidators) {
-		await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+		await client.browser(["snapshot", "--interactive"], undefined, 20_000, { captureSnapshot: true });
 		await client.browser(args);
 		const callsBeforeStaleAttempt = calls.length;
 		await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
@@ -330,21 +446,38 @@ test("every navigation or interaction invalidator clears the latest snapshot ref
 test("a failed replacement snapshot leaves no previously recorded refs usable", async () => {
 	const { calls, exec } = recorder([
 		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
-		{ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]' }) },
+		{ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]', refs: { e2: { role: "button" } }, url: "about:blank" }) },
 		{ code: 1, stderr: "snapshot backend secret" },
 	]);
 	const client = new CmuxBrowserClient(exec);
 	await client.open("about:blank");
-	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
-	await assert.rejects(() => client.browser(["snapshot"], undefined, 20_000, { capture: true }), /failed \(exit 1\)/);
+	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { captureSnapshot: true });
+	await assert.rejects(() => client.browser(["snapshot"], undefined, 20_000, { captureSnapshot: true }), /failed \(exit 1\)/);
 	await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
 	assert.equal(calls.some((args) => args.includes("click")), false);
 });
 
-test("navigation policy rejects credential-bearing URLs and unsafe schemes", () => {
+test("navigation policy allows only origin roots, excluding all path/query/fragment credential channels", () => {
 	for (const url of [
+		"https://example.com/private",
+		"https://example.com/?q=ordinary",
+		"https://example.com/#ordinary",
 		"https://example.com/?token=SECRET",
 		"https://example.com/?apiKey=SECRET",
+		"https://example.com/?SAMLResponse=SECRET",
+		"https://example.com/?SAMLRequest=SECRET",
+		"https://example.com/?RelayState=SECRET",
+		"https://example.com/?clientState=SECRET",
+		"https://example.com/?assertion=SECRET",
+		"https://example.com/?jwt=SECRET",
+		"https://example.com/?oauth=SECRET",
+		"https://example.com/?oidc=SECRET",
+		"https://example.com/?ticket=SECRET",
+		"https://example.com/#oauth=SECRET",
+		"https://example.com/#oidc=SECRET",
+		"https://example.com/#RelayState=SECRET",
+		"https://example.com/#SAMLRequest=SECRET",
+		"https://example.com/#clientState=SECRET",
 		"https://example.com/#accessToken=SECRET",
 		"https://example.com/#/callback?clientSecret=SECRET",
 		"https://example.com/#bad%ZZ",
@@ -355,8 +488,8 @@ test("navigation policy rejects credential-bearing URLs and unsafe schemes", () 
 	]) {
 		assert.throws(() => navigationTarget(url));
 	}
-	assert.deepEqual(navigationTarget("https://example.com/path?q=ordinary"), {
-		url: "https://example.com/path?q=ordinary",
+	assert.deepEqual(navigationTarget("https://example.com"), {
+		url: "https://example.com/",
 		origin: "https://example.com",
 	});
 	assert.deepEqual(navigationTarget("about:blank"), { url: "about:blank", origin: "about:blank" });
@@ -436,18 +569,23 @@ test("private screenshot failures suppress host paths and enforce the read bound
 	}
 });
 
-test("extension source exposes no upload/eval/profile mutation or caller-selected host path/surface/workspace parameters", async () => {
+test("extension source exposes only navigation and atomic accessibility snapshots", async () => {
 	const source = await readFile(new URL("./index.ts", import.meta.url), "utf8");
 	const imageSource = await readFile(new URL("./private-image.ts", import.meta.url), "utf8");
 	for (const forbidden of [
 		'"upload"', '"eval"', '"addscript"', '"addinitscript"', '"profile_add"', '"profile_delete"',
 		'"fill"', '"select"', '"keydown"', '"keyup"', '"tab_list"', '"tab_new"', '"tab_switch"', '"tab_close"',
-		'"state_save"', '"state_load"', "output_path: Type", "allowed_root: Type", "workspace: Type", "surface: Type", "recoverSurface", "setActiveSurface",
+		'"state_save"', '"state_load"', '"browser_interact"', '"browser_download"', '"screenshot"', '"console"', '"errors"',
+		'"highlight"', '"reload"', "output_path: Type", "allowed_root: Type", "workspace: Type", "surface: Type", "recoverSurface", "setActiveSurface",
 	]) {
 		assert.equal(source.includes(forbidden), false, `unexpected exposed capability: ${forbidden}`);
 	}
 	assert.doesNotMatch(source, /action:\s*StringEnum\(\[[^\]]*"type"/);
 	assert.match(source, /session_shutdown[\s\S]{0,200}client\.closeAll\(\)/);
-	assert.match(source, /mkdtemp\(join\(tmpdir\(\), "pi-cmux-browser-"\)\)/);
+	assert.match(source, /pi\.exec\([\s\S]{0,100}process\.execPath/);
+	assert.match(source, /spawn\(\"cmux\"/);
+	assert.match(source, /MAX_CMUX_OUTPUT_BYTES = 10 \* 1024 \* 1024/);
+	assert.match(source, /child\.kill\(\"SIGKILL\"\)/);
+	assert.match(source, /captureApprovedSnapshot/);
 	assert.match(imageSource, /O_NOFOLLOW/);
 });

--- a/cmux-browser/client.test.ts
+++ b/cmux-browser/client.test.ts
@@ -79,6 +79,56 @@ test("upload sends bounded page-eval chunks, dispatches file events, and never e
 	assert.equal(JSON.stringify(result).includes(secretFixture), false);
 });
 
+test("failed upload chunks never expose source content or base64 while preserving safe diagnostics", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
+	const path = join(directory, "UPLOAD_SECRET_SENTINEL_53.txt");
+	await writeFile(path, "UPLOAD_SECRET_SENTINEL_53");
+	const { exec } = recorder([
+		{},
+		{ code: 23, stderr: "cmux eval rejected script globalThis.__piCmuxUploadBase64 += \\\"VVBMT0FEX1NFQ1JFVF9TRU5USU5FTF81Mw==\\\"" },
+		{},
+	]);
+	const client = new CmuxBrowserClient(exec, "surface-uuid");
+	await assert.rejects(
+		() => client.upload(undefined, "#upload", path, directory),
+		(error: Error) => {
+			assert.match(error.message, /cmux browser <surface> eval failed \(exit 23\)/);
+			assert.match(error.message, /cmux eval rejected script/);
+			assert.equal(error.message.includes("UPLOAD_SECRET_SENTINEL_53"), false);
+			assert.equal(error.message.includes("VVBMT0FEX1NFQ1JFVF9TRU5USU5FTF81Mw=="), false);
+			return true;
+		},
+	);
+});
+
+test("sensitive argv is absent from failures and successful command metadata", async () => {
+	const cases = [
+		["eval", "--script", "EVAL_SECRET_53"],
+		["addscript", "--script", "SCRIPT_SECRET_53"],
+		["addinitscript", "--script", "INIT_SECRET_53"],
+		["cookies", "set", "--name", "session", "--value", "COOKIE_SECRET_53"],
+		["cookies", "set", "--name", "structural-value", "--value", "open"],
+		["storage", "local", "set", "auth", "STORAGE_SECRET_53"],
+		["state", "load", "/tmp/STATE_SECRET_53.json"],
+	];
+	for (const args of cases) {
+		const secret = args.at(-1)!;
+		const failed = recorder([{ code: 9, stderr: `safe diagnostic: rejected ${secret}` }]);
+		const client = new CmuxBrowserClient(failed.exec, "surface-uuid");
+		await assert.rejects(() => client.browser(undefined, args), (error: Error) => {
+			assert.match(error.message, /safe diagnostic: rejected \[REDACTED\]/);
+			assert.match(error.message, /exit 9/);
+			assert.equal(error.message.includes(secret), false);
+			return true;
+		});
+
+		const succeeded = recorder([{ stdout: JSON.stringify({ diagnostic: secret }) }]);
+		const result = await new CmuxBrowserClient(succeeded.exec, "surface-uuid").browser(undefined, args);
+		assert.equal(JSON.stringify(result).includes(secret), false);
+		assert.equal(result.stdout.includes("[REDACTED]"), true);
+	}
+});
+
 test("upload rejects directories and oversized files before browser execution", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
 	const { calls, exec } = recorder();

--- a/cmux-browser/client.test.ts
+++ b/cmux-browser/client.test.ts
@@ -77,6 +77,12 @@ test("upload sends bounded page-eval chunks, dispatches file events, and never e
 	assert.ok(scripts.some((script) => script.includes("dispatchEvent(new Event('change'")));
 	assert.ok(scripts.some((script) => script.includes("delete globalThis.__piCmuxUploadBase64")));
 	assert.equal(JSON.stringify(result).includes(secretFixture), false);
+	assert.equal(JSON.stringify(result).includes(path), false);
+	assert.equal(JSON.stringify(result).includes("hello.txt"), false);
+	assert.deepEqual(Object.keys(result).sort(), ["args", "json", "stderr", "stdout", "surface"].sort());
+	assert.deepEqual(result.args, ["browser", "<surface>", "upload"]);
+	assert.deepEqual(result.json, { ok: true, uploaded: true });
+	assert.equal(result.stdout, JSON.stringify({ ok: true, uploaded: true }));
 });
 
 test("failed upload chunks never expose source content or base64 while preserving safe diagnostics", async () => {
@@ -93,7 +99,8 @@ test("failed upload chunks never expose source content or base64 while preservin
 		() => client.upload(undefined, "#upload", path, directory),
 		(error: Error) => {
 			assert.match(error.message, /cmux browser <surface> eval failed \(exit 23\)/);
-			assert.match(error.message, /cmux eval rejected script/);
+			assert.match(error.message, /diagnostics were suppressed/);
+			assert.equal(error.message.includes("cmux eval rejected script"), false);
 			assert.equal(error.message.includes("UPLOAD_SECRET_SENTINEL_53"), false);
 			assert.equal(error.message.includes("VVBMT0FEX1NFQ1JFVF9TRU5USU5FTF81Mw=="), false);
 			return true;
@@ -116,7 +123,8 @@ test("sensitive argv is absent from failures and successful command metadata", a
 		const failed = recorder([{ code: 9, stderr: `safe diagnostic: rejected ${secret}` }]);
 		const client = new CmuxBrowserClient(failed.exec, "surface-uuid");
 		await assert.rejects(() => client.browser(undefined, args), (error: Error) => {
-			assert.match(error.message, /safe diagnostic: rejected \[REDACTED\]/);
+			assert.match(error.message, /diagnostics were suppressed/);
+			assert.equal(error.message.includes("safe diagnostic"), false);
 			assert.match(error.message, /exit 9/);
 			assert.equal(error.message.includes(secret), false);
 			return true;
@@ -127,6 +135,20 @@ test("sensitive argv is absent from failures and successful command metadata", a
 		assert.equal(JSON.stringify(result).includes(secret), false);
 		assert.equal(result.stdout.includes("[REDACTED]"), true);
 	}
+});
+
+test("sensitive failures suppress transformed or escaped raw diagnostics by construction", async () => {
+	const transformed = "U\\u0050LOAD_SECRET_ SENTINEL_53 :: VVBMT0FEX1NFQ1JF\\nVF9TRU5USU5FTF81Mw==";
+	const { exec } = recorder([{ code: 17, stderr: transformed }]);
+	const client = new CmuxBrowserClient(exec, "surface-uuid");
+	await assert.rejects(() => client.browser(undefined, ["eval", "--script", "UPLOAD_SECRET_SENTINEL_53"]), (error: Error) => {
+		assert.match(error.message, /browser <surface> eval failed \(exit 17\)/);
+		assert.match(error.message, /diagnostics were suppressed/);
+		for (const fragment of ["U\\u0050LOAD", "SENTINEL_53", "VVBMT0FEX1NFQ1JF", "VF9TRU5USU5FTF81Mw=="]) {
+			assert.equal(error.message.includes(fragment), false);
+		}
+		return true;
+	});
 });
 
 test("upload rejects directories and oversized files before browser execution", async () => {

--- a/cmux-browser/client.test.ts
+++ b/cmux-browser/client.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { access, link, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { CmuxBrowserClient, type ExecCmux } from "./client.ts";
+import { inspectionArguments, navigationTarget, snapshotRef, toolResult } from "./policy.ts";
+import { readPrivateImage } from "./private-image.ts";
+
+const SURFACE_A = "123e4567-e89b-42d3-a456-426614174000";
+const SURFACE_B = "123e4567-e89b-42d3-a456-426614174001";
 
 function recorder(outputs: Array<{ stdout?: string; stderr?: string; code?: number }> = []) {
 	const calls: string[][] = [];
@@ -15,146 +20,433 @@ function recorder(outputs: Array<{ stdout?: string; stderr?: string; code?: numb
 	return { calls, exec };
 }
 
-test("open targets the caller workspace implicitly and never steals focus", async () => {
-	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface: { surface_id: "A-SURFACE-UUID" } }) }]);
+test("open accepts only a documented top-level UUID, stays backgrounded, and retains no URL", async () => {
+	const secretUrl = "https://example.com/path?ordinary=TAB_SECRET_%31%32%33%34%35%36";
+	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A, url: secretUrl }) }]);
 	const client = new CmuxBrowserClient(exec);
-	const result = await client.open("https://example.com", undefined);
-	assert.equal(result.surface, "A-SURFACE-UUID");
-	assert.equal(client.getActiveSurface(), "A-SURFACE-UUID");
+	const result = await client.open(secretUrl);
+	assert.equal(result.surface, SURFACE_A);
+	assert.equal(client.getActiveSurface(), SURFACE_A);
+	assert.equal(client.getOwnedSurfaceCount(), 1);
 	assert.deepEqual(calls[0], [
-		"--json", "--id-format", "uuids", "browser", "open", "https://example.com", "--focus", "false",
+		"--json", "--id-format", "uuids", "browser", "open", secretUrl, "--focus", "false",
 	]);
-	assert.equal(calls[0]?.includes("--workspace"), false);
+	assert.deepEqual(result.command, ["browser", "open"]);
+	assert.deepEqual(result.json, { ok: true, opened: true });
+	assert.equal(result.exposure, "synthetic");
+	assert.equal(JSON.stringify(result).includes(secretUrl), false);
 });
 
-test("open recovers a UUID from cmux's nested surface payload", async () => {
-	const { exec } = recorder([{ stdout: JSON.stringify({ surface: { id: "nested-surface-uuid" } }) }]);
-	const client = new CmuxBrowserClient(exec);
-	assert.equal((await client.open("about:blank", undefined)).surface, "nested-surface-uuid");
-});
-
-test("explicit workspace remains backgrounded", async () => {
-	const { calls, exec } = recorder();
-	const client = new CmuxBrowserClient(exec);
-	await client.open("about:blank", "workspace:7");
-	assert.deepEqual(calls[0]?.slice(-4), ["--focus", "false", "--workspace", "workspace:7"]);
-});
-
-test("later browser operations reuse the persisted surface without a shell", async () => {
-	const { calls, exec } = recorder();
-	const client = new CmuxBrowserClient(exec, "surface-uuid");
-	await client.browser(undefined, ["snapshot", "--interactive"]);
-	assert.deepEqual(calls[0], [
-		"--json", "--id-format", "uuids", "browser", "surface-uuid", "snapshot", "--interactive",
-	]);
-});
-
-test("a missing surface produces an actionable recovery error", async () => {
-	const { exec } = recorder();
-	const client = new CmuxBrowserClient(exec);
-	await assert.rejects(() => client.browser(undefined, ["get", "url"]), /action=open first/);
-});
-
-test("cmux socket failures are translated into lifecycle recovery guidance", async () => {
-	const { exec } = recorder([{ code: 1, stderr: "Error: Failed to write to socket (Broken pipe, errno 32)" }]);
-	const client = new CmuxBrowserClient(exec);
-	await assert.rejects(() => client.open("https://example.com", undefined), /cmux ping/);
-});
-
-test("upload sends bounded page-eval chunks, dispatches file events, and never emits file contents", async () => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
-	const path = join(directory, "hello.txt");
-	const secretFixture = "synthetic-upload-fixture-not-private";
-	await writeFile(path, secretFixture);
-	const { calls, exec } = recorder();
-	const client = new CmuxBrowserClient(exec, "surface-uuid");
-	const result = await client.upload(undefined, "#upload", path, directory);
-	assert.equal(result.surface, "surface-uuid");
-	assert.ok(calls.length >= 3);
-	assert.ok(calls.every((call) => call[0] === "--json" && call.includes("eval")));
-	const scripts = calls.map((call) => call[call.indexOf("--script") + 1] ?? "");
-	assert.ok(scripts.some((script) => script.includes("new DataTransfer")));
-	assert.ok(scripts.some((script) => script.includes("dispatchEvent(new Event('change'")));
-	assert.ok(scripts.some((script) => script.includes("delete globalThis.__piCmuxUploadBase64")));
-	assert.equal(JSON.stringify(result).includes(secretFixture), false);
-	assert.equal(JSON.stringify(result).includes(path), false);
-	assert.equal(JSON.stringify(result).includes("hello.txt"), false);
-	assert.deepEqual(Object.keys(result).sort(), ["args", "json", "stderr", "stdout", "surface"].sort());
-	assert.deepEqual(result.args, ["browser", "<surface>", "upload"]);
-	assert.deepEqual(result.json, { ok: true, uploaded: true });
-	assert.equal(result.stdout, JSON.stringify({ ok: true, uploaded: true }));
-});
-
-test("failed upload chunks never expose source content or base64 while preserving safe diagnostics", async () => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
-	const path = join(directory, "UPLOAD_SECRET_SENTINEL_53.txt");
-	await writeFile(path, "UPLOAD_SECRET_SENTINEL_53");
-	const { exec } = recorder([
-		{},
-		{ code: 23, stderr: "cmux eval rejected script globalThis.__piCmuxUploadBase64 += \\\"VVBMT0FEX1NFQ1JFVF9TRU5USU5FTF81Mw==\\\"" },
-		{},
-	]);
-	const client = new CmuxBrowserClient(exec, "surface-uuid");
-	await assert.rejects(
-		() => client.upload(undefined, "#upload", path, directory),
-		(error: Error) => {
-			assert.match(error.message, /cmux browser <surface> eval failed \(exit 23\)/);
-			assert.match(error.message, /diagnostics were suppressed/);
-			assert.equal(error.message.includes("cmux eval rejected script"), false);
-			assert.equal(error.message.includes("UPLOAD_SECRET_SENTINEL_53"), false);
-			assert.equal(error.message.includes("VVBMT0FEX1NFQ1JFVF9TRU5USU5FTF81Mw=="), false);
-			return true;
-		},
-	);
-});
-
-test("sensitive argv is absent from failures and successful command metadata", async () => {
-	const cases = [
-		["eval", "--script", "EVAL_SECRET_53"],
-		["addscript", "--script", "SCRIPT_SECRET_53"],
-		["addinitscript", "--script", "INIT_SECRET_53"],
-		["cookies", "set", "--name", "session", "--value", "COOKIE_SECRET_53"],
-		["cookies", "set", "--name", "structural-value", "--value", "open"],
-		["storage", "local", "set", "auth", "STORAGE_SECRET_53"],
-		["state", "load", "/tmp/STATE_SECRET_53.json"],
-	];
-	for (const args of cases) {
-		const secret = args.at(-1)!;
-		const failed = recorder([{ code: 9, stderr: `safe diagnostic: rejected ${secret}` }]);
-		const client = new CmuxBrowserClient(failed.exec, "surface-uuid");
-		await assert.rejects(() => client.browser(undefined, args), (error: Error) => {
-			assert.match(error.message, /diagnostics were suppressed/);
-			assert.equal(error.message.includes("safe diagnostic"), false);
-			assert.match(error.message, /exit 9/);
-			assert.equal(error.message.includes(secret), false);
-			return true;
-		});
-
-		const succeeded = recorder([{ stdout: JSON.stringify({ diagnostic: secret }) }]);
-		const result = await new CmuxBrowserClient(succeeded.exec, "surface-uuid").browser(undefined, args);
-		assert.equal(JSON.stringify(result).includes(secret), false);
-		assert.equal(result.stdout.includes("[REDACTED]"), true);
+test("nested or invalid attacker-controlled surface fields cannot poison the active handle", async () => {
+	for (const payload of [
+		{ surface: { surface_id: SURFACE_A } },
+		{ result: { surface_id: SURFACE_A } },
+		{ surface_id: "surface:1" },
+		{ surface_id: "not-a-uuid" },
+	]) {
+		const { exec } = recorder([{ stdout: JSON.stringify(payload) }]);
+		const client = new CmuxBrowserClient(exec);
+		await assert.rejects(() => client.open("about:blank"), /no valid top-level surface_id UUID/);
+		assert.equal(client.getActiveSurface(), undefined);
+		assert.equal(client.getOwnedSurfaceCount(), 0);
 	}
 });
 
-test("sensitive failures suppress transformed or escaped raw diagnostics by construction", async () => {
-	const transformed = "U\\u0050LOAD_SECRET_ SENTINEL_53 :: VVBMT0FEX1NFQ1JF\\nVF9TRU5USU5FTF81Mw==";
-	const { exec } = recorder([{ code: 17, stderr: transformed }]);
-	const client = new CmuxBrowserClient(exec, "surface-uuid");
-	await assert.rejects(() => client.browser(undefined, ["eval", "--script", "UPLOAD_SECRET_SENTINEL_53"]), (error: Error) => {
-		assert.match(error.message, /browser <surface> eval failed \(exit 17\)/);
-		assert.match(error.message, /diagnostics were suppressed/);
-		for (const fragment of ["U\\u0050LOAD", "SENTINEL_53", "VVBMT0FEX1NFQ1JF", "VF9TRU5USU5FTF81Mw=="]) {
+test("one session cannot target arbitrary surfaces or open a second inaccessible surface", async () => {
+	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }]);
+	const client = new CmuxBrowserClient(exec);
+	await assert.rejects(() => client.browser(["snapshot"]), /action=open first/);
+	await client.open("about:blank");
+	await assert.rejects(() => client.open("about:blank"), /already active/);
+	await client.browser(["snapshot"]);
+	assert.equal(calls[1]?.includes(SURFACE_A), true);
+	assert.equal(calls.flat().includes(SURFACE_B), false);
+});
+
+test("failures expose fixed metadata only, including transformed diagnostics", async () => {
+	const secret = "PASSWORD_%31%32%33%34%35%36";
+	const { exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: JSON.stringify({ snapshot: '- button "Continue" [ref=e1]' }) },
+		{ code: 17, stderr: `P\\u0041SSWORD transformed ${secret}\n${"x".repeat(80_000)}` },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+	await assert.rejects(() => client.browser(["click", "e1"]), (error: Error) => {
+		assert.equal(error.message, "cmux browser <owned-surface> click failed (exit 17). Raw diagnostics were suppressed. If cmux may be unavailable, confirm Pi is running inside a live cmux workspace and run `cmux ping`.");
+		for (const fragment of [secret, "P\\u0041SSWORD", "transformed", "xxxxx"]) {
 			assert.equal(error.message.includes(fragment), false);
 		}
 		return true;
 	});
 });
 
-test("upload rejects directories and oversized files before browser execution", async () => {
-	const directory = await mkdtemp(join(tmpdir(), "pi-cmux-browser-test-"));
-	const { calls, exec } = recorder();
-	const client = new CmuxBrowserClient(exec, "surface-uuid");
-	await assert.rejects(() => client.upload(undefined, "#upload", directory, directory), /not a regular file/);
-	assert.equal(calls.length, 0);
+test("socket failures retain lifecycle guidance but no raw output", async () => {
+	const { exec } = recorder([{ code: 1, stderr: "Error: Failed to write to socket (Broken pipe) SECRET" }]);
+	const client = new CmuxBrowserClient(exec);
+	await assert.rejects(() => client.open("https://example.com"), (error: Error) => {
+		assert.match(error.message, /cmux ping/);
+		assert.equal(error.message.includes("SECRET"), false);
+		return true;
+	});
+});
+
+test("subprocess rejections expose fixed metadata without argv or exception diagnostics", async () => {
+	const secret = "REJECTED_EXEC_SECRET_53";
+	const exec: ExecCmux = async () => {
+		throw new Error(`spawn failed with argv https://example.com/${secret}`);
+	};
+	const client = new CmuxBrowserClient(exec);
+	await assert.rejects(() => client.open(`https://example.com/${secret}`), (error: Error) => {
+		assert.match(error.message, /cmux browser open could not be invoked/);
+		assert.equal(error.message.includes(secret), false);
+		assert.equal(error.message.includes("https://"), false);
+		return true;
+	});
+});
+
+test("value-bearing browser capabilities are rejected before subprocess invocation", async () => {
+	const secrets = ["PASSWORD_123456", "STATE_SECRET_53", "TAB_SECRET_53", "UPLOAD_SECRET_SENTINEL_53"];
+	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	for (const args of [
+		["fill", "e1", secrets[0]],
+		["state", "load", secrets[1]],
+		["tab", "new", `https://example.com/${secrets[2]}`],
+		["eval", secrets[3]],
+	]) {
+		await assert.rejects(() => client.browser(args), /Unsupported browser operation/);
+	}
+	assert.equal(calls.length, 1);
+	assert.equal(secrets.some((secret) => JSON.stringify(calls).includes(secret)), false);
+});
+
+test("allowed operations reject undocumented argument shapes before subprocess invocation", async () => {
+	const secret = "ARGUMENT_SHAPE_SECRET_53";
+	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	for (const args of [
+		["goto", `https://example.com/?token=${secret}`],
+		["goto", `https://example.com/#accessToken=${secret}`],
+		["reload", secret],
+		["snapshot", "--selector", secret],
+		["snapshot", "--compact", "--compact"],
+		["snapshot", "--max-depth", "0"],
+		["snapshot", "--max-depth", "21"],
+		["get", "attr", "--selector", "e1", "--attr", "value"],
+		["get", "text", "--selector", "e0"],
+		["console", "list", secret],
+		["errors", "list", "extra"],
+		["press", "--key", secret],
+		["scroll", "--dx", "10001"],
+		["scroll", "--dy", "NaN"],
+		["wait", "--load-state", "networkidle", "--timeout-ms", "1"],
+		["wait", "--load-state", "complete", "--timeout-ms", "0"],
+		["download", "wait", "--timeout-ms", "120001"],
+		["download", "wait", "--timeout-ms", "1", "--out", secret],
+		["screenshot", "--out", "/private/path.png", secret],
+	]) {
+		await assert.rejects(
+			() => client.browser(args),
+			(error: Error) => /fixed documented command shapes/.test(error.message) && !error.message.includes(secret),
+		);
+	}
+	assert.equal(calls.length, 1);
+	assert.equal(JSON.stringify(calls).includes(secret), false);
+});
+
+test("open rejects unsafe navigation before subprocess invocation", async () => {
+	const secret = "NAVIGATION_SECRET_53";
+	for (const url of [
+		`https://user:${secret}@example.com/`,
+		`https://example.com/?apiKey=${secret}`,
+		`https://example.com/#/callback?refreshToken=${secret}`,
+		"https://example.com/#bad%ZZ",
+		"file:///private/secret",
+	]) {
+		const { calls, exec } = recorder();
+		const client = new CmuxBrowserClient(exec);
+		await assert.rejects(
+			() => client.open(url),
+			(error: Error) => /fixed documented command shapes/.test(error.message) && !error.message.includes(secret),
+		);
+		assert.equal(calls.length, 0);
+	}
+});
+
+test("explicit read capture bounds stdout, suppresses successful stderr, and does not parse truncated JSON", async () => {
+	const hugeSecret = `start-${"x".repeat(80_000)}-END_SECRET`;
+	const { exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: hugeSecret, stderr: "e".repeat(80_000) },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	const result = await client.browser(["snapshot"], undefined, 20_000, { capture: true });
+	assert.ok(Buffer.byteLength(result.stdout) < 52 * 1024);
+	assert.equal(result.stderr, "");
+	assert.equal(result.stdout.includes("END_SECRET"), false);
+	assert.equal(result.json, undefined);
+	assert.equal(result.exposure, "captured");
+});
+
+test("close is terminal, cannot resurrect the old handle, and shutdown closes all owned surfaces", async () => {
+	const { calls, exec } = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	const closed = await client.closeActive();
+	assert.equal(closed.surface, undefined);
+	assert.equal(client.getActiveSurface(), undefined);
+	assert.equal(client.getOwnedSurfaceCount(), 0);
+	await assert.rejects(() => client.browser(["snapshot"]), /action=open first/);
+	assert.deepEqual(calls[1]?.slice(3), ["close-surface", "--surface", SURFACE_A]);
+
+	const second = recorder([{ stdout: JSON.stringify({ surface_id: SURFACE_B }) }]);
+	const shutdownClient = new CmuxBrowserClient(second.exec);
+	await shutdownClient.open("about:blank");
+	await shutdownClient.closeAll();
+	assert.equal(shutdownClient.getOwnedSurfaceCount(), 0);
+	assert.deepEqual(second.calls[1]?.slice(3), ["close-surface", "--surface", SURFACE_B]);
+});
+
+test("a failed close still relinquishes the stale owned handle", async () => {
+	const { exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ code: 1, stderr: "private close diagnostic" },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	await assert.rejects(() => client.closeActive(), /Raw diagnostics were suppressed/);
+	assert.equal(client.getActiveSurface(), undefined);
+	assert.equal(client.getOwnedSurfaceCount(), 0);
+	await assert.rejects(() => client.browser(["snapshot"]), /action=open first/);
+});
+
+test("current origin keeps URL details internal and returns only the parsed origin", async () => {
+	const full = "https://example.com/private/path?ordinary=VALUE_SECRET_53";
+	const { exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: JSON.stringify({ url: full }) },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	assert.equal(await client.currentOrigin(), "https://example.com");
+});
+
+test("current origin refuses non-contract output without reflecting it into diagnostics", async () => {
+	const secret = "ORIGIN_OUTPUT_SECRET_53";
+	for (const stdout of [JSON.stringify({ value: secret }), JSON.stringify({ result: secret }), JSON.stringify(secret), secret]) {
+		const { exec } = recorder([
+			{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+			{ stdout },
+		]);
+		const client = new CmuxBrowserClient(exec);
+		await client.open("about:blank");
+		await assert.rejects(
+			() => client.currentOrigin(),
+			(error: Error) => !error.message.includes(secret) && /operation refused/.test(error.message),
+		);
+	}
+});
+
+test("synthetic tool results persist only allowlisted metadata, never raw output or values", () => {
+	const secret = "PASSWORD_123456";
+	const result = toolResult("click", {
+		command: ["browser", "<owned-surface>", "click"],
+		stdout: `raw-${secret}`,
+		stderr: `stderr-${secret}`,
+		json: { ok: true, interacted: true, diagnostic: `transformed-${secret}` },
+		surface: SURFACE_A,
+		exposure: "synthetic",
+	});
+	assert.deepEqual(Object.keys(result.details).sort(), ["action", "command", "output", "surface"].sort());
+	assert.deepEqual(result.details.command, ["browser", "<owned-surface>", "click"]);
+	assert.deepEqual(result.content, [{ type: "text", text: JSON.stringify({ ok: true, interacted: true }) }]);
+	assert.equal(JSON.stringify(result).includes(secret), false);
+	assert.equal(JSON.stringify(result).includes("transformed"), false);
+	assert.equal(JSON.stringify(result).includes(SURFACE_A), false);
+	assert.equal(result.details.surface, "owned");
+	assert.equal("json" in result.details, false);
+});
+
+test("snapshot refs reject arbitrary selectors, attacker-controlled suffixes, and refs absent from the latest snapshot", async () => {
+	for (const value of [undefined, "", "e0", "E1", "e1,body", "#password", "[name=token]", "e2 --script SECRET"]) {
+		assert.throws(() => snapshotRef(value, "click"), /fresh snapshot ref/);
+	}
+	assert.equal(snapshotRef("e3", "click"), "e3");
+	assert.equal(snapshotRef("e999", "click"), "e999");
+
+	const { calls, exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]\n- text "e9 is untrusted page text"' }) },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
+	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+	await assert.rejects(() => client.browser(["click", "e9"]), /latest successful snapshot/);
+	assert.equal(calls.some((args) => args.includes("click")), false);
+	await client.browser(["click", "e2"]);
+	await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
+	assert.equal(calls.filter((args) => args.includes("click")).length, 1);
+});
+
+test("every navigation or interaction invalidator clears the latest snapshot refs", async () => {
+	const invalidators = [
+		["goto", "https://example.com/next"],
+		["reload"],
+		["wait", "--load-state", "complete", "--timeout-ms", "1"],
+		["click", "e2"],
+		["dblclick", "e2"],
+		["hover", "e2"],
+		["focus", "e2"],
+		["press", "--key", "Tab"],
+		["check", "e2"],
+		["uncheck", "e2"],
+		["scroll", "--dy", "1"],
+		["scroll-into-view", "e2"],
+	];
+	const outputs = [{ stdout: JSON.stringify({ surface_id: SURFACE_A }) }];
+	for (let index = 0; index < invalidators.length; index += 1) {
+		outputs.push({ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]' }) });
+		outputs.push({ stdout: JSON.stringify({ ok: true }) });
+	}
+	const { calls, exec } = recorder(outputs);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	for (const args of invalidators) {
+		await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+		await client.browser(args);
+		const callsBeforeStaleAttempt = calls.length;
+		await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
+		assert.equal(calls.length, callsBeforeStaleAttempt);
+	}
+});
+
+test("a failed replacement snapshot leaves no previously recorded refs usable", async () => {
+	const { calls, exec } = recorder([
+		{ stdout: JSON.stringify({ surface_id: SURFACE_A }) },
+		{ stdout: JSON.stringify({ snapshot: '- button "Current" [ref=e2]' }) },
+		{ code: 1, stderr: "snapshot backend secret" },
+	]);
+	const client = new CmuxBrowserClient(exec);
+	await client.open("about:blank");
+	await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+	await assert.rejects(() => client.browser(["snapshot"], undefined, 20_000, { capture: true }), /failed \(exit 1\)/);
+	await assert.rejects(() => client.browser(["click", "e2"]), /latest successful snapshot/);
+	assert.equal(calls.some((args) => args.includes("click")), false);
+});
+
+test("navigation policy rejects credential-bearing URLs and unsafe schemes", () => {
+	for (const url of [
+		"https://example.com/?token=SECRET",
+		"https://example.com/?apiKey=SECRET",
+		"https://example.com/#accessToken=SECRET",
+		"https://example.com/#/callback?clientSecret=SECRET",
+		"https://example.com/#bad%ZZ",
+		"https://user:password@example.com/",
+		"file:///etc/passwd",
+		"javascript:alert(1)",
+		"about:config",
+	]) {
+		assert.throws(() => navigationTarget(url));
+	}
+	assert.deepEqual(navigationTarget("https://example.com/path?q=ordinary"), {
+		url: "https://example.com/path?q=ordinary",
+		origin: "https://example.com",
+	});
+	assert.deepEqual(navigationTarget("about:blank"), { url: "about:blank", origin: "about:blank" });
+});
+
+test("get actions use cmux 0.64.13's exact selector and attr argv", () => {
+	assert.deepEqual(inspectionArguments("text", "e3"), ["get", "text", "--selector", "e3"]);
+	assert.deepEqual(inspectionArguments("attr", "e4", "role"), ["get", "attr", "--selector", "e4", "--attr", "role"]);
+	assert.deepEqual(inspectionArguments("count", "e5"), ["get", "count", "--selector", "e5"]);
+	assert.deepEqual(inspectionArguments("box", "e6"), ["get", "box", "--selector", "e6"]);
+	assert.throws(() => inspectionArguments("attr", "e4"), /attribute is required/);
+	assert.throws(() => inspectionArguments("attr", "e4", "value"), /non-value metadata attributes/);
+});
+
+test("private screenshot reads normalize permissions and remove the file", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-cmux-browser-image-test-"));
+	const path = join(root, "image.png");
+	try {
+		await writeFile(path, "image-bytes", { mode: 0o666 });
+		const data = await readPrivateImage(path, 1024);
+		assert.equal(Buffer.from(data, "base64").toString("utf8"), "image-bytes");
+		await assert.rejects(() => access(path));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("private screenshot reads refuse symlink substitution without touching the target", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-cmux-browser-image-test-"));
+	const external = join(root, "external.png");
+	const link = join(root, "image.png");
+	try {
+		await writeFile(external, "outside-secret", { mode: 0o600 });
+		await symlink(external, link);
+		await assert.rejects(() => readPrivateImage(link, 1024));
+		assert.equal(await readFile(external, "utf8"), "outside-secret");
+		assert.equal((await stat(external)).isFile(), true);
+		await assert.rejects(() => access(link));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("private screenshot reads refuse hard-linked files before changing the target", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-cmux-browser-image-test-"));
+	const external = join(root, "external.png");
+	const candidate = join(root, "image.png");
+	try {
+		await writeFile(external, "outside-secret", { mode: 0o644 });
+		const originalMode = (await stat(external)).mode & 0o777;
+		await link(external, candidate);
+		await assert.rejects(() => readPrivateImage(candidate, 1024), /private standalone file/);
+		assert.equal(await readFile(external, "utf8"), "outside-secret");
+		assert.equal((await stat(external)).mode & 0o777, originalMode);
+		await assert.rejects(() => access(candidate));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("private screenshot failures suppress host paths and enforce the read bound", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-cmux-browser-image-test-"));
+	const missing = join(root, "sensitive-basename.png");
+	const oversized = join(root, "oversized.png");
+	try {
+		await assert.rejects(
+			() => readPrivateImage(missing, 8),
+			(error: Error) => error.message === "cmux screenshot output could not be read securely."
+				&& !error.message.includes(root)
+				&& !error.message.includes("sensitive-basename"),
+		);
+		await writeFile(oversized, Buffer.alloc(9), { mode: 0o600 });
+		await assert.rejects(() => readPrivateImage(oversized, 8), /exceeded the 8 byte safety limit/);
+		await assert.rejects(() => access(oversized));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("extension source exposes no upload/eval/profile mutation or caller-selected host path/surface/workspace parameters", async () => {
+	const source = await readFile(new URL("./index.ts", import.meta.url), "utf8");
+	const imageSource = await readFile(new URL("./private-image.ts", import.meta.url), "utf8");
+	for (const forbidden of [
+		'"upload"', '"eval"', '"addscript"', '"addinitscript"', '"profile_add"', '"profile_delete"',
+		'"fill"', '"select"', '"keydown"', '"keyup"', '"tab_list"', '"tab_new"', '"tab_switch"', '"tab_close"',
+		'"state_save"', '"state_load"', "output_path: Type", "allowed_root: Type", "workspace: Type", "surface: Type", "recoverSurface", "setActiveSurface",
+	]) {
+		assert.equal(source.includes(forbidden), false, `unexpected exposed capability: ${forbidden}`);
+	}
+	assert.doesNotMatch(source, /action:\s*StringEnum\(\[[^\]]*"type"/);
+	assert.match(source, /session_shutdown[\s\S]{0,200}client\.closeAll\(\)/);
+	assert.match(source, /mkdtemp\(join\(tmpdir\(\), "pi-cmux-browser-"\)\)/);
+	assert.match(imageSource, /O_NOFOLLOW/);
 });

--- a/cmux-browser/client.ts
+++ b/cmux-browser/client.ts
@@ -57,17 +57,65 @@ function parseJson(stdout: string): unknown | undefined {
 	}
 }
 
+const STRUCTURAL_ARGS = new Set([
+	"browser", "open", "open-split", "new", "status", "goto", "navigate", "back", "forward", "reload",
+	"snapshot", "eval", "wait", "click", "dblclick", "hover", "focus", "fill", "type", "press", "key",
+	"keydown", "keyup", "select", "scroll", "scroll-into-view", "screenshot", "get", "is", "find", "frame",
+	"dialog", "download", "profiles", "cookies", "storage", "tab", "console", "errors", "highlight", "state",
+	"addinitscript", "addscript", "addstyle", "viewport", "geolocation", "geo", "offline", "trace", "network",
+	"screencast", "input", "close-surface", "list", "save", "load", "add", "rename", "delete", "clear",
+]);
+
+function safeCommand(args: string[]): string[] {
+	const browserIndex = args.indexOf("browser");
+	if (browserIndex < 0) return args.slice(0, 1).filter((arg) => STRUCTURAL_ARGS.has(arg));
+	const safe = ["browser"];
+	const first = args[browserIndex + 1];
+	if (!first) return safe;
+	if (STRUCTURAL_ARGS.has(first)) return [...safe, first];
+	safe.push("<surface>");
+	const command = args[browserIndex + 2];
+	if (command && STRUCTURAL_ARGS.has(command)) safe.push(command);
+	return safe;
+}
+
+const VALUE_BEARING_COMMANDS = new Set([
+	"open", "goto", "navigate", "eval", "wait", "click", "dblclick", "hover", "focus", "fill", "type",
+	"press", "key", "keydown", "keyup", "select", "scroll", "scroll-into-view", "screenshot", "get", "find",
+	"frame", "dialog", "download", "profiles", "cookies", "storage", "highlight", "state", "addinitscript",
+	"addscript", "addstyle", "geolocation", "geo", "trace", "network", "input",
+]);
+
+function redactArgv(text: string, args: string[]): string {
+	let redacted = text;
+	const sensitive = new Set<string>();
+	const valueCommandIndex = args.findIndex((arg) => VALUE_BEARING_COMMANDS.has(arg));
+	for (const [index, arg] of args.entries()) {
+		if (!arg || arg === "true" || arg === "false") continue;
+		const commandValue = valueCommandIndex >= 0 && index > valueCommandIndex && !arg.startsWith("--");
+		if (!commandValue && (STRUCTURAL_ARGS.has(arg) || arg.startsWith("--"))) continue;
+		sensitive.add(arg);
+		for (const token of arg.match(/[A-Za-z0-9+/]{16,}={0,2}/g) ?? []) sensitive.add(token);
+	}
+	for (const value of [...sensitive].sort((a, b) => b.length - a.length)) {
+		redacted = redacted.split(value).join("[REDACTED]");
+		redacted = redacted.split(JSON.stringify(value).slice(1, -1)).join("[REDACTED]");
+	}
+	return redacted;
+}
+
 function formatFailure(args: string[], result: ExecResult): Error {
-	const detail = (result.stderr || result.stdout || `exit ${result.code}`).trim();
+	const command = safeCommand(args).join(" ") || "command";
+	const detail = redactArgv(result.stderr || result.stdout || `exit ${result.code}`, args).trim();
 	if (/broken pipe|failed to write to socket|connection refused|no such file/i.test(detail)) {
 		return new Error(
-			`cmux browser is unavailable (${detail}). Confirm Pi is running inside a live cmux workspace, run \`cmux ping\`, and retry.`,
+			`cmux browser is unavailable (exit ${result.code}: ${detail}). Confirm Pi is running inside a live cmux workspace, run \`cmux ping\`, and retry.`,
 		);
 	}
 	if (/not[_ -]supported/i.test(detail)) {
-		return new Error(`cmux/WKWebView does not support this operation: ${detail}`);
+		return new Error(`cmux/WKWebView does not support ${command} (exit ${result.code}): ${detail}`);
 	}
-	return new Error(`cmux ${args.join(" ")} failed: ${detail}`);
+	return new Error(`cmux ${command} failed (exit ${result.code}): ${detail}`);
 }
 
 export class CmuxBrowserClient {
@@ -100,10 +148,12 @@ export class CmuxBrowserClient {
 		const fullArgs = ["--json", "--id-format", "uuids", ...args];
 		const result = await this.execCmux(fullArgs, { signal, timeout });
 		if (result.code !== 0) throw formatFailure(args, result);
-		const json = parseJson(result.stdout);
+		const stdout = redactArgv(result.stdout, args);
+		const stderr = redactArgv(result.stderr, args);
+		const json = parseJson(stdout);
 		const surface = findSurface(json);
 		if (surface) this.activeSurface = surface;
-		return { args, stdout: result.stdout, stderr: result.stderr, json, surface: surface ?? this.activeSurface };
+		return { args: safeCommand(args), stdout, stderr, json, surface: surface ?? this.activeSurface };
 	}
 
 	async open(url: string, workspace: string | undefined, signal?: AbortSignal): Promise<BrowserCommandResult> {
@@ -131,12 +181,22 @@ export class CmuxBrowserClient {
 		signal?: AbortSignal,
 	): Promise<BrowserCommandResult> {
 		const absolutePath = resolve(cwd, path.replace(/^@/, ""));
-		const info = await stat(absolutePath);
-		if (!info.isFile()) throw new Error(`Upload path is not a regular file: ${absolutePath}`);
+		let info;
+		try {
+			info = await stat(absolutePath);
+		} catch {
+			throw new Error("Upload file could not be inspected. Confirm that the approved path exists and is readable.");
+		}
+		if (!info.isFile()) throw new Error("Upload path is not a regular file.");
 		if (info.size > MAX_UPLOAD_BYTES) {
 			throw new Error(`Upload is ${info.size} bytes; the safe DOM upload limit is ${MAX_UPLOAD_BYTES} bytes.`);
 		}
-		const data = (await readFile(absolutePath)).toString("base64");
+		let data: string;
+		try {
+			data = (await readFile(absolutePath)).toString("base64");
+		} catch {
+			throw new Error("Upload file could not be read. Confirm permissions and retry.");
+		}
 		const target = this.requireSurface(surface);
 		const evalScript = (script: string) => this.browser(target, ["eval", "--script", script], signal, 30_000);
 		await evalScript("globalThis.__piCmuxUploadBase64 = ''");

--- a/cmux-browser/client.ts
+++ b/cmux-browser/client.ts
@@ -1,3 +1,5 @@
+import { navigationTarget } from "./policy.ts";
+
 export interface ExecResult {
 	stdout: string;
 	stderr: string;
@@ -10,25 +12,67 @@ export type ExecCmux = (
 	options: { signal?: AbortSignal; timeout: number },
 ) => Promise<ExecResult>;
 
-export interface BrowserCommandResult {
+export interface SyntheticBrowserOutput {
+	ok: true;
+	opened?: true;
+	navigated?: true;
+	closed?: true;
+	interacted?: true;
+	download_ready?: true;
+}
+
+export type SyntheticOutcome = "ok" | "opened" | "navigated" | "closed" | "interacted" | "download_ready";
+
+const SYNTHETIC_OUTPUTS: Readonly<Record<SyntheticOutcome, Readonly<SyntheticBrowserOutput>>> = Object.freeze({
+	ok: Object.freeze({ ok: true }),
+	opened: Object.freeze({ ok: true, opened: true }),
+	navigated: Object.freeze({ ok: true, navigated: true }),
+	closed: Object.freeze({ ok: true, closed: true }),
+	interacted: Object.freeze({ ok: true, interacted: true }),
+	download_ready: Object.freeze({ ok: true, download_ready: true }),
+});
+
+interface BrowserCommandResultBase {
 	command: string[];
+	surface?: string;
+}
+
+export interface CapturedBrowserCommandResult extends BrowserCommandResultBase {
+	/** Bounded stdout from an explicitly read-only operation; intentionally model-visible. */
+	exposure: "captured";
 	stdout: string;
 	json?: unknown;
-	surface?: string;
-	/** Captured output is intentionally model-visible; synthetic output is fixed extension metadata. */
-	exposure: "captured" | "synthetic";
+	/** Internally verified snapshot origin; tool rendering never forwards this field. */
+	observedOrigin?: string;
 }
+
+export interface SyntheticBrowserCommandResult extends BrowserCommandResultBase {
+	/** Fixed extension-owned metadata. Raw subprocess stdout/stderr cannot inhabit this variant. */
+	exposure: "synthetic";
+	output: Readonly<SyntheticBrowserOutput>;
+}
+
+export type BrowserCommandResult = CapturedBrowserCommandResult | SyntheticBrowserCommandResult;
 
 export interface RunOptions {
 	/** Retain bounded stdout for explicitly read-only inspection operations. */
 	capture?: boolean;
 	/** Parse exactly the documented top-level browser-open surface_id field. */
 	captureOpenedSurface?: boolean;
-	/** Safe synthetic result used when raw command output is intentionally discarded. */
-	success?: Record<string, boolean | number>;
+	/** Project a raw cmux snapshot response to accessibility text and authoritative refs only. */
+	captureSnapshot?: boolean;
+	/** Require close output to confirm this exact owned top-level surface_id. */
+	confirmClosedSurface?: string;
+	/** Select one fixed extension-owned result when raw command output is discarded. */
+	success?: SyntheticOutcome;
+}
+
+export interface BrowserLifecycleBlock {
+	blocked: boolean;
 }
 
 const MAX_CAPTURE_BYTES = 50 * 1024;
+const MAX_SNAPSHOT_RESPONSE_BYTES = 10 * 1024 * 1024;
 const SURFACE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const BROWSER_COMMANDS = new Set([
@@ -42,8 +86,9 @@ const REF_TARGET_OPERATIONS = new Set([
 const REF_INVALIDATING_OPERATIONS = new Set([
 	"goto", "reload", "wait", "click", "dblclick", "hover", "focus", "press", "check", "uncheck", "scroll", "scroll-into-view",
 ]);
-const SNAPSHOT_REF_MARKER = /\bref=(e[1-9][0-9]*)\b/g;
 const SNAPSHOT_REF_VALUE = /^e[1-9][0-9]*$/;
+const REFERENCED_SNAPSHOT_NAME = /^(\s*-\s+[^\s]+)\s+"[^"]*"(\s+\[ref=e[1-9][0-9]*\].*)$/gm;
+const DOCUMENT_SNAPSHOT_NAME = /^(\s*-\s+document)\s+"[^"]*"\s*$/gm;
 const SAFE_KEY = new Set([
 	"Enter", "Tab", "Escape", "Backspace", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
 	"Home", "End", "PageUp", "PageDown", "Space",
@@ -52,41 +97,16 @@ const SAFE_ATTRIBUTE = new Set([
 	"role", "aria-label", "aria-checked", "aria-disabled", "aria-expanded", "aria-hidden", "aria-selected",
 	"alt", "name", "title", "type",
 ]);
-const SENSITIVE_QUERY_KEY = /(?:^|[_-])(auth|authorization|code|credential|key|password|secret|session|sig|signature|token)(?:$|[_-])/i;
-const SENSITIVE_COMPACT_KEY = /(?:token|secret|password|credential|authorization|session|signature)/i;
-const SENSITIVE_EXACT_KEY = new Set(["apikey", "auth", "code", "key", "sig"]);
-
 function invalidArguments(): never {
 	throw new Error("Invalid browser arguments; only the extension's fixed documented command shapes are allowed.");
 }
 
-function isSensitiveParameterKey(key: string): boolean {
-	const compact = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
-	return SENSITIVE_QUERY_KEY.test(key) || SENSITIVE_COMPACT_KEY.test(compact) || SENSITIVE_EXACT_KEY.has(compact);
-}
-
 function assertSafeNavigationUrl(raw: string | undefined): void {
 	if (!raw) invalidArguments();
-	let url: URL;
 	try {
-		url = new URL(raw);
+		navigationTarget(raw);
 	} catch {
 		invalidArguments();
-	}
-	if (url.protocol === "about:" && url.href === "about:blank") return;
-	if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password) invalidArguments();
-	for (const key of url.searchParams.keys()) if (isSensitiveParameterKey(key)) invalidArguments();
-	if (url.hash) {
-		let fragment: string;
-		try {
-			fragment = decodeURIComponent(url.hash.slice(1));
-		} catch {
-			invalidArguments();
-		}
-		for (const part of fragment.split(/[?&;]/)) {
-			const equals = part.indexOf("=");
-			if (equals >= 0 && isSensitiveParameterKey(part.slice(0, equals).replace(/^.*\//, ""))) invalidArguments();
-		}
 	}
 }
 
@@ -217,14 +237,77 @@ function openedSurface(json: unknown): string | undefined {
 	return typeof value === "string" && SURFACE_UUID.test(value) ? value : undefined;
 }
 
+function confirmsClosedSurface(json: unknown, expected: string): boolean {
+	if (!json || typeof json !== "object" || Array.isArray(json)) return false;
+	return (json as Record<string, unknown>).surface_id === expected;
+}
+
+function projectSnapshot(raw: string): {
+	stdout: string;
+	json: { snapshot: string; refs: string[] };
+	observedOrigin: string;
+} {
+	if (Buffer.byteLength(raw, "utf8") > MAX_SNAPSHOT_RESPONSE_BYTES) {
+		throw new Error("cmux snapshot response exceeded the private processing limit; raw output was suppressed.");
+	}
+	const parsed = parseJson(raw);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("cmux snapshot returned no valid top-level accessibility payload; raw output was suppressed.");
+	}
+	const payload = parsed as Record<string, unknown>;
+	if (typeof payload.snapshot !== "string") {
+		throw new Error("cmux snapshot returned no valid top-level accessibility text; raw output was suppressed.");
+	}
+	if (typeof payload.url !== "string") {
+		throw new Error("cmux snapshot returned no valid top-level URL for origin verification; raw output was suppressed.");
+	}
+	let observedOrigin: string;
+	try {
+		const url = new URL(payload.url);
+		if (url.href === "about:blank") observedOrigin = "about:blank";
+		else if ((url.protocol === "http:" || url.protocol === "https:") && url.origin !== "null") observedOrigin = url.origin;
+		else throw new Error("unsupported snapshot origin");
+	} catch {
+		throw new Error("cmux snapshot returned an unsupported top-level URL; raw output was suppressed.");
+	}
+	// cmux 0.64.13 may use an input's live value as its accessibility name even
+	// when the input declares a misleading explicit ARIA role. Remove every
+	// ref-bearing name (and the document title) rather than trusting page roles.
+	const sanitizedSnapshot = payload.snapshot
+		.replace(REFERENCED_SNAPSHOT_NAME, "$1$2")
+		.replace(DOCUMENT_SNAPSHOT_NAME, "$1");
+	const snapshot = utf8Prefix(sanitizedSnapshot, MAX_CAPTURE_BYTES);
+	const refsObject = payload.refs && typeof payload.refs === "object" && !Array.isArray(payload.refs)
+		? payload.refs as Record<string, unknown>
+		: {};
+	const refs = Object.keys(refsObject).filter((ref) => SNAPSHOT_REF_VALUE.test(ref));
+	return { stdout: snapshot, json: { snapshot, refs }, observedOrigin };
+}
+
 export class CmuxBrowserClient {
 	private activeSurface?: string;
 	private readonly ownedSurfaces = new Set<string>();
 	private readonly freshSnapshotRefs = new Set<string>();
 	private readonly execCmux: ExecCmux;
+	private operationTail: Promise<void> = Promise.resolve();
+	private openLifecycleUncertain: boolean;
+	private readonly lifecycleBlock?: BrowserLifecycleBlock;
 
-	constructor(execCmux: ExecCmux) {
+	constructor(execCmux: ExecCmux, lifecycleBlock?: BrowserLifecycleBlock) {
 		this.execCmux = execCmux;
+		this.lifecycleBlock = lifecycleBlock;
+		this.openLifecycleUncertain = lifecycleBlock?.blocked ?? false;
+	}
+
+	private withExclusiveOperation<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.operationTail.then(operation, operation);
+		this.operationTail = result.then(() => undefined, () => undefined);
+		return result;
+	}
+
+	private blockFutureOpens(): void {
+		this.openLifecycleUncertain = true;
+		if (this.lifecycleBlock) this.lifecycleBlock.blocked = true;
 	}
 
 	getActiveSurface(): string | undefined {
@@ -259,10 +342,13 @@ export class CmuxBrowserClient {
 
 	private recordSnapshotRefs(result: BrowserCommandResult): void {
 		this.freshSnapshotRefs.clear();
+		if (result.exposure !== "captured") return;
 		if (!result.json || typeof result.json !== "object" || Array.isArray(result.json)) return;
-		const snapshot = (result.json as Record<string, unknown>).snapshot;
-		if (typeof snapshot !== "string") return;
-		for (const match of snapshot.matchAll(SNAPSHOT_REF_MARKER)) this.freshSnapshotRefs.add(match[1]!);
+		const refs = (result.json as Record<string, unknown>).refs;
+		if (!Array.isArray(refs)) return;
+		for (const ref of refs) {
+			if (typeof ref === "string" && SNAPSHOT_REF_VALUE.test(ref)) this.freshSnapshotRefs.add(ref);
+		}
 	}
 
 	private async run(args: string[], signal?: AbortSignal, timeout = 20_000, options: RunOptions = {}): Promise<BrowserCommandResult> {
@@ -272,6 +358,7 @@ export class CmuxBrowserClient {
 		} catch {
 			throw lifecycleFailure(args, "could not be invoked");
 		}
+		if (result.killed) throw lifecycleFailure(args, "was interrupted before completion could be confirmed");
 		if (result.code !== 0) throw formatFailure(args, result);
 
 		let surface = this.activeSurface;
@@ -286,34 +373,57 @@ export class CmuxBrowserClient {
 			surface = opened;
 		}
 
+		if (options.confirmClosedSurface) {
+			const parsed = parseJson(utf8Prefix(result.stdout, 8 * 1024));
+			if (!confirmsClosedSurface(parsed, options.confirmClosedSurface)) {
+				throw new Error("cmux close succeeded without confirming the exact owned surface_id; raw output was suppressed.");
+			}
+		}
+
+		if (options.captureSnapshot) {
+			const projected = projectSnapshot(result.stdout);
+			return { command: safeCommand(args), ...projected, surface, exposure: "captured" };
+		}
+
 		if (options.capture) {
 			const stdout = utf8Prefix(result.stdout, MAX_CAPTURE_BYTES);
 			return { command: safeCommand(args), stdout, json: parseJson(stdout), surface, exposure: "captured" };
 		}
 
-		const json = options.success ?? { ok: true };
 		return {
 			command: safeCommand(args),
-			stdout: JSON.stringify(json),
-			json,
+			output: SYNTHETIC_OUTPUTS[options.success ?? "ok"],
 			surface,
 			exposure: "synthetic",
 		};
 	}
 
 	async open(url: string, signal?: AbortSignal): Promise<BrowserCommandResult> {
-		if (this.activeSurface) throw new Error("An extension-owned browser surface is already active; close it before opening another.");
-		assertSafeNavigationUrl(url);
-		this.freshSnapshotRefs.clear();
-		return this.run(
-			["browser", "open", url, "--focus", "false"],
-			signal,
-			30_000,
-			{ captureOpenedSurface: true, success: { ok: true, opened: true } },
-		);
+		return this.withExclusiveOperation(async () => {
+			if (this.openLifecycleUncertain) {
+				throw new Error("Browser open lifecycle is uncertain after an earlier failed or malformed response. Close any unowned native pane manually and restart Pi before opening another.");
+			}
+			if (this.activeSurface) throw new Error("An extension-owned browser surface is already active; close it before opening another.");
+			assertSafeNavigationUrl(url);
+			this.freshSnapshotRefs.clear();
+			try {
+				return await this.run(
+					["browser", "open", url, "--focus", "false"],
+					signal,
+					30_000,
+					{ captureOpenedSurface: true, success: "opened" },
+				);
+			} catch (error) {
+				// cmux may create the pane before an abort, timeout, transport failure,
+				// or malformed response prevents us from learning its UUID. Refuse all
+				// later opens in this instance rather than risk orphaning a second pane.
+				this.blockFutureOpens();
+				throw error;
+			}
+		});
 	}
 
-	async browser(
+	private async browserUnlocked(
 		args: string[],
 		signal?: AbortSignal,
 		timeout = 20_000,
@@ -325,8 +435,14 @@ export class CmuxBrowserClient {
 			throw new Error("Unsupported browser operation; only the extension's fixed capability set is allowed.");
 		}
 		validateBrowserArguments(args);
-		if (options.capture && !CAPTURED_BROWSER_READS.has(operation)) {
+		if ((options.capture || options.captureSnapshot) && !CAPTURED_BROWSER_READS.has(operation)) {
 			throw new Error("Captured output is allowed only for browser snapshot/get/console/errors reads.");
+		}
+		if (operation === "snapshot" && !options.captureSnapshot) {
+			throw new Error("Snapshot output must use the accessibility-only projection.");
+		}
+		if (operation !== "snapshot" && options.captureSnapshot) {
+			throw new Error("The accessibility-only projection is valid only for snapshots.");
 		}
 		const referenced = this.referencedSnapshotRef(args);
 		if (referenced !== undefined && !this.freshSnapshotRefs.has(referenced)) {
@@ -338,56 +454,77 @@ export class CmuxBrowserClient {
 		return result;
 	}
 
+	async browser(
+		args: string[],
+		signal?: AbortSignal,
+		timeout = 20_000,
+		options: RunOptions = {},
+	): Promise<BrowserCommandResult> {
+		return this.withExclusiveOperation(() => this.browserUnlocked(args, signal, timeout, options));
+	}
+
 	async currentOrigin(signal?: AbortSignal): Promise<string> {
-		const result = await this.browser(["get", "url"], signal, 20_000, { capture: true });
-		const parsed = result.json;
-		const raw = parsed && typeof parsed === "object" && !Array.isArray(parsed)
-			? (parsed as Record<string, unknown>).url
-			: undefined;
-		if (typeof raw !== "string") {
-			throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
-		}
-		try {
-			const url = new URL(raw);
-			if (url.href === "about:blank") return "about:blank";
-			if ((url.protocol === "http:" || url.protocol === "https:") && url.origin !== "null") return url.origin;
-			throw new Error("unsupported browser origin");
-		} catch {
-			throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
-		}
+		return this.withExclusiveOperation(async () => {
+			const result = await this.browserUnlocked(["get", "url"], signal, 20_000, { capture: true });
+			if (result.exposure !== "captured") {
+				throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
+			}
+			const parsed = result.json;
+			const raw = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+				? (parsed as Record<string, unknown>).url
+				: undefined;
+			if (typeof raw !== "string") {
+				throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
+			}
+			try {
+				const url = new URL(raw);
+				if (url.href === "about:blank") return "about:blank";
+				if ((url.protocol === "http:" || url.protocol === "https:") && url.origin !== "null") return url.origin;
+				throw new Error("unsupported browser origin");
+			} catch {
+				throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
+			}
+		});
 	}
 
 	async closeActive(signal?: AbortSignal): Promise<BrowserCommandResult> {
-		const target = this.requireOwnedSurface();
-		// Relinquish ownership before the subprocess call so an aborted or failed
-		// close can never resurrect a stale handle in this extension instance.
-		this.ownedSurfaces.delete(target);
-		this.activeSurface = undefined;
-		this.freshSnapshotRefs.clear();
-		const result = await this.run(
-			["close-surface", "--surface", target],
-			signal,
-			20_000,
-			{ success: { ok: true, closed: true } },
-		);
-		return { ...result, surface: undefined };
+		return this.withExclusiveOperation(async () => {
+			const target = this.requireOwnedSurface();
+			// Keep ownership until cmux confirms success. A failed or aborted close
+			// may have left the pane alive, so forgetting it would permit a second open.
+			const result = await this.run(
+				["close-surface", "--surface", target],
+				signal,
+				20_000,
+				{ confirmClosedSurface: target, success: "closed" },
+			);
+			this.ownedSurfaces.delete(target);
+			this.activeSurface = undefined;
+			this.freshSnapshotRefs.clear();
+			return { ...result, surface: undefined };
+		});
 	}
 
-	async closeAll(): Promise<void> {
-		for (const surface of [...this.ownedSurfaces]) {
-			try {
-				await this.run(
-					["close-surface", "--surface", surface],
-					undefined,
-					5_000,
-					{ success: { ok: true, closed: true } },
-				);
-			} catch {
-				// Shutdown cleanup is best-effort and deliberately does not retain raw diagnostics.
+	async closeAll(): Promise<boolean> {
+		return this.withExclusiveOperation(async () => {
+			for (const surface of [...this.ownedSurfaces]) {
+				try {
+					await this.run(
+						["close-surface", "--surface", surface],
+						undefined,
+						5_000,
+						{ confirmClosedSurface: surface, success: "closed" },
+					);
+					this.ownedSurfaces.delete(surface);
+				} catch {
+					// Shutdown cleanup is best-effort and deliberately does not retain raw diagnostics.
+					// Preserve ownership so an explicit retry in this instance cannot open a second pane.
+				}
 			}
-			this.ownedSurfaces.delete(surface);
-		}
-		this.activeSurface = undefined;
-		this.freshSnapshotRefs.clear();
+			if (this.activeSurface && !this.ownedSurfaces.has(this.activeSurface)) this.activeSurface = undefined;
+			if (this.ownedSurfaces.size > 0) this.blockFutureOpens();
+			this.freshSnapshotRefs.clear();
+			return this.ownedSurfaces.size === 0;
+		});
 	}
 }

--- a/cmux-browser/client.ts
+++ b/cmux-browser/client.ts
@@ -13,7 +13,6 @@ export type ExecCmux = (
 export interface BrowserCommandResult {
 	command: string[];
 	stdout: string;
-	stderr: string;
 	json?: unknown;
 	surface?: string;
 	/** Captured output is intentionally model-visible; synthetic output is fixed extension metadata. */
@@ -21,7 +20,7 @@ export interface BrowserCommandResult {
 }
 
 export interface RunOptions {
-	/** Retain bounded stdout/stderr for explicitly read-only inspection operations. */
+	/** Retain bounded stdout for explicitly read-only inspection operations. */
 	capture?: boolean;
 	/** Parse exactly the documented top-level browser-open surface_id field. */
 	captureOpenedSurface?: boolean;
@@ -289,14 +288,13 @@ export class CmuxBrowserClient {
 
 		if (options.capture) {
 			const stdout = utf8Prefix(result.stdout, MAX_CAPTURE_BYTES);
-			return { command: safeCommand(args), stdout, stderr: "", json: parseJson(stdout), surface, exposure: "captured" };
+			return { command: safeCommand(args), stdout, json: parseJson(stdout), surface, exposure: "captured" };
 		}
 
 		const json = options.success ?? { ok: true };
 		return {
 			command: safeCommand(args),
 			stdout: JSON.stringify(json),
-			stderr: "",
 			json,
 			surface,
 			exposure: "synthetic",

--- a/cmux-browser/client.ts
+++ b/cmux-browser/client.ts
@@ -1,0 +1,167 @@
+import { readFile, stat } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+
+export interface ExecResult {
+	stdout: string;
+	stderr: string;
+	code: number;
+	killed?: boolean;
+}
+
+export type ExecCmux = (
+	args: string[],
+	options: { signal?: AbortSignal; timeout: number },
+) => Promise<ExecResult>;
+
+export interface BrowserCommandResult {
+	args: string[];
+	stdout: string;
+	stderr: string;
+	json?: unknown;
+	surface?: string;
+}
+
+const SURFACE_KEYS = new Set(["surface", "surfaceId", "surface_id", "surfaceUUID", "surface_uuid"]);
+const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+const UPLOAD_CHUNK_CHARS = 64 * 1024;
+
+function findSurface(value: unknown): string | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const found = findSurface(item);
+			if (found) return found;
+		}
+		return undefined;
+	}
+	for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+		if (SURFACE_KEYS.has(key) && typeof item === "string" && item.trim()) return item;
+		if (key === "surface" && item && typeof item === "object") {
+			const nested = item as Record<string, unknown>;
+			const id = nested.id ?? nested.uuid ?? nested.surface_id ?? nested.surfaceId;
+			if (typeof id === "string" && id.trim()) return id;
+		}
+		const found = findSurface(item);
+		if (found) return found;
+	}
+	return undefined;
+}
+
+function parseJson(stdout: string): unknown | undefined {
+	const text = stdout.trim();
+	if (!text) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+function formatFailure(args: string[], result: ExecResult): Error {
+	const detail = (result.stderr || result.stdout || `exit ${result.code}`).trim();
+	if (/broken pipe|failed to write to socket|connection refused|no such file/i.test(detail)) {
+		return new Error(
+			`cmux browser is unavailable (${detail}). Confirm Pi is running inside a live cmux workspace, run \`cmux ping\`, and retry.`,
+		);
+	}
+	if (/not[_ -]supported/i.test(detail)) {
+		return new Error(`cmux/WKWebView does not support this operation: ${detail}`);
+	}
+	return new Error(`cmux ${args.join(" ")} failed: ${detail}`);
+}
+
+export class CmuxBrowserClient {
+	private activeSurface?: string;
+
+	constructor(
+		private readonly execCmux: ExecCmux,
+		initialSurface?: string,
+	) {
+		this.activeSurface = initialSurface;
+	}
+
+	getActiveSurface(): string | undefined {
+		return this.activeSurface;
+	}
+
+	setActiveSurface(surface: string | undefined): void {
+		this.activeSurface = surface?.trim() || undefined;
+	}
+
+	private requireSurface(surface?: string): string {
+		const resolved = surface?.trim() || this.activeSurface;
+		if (!resolved) {
+			throw new Error("No browser surface is active. Call browser_navigate with action=open first, or pass surface explicitly.");
+		}
+		return resolved;
+	}
+
+	async run(args: string[], signal?: AbortSignal, timeout = 20_000): Promise<BrowserCommandResult> {
+		const fullArgs = ["--json", "--id-format", "uuids", ...args];
+		const result = await this.execCmux(fullArgs, { signal, timeout });
+		if (result.code !== 0) throw formatFailure(args, result);
+		const json = parseJson(result.stdout);
+		const surface = findSurface(json);
+		if (surface) this.activeSurface = surface;
+		return { args, stdout: result.stdout, stderr: result.stderr, json, surface: surface ?? this.activeSurface };
+	}
+
+	async open(url: string, workspace: string | undefined, signal?: AbortSignal): Promise<BrowserCommandResult> {
+		const args = ["browser", "open", url, "--focus", "false"];
+		if (workspace?.trim()) args.push("--workspace", workspace.trim());
+		return this.run(args, signal, 30_000);
+	}
+
+	async browser(surface: string | undefined, args: string[], signal?: AbortSignal, timeout?: number): Promise<BrowserCommandResult> {
+		return this.run(["browser", this.requireSurface(surface), ...args], signal, timeout);
+	}
+
+	async closeSurface(surface: string | undefined, signal?: AbortSignal): Promise<BrowserCommandResult> {
+		const target = this.requireSurface(surface);
+		const result = await this.run(["close-surface", "--surface", target], signal);
+		if (target === this.activeSurface) this.activeSurface = undefined;
+		return { ...result, surface: undefined };
+	}
+
+	async upload(
+		surface: string | undefined,
+		selector: string,
+		path: string,
+		cwd: string,
+		signal?: AbortSignal,
+	): Promise<BrowserCommandResult> {
+		const absolutePath = resolve(cwd, path.replace(/^@/, ""));
+		const info = await stat(absolutePath);
+		if (!info.isFile()) throw new Error(`Upload path is not a regular file: ${absolutePath}`);
+		if (info.size > MAX_UPLOAD_BYTES) {
+			throw new Error(`Upload is ${info.size} bytes; the safe DOM upload limit is ${MAX_UPLOAD_BYTES} bytes.`);
+		}
+		const data = (await readFile(absolutePath)).toString("base64");
+		const target = this.requireSurface(surface);
+		const evalScript = (script: string) => this.browser(target, ["eval", "--script", script], signal, 30_000);
+		await evalScript("globalThis.__piCmuxUploadBase64 = ''");
+		try {
+			for (let offset = 0; offset < data.length; offset += UPLOAD_CHUNK_CHARS) {
+				const chunk = data.slice(offset, offset + UPLOAD_CHUNK_CHARS);
+				await evalScript(`globalThis.__piCmuxUploadBase64 += ${JSON.stringify(chunk)}`);
+			}
+			const script = `(() => {
+				const input = document.querySelector(${JSON.stringify(selector)});
+				if (!(input instanceof HTMLInputElement) || input.type !== 'file') throw new Error('selector must resolve to <input type="file">');
+				const raw = atob(globalThis.__piCmuxUploadBase64 || '');
+				const bytes = new Uint8Array(raw.length);
+				for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+				const file = new File([bytes], ${JSON.stringify(basename(absolutePath))}, { type: 'application/octet-stream' });
+				const transfer = new DataTransfer();
+				transfer.items.add(file);
+				input.files = transfer.files;
+				input.dispatchEvent(new Event('input', { bubbles: true }));
+				input.dispatchEvent(new Event('change', { bubbles: true }));
+				return { name: file.name, size: file.size, files: input.files?.length ?? 0 };
+			})()`;
+			return await evalScript(script);
+		} finally {
+			await evalScript("delete globalThis.__piCmuxUploadBase64").catch(() => undefined);
+		}
+	}
+}

--- a/cmux-browser/client.ts
+++ b/cmux-browser/client.ts
@@ -1,6 +1,3 @@
-import { readFile, stat } from "node:fs/promises";
-import { basename, resolve } from "node:path";
-
 export interface ExecResult {
 	stdout: string;
 	stderr: string;
@@ -14,225 +11,385 @@ export type ExecCmux = (
 ) => Promise<ExecResult>;
 
 export interface BrowserCommandResult {
-	args: string[];
+	command: string[];
 	stdout: string;
 	stderr: string;
 	json?: unknown;
 	surface?: string;
+	/** Captured output is intentionally model-visible; synthetic output is fixed extension metadata. */
+	exposure: "captured" | "synthetic";
 }
 
-const SURFACE_KEYS = new Set(["surface", "surfaceId", "surface_id", "surfaceUUID", "surface_uuid"]);
-const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
-const UPLOAD_CHUNK_CHARS = 64 * 1024;
-
-function findSurface(value: unknown): string | undefined {
-	if (!value || typeof value !== "object") return undefined;
-	if (Array.isArray(value)) {
-		for (const item of value) {
-			const found = findSurface(item);
-			if (found) return found;
-		}
-		return undefined;
-	}
-	for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-		if (SURFACE_KEYS.has(key) && typeof item === "string" && item.trim()) return item;
-		if (key === "surface" && item && typeof item === "object") {
-			const nested = item as Record<string, unknown>;
-			const id = nested.id ?? nested.uuid ?? nested.surface_id ?? nested.surfaceId;
-			if (typeof id === "string" && id.trim()) return id;
-		}
-		const found = findSurface(item);
-		if (found) return found;
-	}
-	return undefined;
+export interface RunOptions {
+	/** Retain bounded stdout/stderr for explicitly read-only inspection operations. */
+	capture?: boolean;
+	/** Parse exactly the documented top-level browser-open surface_id field. */
+	captureOpenedSurface?: boolean;
+	/** Safe synthetic result used when raw command output is intentionally discarded. */
+	success?: Record<string, boolean | number>;
 }
 
-function parseJson(stdout: string): unknown | undefined {
-	const text = stdout.trim();
-	if (!text) return undefined;
+const MAX_CAPTURE_BYTES = 50 * 1024;
+const SURFACE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const BROWSER_COMMANDS = new Set([
+	"open", "goto", "reload", "snapshot", "wait", "click", "dblclick", "hover", "focus", "press",
+	"check", "uncheck", "scroll", "scroll-into-view", "screenshot", "get", "console", "errors", "highlight", "download",
+]);
+const CAPTURED_BROWSER_READS = new Set(["snapshot", "get", "console", "errors"]);
+const REF_TARGET_OPERATIONS = new Set([
+	"click", "dblclick", "hover", "focus", "check", "uncheck", "scroll-into-view",
+]);
+const REF_INVALIDATING_OPERATIONS = new Set([
+	"goto", "reload", "wait", "click", "dblclick", "hover", "focus", "press", "check", "uncheck", "scroll", "scroll-into-view",
+]);
+const SNAPSHOT_REF_MARKER = /\bref=(e[1-9][0-9]*)\b/g;
+const SNAPSHOT_REF_VALUE = /^e[1-9][0-9]*$/;
+const SAFE_KEY = new Set([
+	"Enter", "Tab", "Escape", "Backspace", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
+	"Home", "End", "PageUp", "PageDown", "Space",
+]);
+const SAFE_ATTRIBUTE = new Set([
+	"role", "aria-label", "aria-checked", "aria-disabled", "aria-expanded", "aria-hidden", "aria-selected",
+	"alt", "name", "title", "type",
+]);
+const SENSITIVE_QUERY_KEY = /(?:^|[_-])(auth|authorization|code|credential|key|password|secret|session|sig|signature|token)(?:$|[_-])/i;
+const SENSITIVE_COMPACT_KEY = /(?:token|secret|password|credential|authorization|session|signature)/i;
+const SENSITIVE_EXACT_KEY = new Set(["apikey", "auth", "code", "key", "sig"]);
+
+function invalidArguments(): never {
+	throw new Error("Invalid browser arguments; only the extension's fixed documented command shapes are allowed.");
+}
+
+function isSensitiveParameterKey(key: string): boolean {
+	const compact = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+	return SENSITIVE_QUERY_KEY.test(key) || SENSITIVE_COMPACT_KEY.test(compact) || SENSITIVE_EXACT_KEY.has(compact);
+}
+
+function assertSafeNavigationUrl(raw: string | undefined): void {
+	if (!raw) invalidArguments();
+	let url: URL;
 	try {
-		return JSON.parse(text);
+		url = new URL(raw);
+	} catch {
+		invalidArguments();
+	}
+	if (url.protocol === "about:" && url.href === "about:blank") return;
+	if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password) invalidArguments();
+	for (const key of url.searchParams.keys()) if (isSensitiveParameterKey(key)) invalidArguments();
+	if (url.hash) {
+		let fragment: string;
+		try {
+			fragment = decodeURIComponent(url.hash.slice(1));
+		} catch {
+			invalidArguments();
+		}
+		for (const part of fragment.split(/[?&;]/)) {
+			const equals = part.indexOf("=");
+			if (equals >= 0 && isSensitiveParameterKey(part.slice(0, equals).replace(/^.*\//, ""))) invalidArguments();
+		}
+	}
+}
+
+function isFiniteNumber(value: string | undefined, minimum: number, maximum: number): boolean {
+	if (value === undefined || value.trim() === "") return false;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed >= minimum && parsed <= maximum;
+}
+
+function isInteger(value: string | undefined, minimum: number, maximum: number): boolean {
+	return value !== undefined && /^\d+$/.test(value) && Number(value) >= minimum && Number(value) <= maximum;
+}
+
+function validateOptions(args: string[], allowed: Record<string, (value?: string) => boolean>): void {
+	const seen = new Set<string>();
+	for (let index = 1; index < args.length;) {
+		const flag = args[index]!;
+		const accepts = allowed[flag];
+		if (!accepts || seen.has(flag)) invalidArguments();
+		seen.add(flag);
+		if (accepts()) {
+			index += 1;
+		} else {
+			if (!accepts(args[index + 1])) invalidArguments();
+			index += 2;
+		}
+	}
+}
+
+function validateBrowserArguments(args: string[]): void {
+	const operation = args[0];
+	if (!operation) invalidArguments();
+	if (operation === "goto") {
+		if (args.length !== 2) invalidArguments();
+		assertSafeNavigationUrl(args[1]);
+		return;
+	}
+	if (operation === "reload") {
+		if (args.length !== 1) invalidArguments();
+		return;
+	}
+	if (operation === "snapshot") {
+		validateOptions(args, {
+			"--interactive": (value) => value === undefined,
+			"--compact": (value) => value === undefined,
+			"--max-depth": (value) => isInteger(value, 1, 20),
+		});
+		return;
+	}
+	if (["click", "dblclick", "hover", "focus", "check", "uncheck", "scroll-into-view"].includes(operation)) {
+		if (args.length !== 2 || !SNAPSHOT_REF_VALUE.test(args[1] ?? "")) invalidArguments();
+		return;
+	}
+	if (operation === "press") {
+		if (args.length !== 3 || args[1] !== "--key" || !SAFE_KEY.has(args[2] ?? "")) invalidArguments();
+		return;
+	}
+	if (operation === "scroll") {
+		validateOptions(args, {
+			"--selector": (value) => value !== undefined && SNAPSHOT_REF_VALUE.test(value),
+			"--dx": (value) => isFiniteNumber(value, -10_000, 10_000),
+			"--dy": (value) => isFiniteNumber(value, -10_000, 10_000),
+		});
+		if (args.length === 1) invalidArguments();
+		return;
+	}
+	if (operation === "wait") {
+		validateOptions(args, {
+			"--selector": (value) => value !== undefined && SNAPSHOT_REF_VALUE.test(value),
+			"--load-state": (value) => value === "interactive" || value === "complete",
+			"--timeout-ms": (value) => isInteger(value, 1, 120_000),
+		});
+		if (args.length < 5 || !args.includes("--timeout-ms") || (!args.includes("--selector") && !args.includes("--load-state"))) invalidArguments();
+		return;
+	}
+	if (operation === "get") {
+		if ((args[1] === "url" || args[1] === "title") && args.length === 2) return;
+		if (["text", "count", "box"].includes(args[1] ?? "") && args.length === 4 && args[2] === "--selector" && SNAPSHOT_REF_VALUE.test(args[3] ?? "")) return;
+		if (args[1] === "attr" && args.length === 6 && args[2] === "--selector" && SNAPSHOT_REF_VALUE.test(args[3] ?? "") && args[4] === "--attr" && SAFE_ATTRIBUTE.has(args[5] ?? "")) return;
+		invalidArguments();
+	}
+	if ((operation === "console" || operation === "errors") && args.length === 2 && args[1] === "list") return;
+	if (operation === "highlight" && args.length === 3 && args[1] === "--selector" && SNAPSHOT_REF_VALUE.test(args[2] ?? "")) return;
+	if (operation === "screenshot" && args.length === 3 && args[1] === "--out" && Boolean(args[2])) return;
+	if (operation === "download" && args.length === 4 && args[1] === "wait" && args[2] === "--timeout-ms" && isInteger(args[3], 1, 120_000)) return;
+	invalidArguments();
+}
+
+function parseJson(text: string): unknown | undefined {
+	const trimmed = text.trim();
+	if (!trimmed) return undefined;
+	try {
+		return JSON.parse(trimmed);
 	} catch {
 		return undefined;
 	}
 }
 
-const STRUCTURAL_ARGS = new Set([
-	"browser", "open", "open-split", "new", "status", "goto", "navigate", "back", "forward", "reload",
-	"snapshot", "eval", "wait", "click", "dblclick", "hover", "focus", "fill", "type", "press", "key",
-	"keydown", "keyup", "select", "scroll", "scroll-into-view", "screenshot", "get", "is", "find", "frame",
-	"dialog", "download", "profiles", "cookies", "storage", "tab", "console", "errors", "highlight", "state",
-	"addinitscript", "addscript", "addstyle", "viewport", "geolocation", "geo", "offline", "trace", "network",
-	"screencast", "input", "close-surface", "upload", "list", "save", "load", "add", "rename", "delete", "clear",
-]);
-
-function safeCommand(args: string[]): string[] {
-	const browserIndex = args.indexOf("browser");
-	if (browserIndex < 0) return args.slice(0, 1).filter((arg) => STRUCTURAL_ARGS.has(arg));
-	const safe = ["browser"];
-	const first = args[browserIndex + 1];
-	if (!first) return safe;
-	if (STRUCTURAL_ARGS.has(first)) return [...safe, first];
-	safe.push("<surface>");
-	const command = args[browserIndex + 2];
-	if (command && STRUCTURAL_ARGS.has(command)) safe.push(command);
-	return safe;
+function utf8Prefix(text: string, maxBytes: number): string {
+	const bytes = Buffer.from(text, "utf8");
+	if (bytes.length <= maxBytes) return text;
+	return `${bytes.subarray(0, maxBytes).toString("utf8")}\n[output truncated at ${maxBytes} bytes]`;
 }
 
-const VALUE_BEARING_COMMANDS = new Set([
-	"open", "goto", "navigate", "eval", "wait", "click", "dblclick", "hover", "focus", "fill", "type",
-	"press", "key", "keydown", "keyup", "select", "scroll", "scroll-into-view", "screenshot", "get", "find",
-	"frame", "dialog", "download", "profiles", "cookies", "storage", "highlight", "state", "addinitscript",
-	"addscript", "addstyle", "geolocation", "geo", "trace", "network", "input",
-]);
+/** Return only fixed operation labels. No URL, selector, text, path, script, or handle is retained. */
+function safeCommand(args: string[]): string[] {
+	if (args[0] === "close-surface") return ["close-surface"];
+	if (args[0] !== "browser") return ["cmux"];
+	if (args[1] && BROWSER_COMMANDS.has(args[1])) return ["browser", args[1]];
+	if (args[2] && BROWSER_COMMANDS.has(args[2])) return ["browser", "<owned-surface>", args[2]];
+	return ["browser"];
+}
 
-function redactArgv(text: string, args: string[]): string {
-	let redacted = text;
-	const sensitive = new Set<string>();
-	const valueCommandIndex = args.findIndex((arg) => VALUE_BEARING_COMMANDS.has(arg));
-	for (const [index, arg] of args.entries()) {
-		if (!arg || arg === "true" || arg === "false") continue;
-		const commandValue = valueCommandIndex >= 0 && index > valueCommandIndex && !arg.startsWith("--");
-		if (!commandValue && (STRUCTURAL_ARGS.has(arg) || arg.startsWith("--"))) continue;
-		sensitive.add(arg);
-		for (const token of arg.match(/[A-Za-z0-9+/]{16,}={0,2}/g) ?? []) sensitive.add(token);
-	}
-	for (const value of [...sensitive].sort((a, b) => b.length - a.length)) {
-		redacted = redacted.split(value).join("[REDACTED]");
-		redacted = redacted.split(JSON.stringify(value).slice(1, -1)).join("[REDACTED]");
-	}
-	return redacted;
+function lifecycleFailure(args: string[], outcome: string): Error {
+	const command = safeCommand(args).join(" ");
+	return new Error(
+		`cmux ${command} ${outcome}. Raw diagnostics were suppressed. If cmux may be unavailable, confirm Pi is running inside a live cmux workspace and run \`cmux ping\`.`,
+	);
 }
 
 function formatFailure(args: string[], result: ExecResult): Error {
-	const command = safeCommand(args).join(" ") || "command";
-	const raw = result.stderr || result.stdout;
-	if (/broken pipe|failed to write to socket|connection refused|no such file/i.test(raw)) {
-		return new Error(
-			`cmux browser is unavailable (${command}, exit ${result.code}). Confirm Pi is running inside a live cmux workspace, run \`cmux ping\`, and retry.`,
-		);
-	}
-	if (/not[_ -]supported/i.test(raw)) {
-		return new Error(`cmux/WKWebView does not support ${command} (exit ${result.code}).`);
-	}
-	if (args.some((arg) => VALUE_BEARING_COMMANDS.has(arg))) {
-		return new Error(`cmux ${command} failed (exit ${result.code}); cmux diagnostics were suppressed because this invocation contained sensitive arguments.`);
-	}
-	const detail = redactArgv(raw || `exit ${result.code}`, args).trim();
-	return new Error(`cmux ${command} failed (exit ${result.code}): ${detail}`);
+	return lifecycleFailure(args, `failed (exit ${result.code})`);
+}
+
+function openedSurface(json: unknown): string | undefined {
+	if (!json || typeof json !== "object" || Array.isArray(json)) return undefined;
+	const value = (json as Record<string, unknown>).surface_id;
+	return typeof value === "string" && SURFACE_UUID.test(value) ? value : undefined;
 }
 
 export class CmuxBrowserClient {
 	private activeSurface?: string;
+	private readonly ownedSurfaces = new Set<string>();
+	private readonly freshSnapshotRefs = new Set<string>();
+	private readonly execCmux: ExecCmux;
 
-	constructor(
-		private readonly execCmux: ExecCmux,
-		initialSurface?: string,
-	) {
-		this.activeSurface = initialSurface;
+	constructor(execCmux: ExecCmux) {
+		this.execCmux = execCmux;
 	}
 
 	getActiveSurface(): string | undefined {
 		return this.activeSurface;
 	}
 
-	setActiveSurface(surface: string | undefined): void {
-		this.activeSurface = surface?.trim() || undefined;
+	getOwnedSurfaceCount(): number {
+		return this.ownedSurfaces.size;
 	}
 
-	private requireSurface(surface?: string): string {
-		const resolved = surface?.trim() || this.activeSurface;
-		if (!resolved) {
-			throw new Error("No browser surface is active. Call browser_navigate with action=open first, or pass surface explicitly.");
+	private requireOwnedSurface(): string {
+		const surface = this.activeSurface;
+		if (!surface || !this.ownedSurfaces.has(surface)) {
+			throw new Error("No extension-owned browser surface is active. Call browser_navigate with action=open first.");
 		}
-		return resolved;
+		return surface;
 	}
 
-	async run(args: string[], signal?: AbortSignal, timeout = 20_000): Promise<BrowserCommandResult> {
-		const fullArgs = ["--json", "--id-format", "uuids", ...args];
-		const result = await this.execCmux(fullArgs, { signal, timeout });
+	private referencedSnapshotRef(args: string[]): string | undefined {
+		const operation = args[0] ?? "";
+		if (REF_TARGET_OPERATIONS.has(operation)) return args[1];
+		if (operation === "get" && args[1] !== "url") {
+			const index = args.indexOf("--selector");
+			return index >= 0 ? args[index + 1] : undefined;
+		}
+		if (operation === "highlight" || operation === "wait" || operation === "scroll") {
+			const index = args.indexOf("--selector");
+			return index >= 0 ? args[index + 1] : undefined;
+		}
+		return undefined;
+	}
+
+	private recordSnapshotRefs(result: BrowserCommandResult): void {
+		this.freshSnapshotRefs.clear();
+		if (!result.json || typeof result.json !== "object" || Array.isArray(result.json)) return;
+		const snapshot = (result.json as Record<string, unknown>).snapshot;
+		if (typeof snapshot !== "string") return;
+		for (const match of snapshot.matchAll(SNAPSHOT_REF_MARKER)) this.freshSnapshotRefs.add(match[1]!);
+	}
+
+	private async run(args: string[], signal?: AbortSignal, timeout = 20_000, options: RunOptions = {}): Promise<BrowserCommandResult> {
+		let result: ExecResult;
+		try {
+			result = await this.execCmux(["--json", "--id-format", "uuids", ...args], { signal, timeout });
+		} catch {
+			throw lifecycleFailure(args, "could not be invoked");
+		}
 		if (result.code !== 0) throw formatFailure(args, result);
-		const stdout = redactArgv(result.stdout, args);
-		const stderr = redactArgv(result.stderr, args);
-		const json = parseJson(stdout);
-		const surface = findSurface(json);
-		if (surface) this.activeSurface = surface;
-		return { args: safeCommand(args), stdout, stderr, json, surface: surface ?? this.activeSurface };
+
+		let surface = this.activeSurface;
+		if (options.captureOpenedSurface) {
+			const parsed = parseJson(utf8Prefix(result.stdout, 8 * 1024));
+			const opened = openedSurface(parsed);
+			if (!opened) {
+				throw new Error("cmux browser open succeeded but returned no valid top-level surface_id UUID; raw output was suppressed.");
+			}
+			this.ownedSurfaces.add(opened);
+			this.activeSurface = opened;
+			surface = opened;
+		}
+
+		if (options.capture) {
+			const stdout = utf8Prefix(result.stdout, MAX_CAPTURE_BYTES);
+			return { command: safeCommand(args), stdout, stderr: "", json: parseJson(stdout), surface, exposure: "captured" };
+		}
+
+		const json = options.success ?? { ok: true };
+		return {
+			command: safeCommand(args),
+			stdout: JSON.stringify(json),
+			stderr: "",
+			json,
+			surface,
+			exposure: "synthetic",
+		};
 	}
 
-	async open(url: string, workspace: string | undefined, signal?: AbortSignal): Promise<BrowserCommandResult> {
-		const args = ["browser", "open", url, "--focus", "false"];
-		if (workspace?.trim()) args.push("--workspace", workspace.trim());
-		return this.run(args, signal, 30_000);
+	async open(url: string, signal?: AbortSignal): Promise<BrowserCommandResult> {
+		if (this.activeSurface) throw new Error("An extension-owned browser surface is already active; close it before opening another.");
+		assertSafeNavigationUrl(url);
+		this.freshSnapshotRefs.clear();
+		return this.run(
+			["browser", "open", url, "--focus", "false"],
+			signal,
+			30_000,
+			{ captureOpenedSurface: true, success: { ok: true, opened: true } },
+		);
 	}
 
-	async browser(surface: string | undefined, args: string[], signal?: AbortSignal, timeout?: number): Promise<BrowserCommandResult> {
-		return this.run(["browser", this.requireSurface(surface), ...args], signal, timeout);
+	async browser(
+		args: string[],
+		signal?: AbortSignal,
+		timeout = 20_000,
+		options: RunOptions = {},
+	): Promise<BrowserCommandResult> {
+		const surface = this.requireOwnedSurface();
+		const operation = args[0] ?? "";
+		if (!BROWSER_COMMANDS.has(operation) || operation === "open") {
+			throw new Error("Unsupported browser operation; only the extension's fixed capability set is allowed.");
+		}
+		validateBrowserArguments(args);
+		if (options.capture && !CAPTURED_BROWSER_READS.has(operation)) {
+			throw new Error("Captured output is allowed only for browser snapshot/get/console/errors reads.");
+		}
+		const referenced = this.referencedSnapshotRef(args);
+		if (referenced !== undefined && !this.freshSnapshotRefs.has(referenced)) {
+			throw new Error("The requested element ref is not present in the latest successful snapshot; take a fresh snapshot first.");
+		}
+		if (operation === "snapshot" || REF_INVALIDATING_OPERATIONS.has(operation)) this.freshSnapshotRefs.clear();
+		const result = await this.run(["browser", surface, ...args], signal, timeout, options);
+		if (operation === "snapshot") this.recordSnapshotRefs(result);
+		return result;
 	}
 
-	async closeSurface(surface: string | undefined, signal?: AbortSignal): Promise<BrowserCommandResult> {
-		const target = this.requireSurface(surface);
-		const result = await this.run(["close-surface", "--surface", target], signal);
-		if (target === this.activeSurface) this.activeSurface = undefined;
+	async currentOrigin(signal?: AbortSignal): Promise<string> {
+		const result = await this.browser(["get", "url"], signal, 20_000, { capture: true });
+		const parsed = result.json;
+		const raw = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>).url
+			: undefined;
+		if (typeof raw !== "string") {
+			throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
+		}
+		try {
+			const url = new URL(raw);
+			if (url.href === "about:blank") return "about:blank";
+			if ((url.protocol === "http:" || url.protocol === "https:") && url.origin !== "null") return url.origin;
+			throw new Error("unsupported browser origin");
+		} catch {
+			throw new Error("Could not verify an approved http(s) browser origin; operation refused.");
+		}
+	}
+
+	async closeActive(signal?: AbortSignal): Promise<BrowserCommandResult> {
+		const target = this.requireOwnedSurface();
+		// Relinquish ownership before the subprocess call so an aborted or failed
+		// close can never resurrect a stale handle in this extension instance.
+		this.ownedSurfaces.delete(target);
+		this.activeSurface = undefined;
+		this.freshSnapshotRefs.clear();
+		const result = await this.run(
+			["close-surface", "--surface", target],
+			signal,
+			20_000,
+			{ success: { ok: true, closed: true } },
+		);
 		return { ...result, surface: undefined };
 	}
 
-	async upload(
-		surface: string | undefined,
-		selector: string,
-		path: string,
-		cwd: string,
-		signal?: AbortSignal,
-	): Promise<BrowserCommandResult> {
-		const absolutePath = resolve(cwd, path.replace(/^@/, ""));
-		let info;
-		try {
-			info = await stat(absolutePath);
-		} catch {
-			throw new Error("Upload file could not be inspected. Confirm that the approved path exists and is readable.");
-		}
-		if (!info.isFile()) throw new Error("Upload path is not a regular file.");
-		if (info.size > MAX_UPLOAD_BYTES) {
-			throw new Error(`Upload is ${info.size} bytes; the safe DOM upload limit is ${MAX_UPLOAD_BYTES} bytes.`);
-		}
-		let data: string;
-		try {
-			data = (await readFile(absolutePath)).toString("base64");
-		} catch {
-			throw new Error("Upload file could not be read. Confirm permissions and retry.");
-		}
-		const target = this.requireSurface(surface);
-		const evalScript = (script: string) => this.browser(target, ["eval", "--script", script], signal, 30_000);
-		await evalScript("globalThis.__piCmuxUploadBase64 = ''");
-		try {
-			for (let offset = 0; offset < data.length; offset += UPLOAD_CHUNK_CHARS) {
-				const chunk = data.slice(offset, offset + UPLOAD_CHUNK_CHARS);
-				await evalScript(`globalThis.__piCmuxUploadBase64 += ${JSON.stringify(chunk)}`);
+	async closeAll(): Promise<void> {
+		for (const surface of [...this.ownedSurfaces]) {
+			try {
+				await this.run(
+					["close-surface", "--surface", surface],
+					undefined,
+					5_000,
+					{ success: { ok: true, closed: true } },
+				);
+			} catch {
+				// Shutdown cleanup is best-effort and deliberately does not retain raw diagnostics.
 			}
-			const script = `(() => {
-				const input = document.querySelector(${JSON.stringify(selector)});
-				if (!(input instanceof HTMLInputElement) || input.type !== 'file') throw new Error('selector must resolve to <input type="file">');
-				const raw = atob(globalThis.__piCmuxUploadBase64 || '');
-				const bytes = new Uint8Array(raw.length);
-				for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
-				const file = new File([bytes], ${JSON.stringify(basename(absolutePath))}, { type: 'application/octet-stream' });
-				const transfer = new DataTransfer();
-				transfer.items.add(file);
-				input.files = transfer.files;
-				input.dispatchEvent(new Event('input', { bubbles: true }));
-				input.dispatchEvent(new Event('change', { bubbles: true }));
-				return { name: file.name, size: file.size, files: input.files?.length ?? 0 };
-			})()`;
-			await evalScript(script);
-			return {
-				args: ["browser", "<surface>", "upload"],
-				stdout: JSON.stringify({ ok: true, uploaded: true }),
-				stderr: "",
-				json: { ok: true, uploaded: true },
-				surface: target,
-			};
-		} finally {
-			await evalScript("delete globalThis.__piCmuxUploadBase64").catch(() => undefined);
+			this.ownedSurfaces.delete(surface);
 		}
+		this.activeSurface = undefined;
+		this.freshSnapshotRefs.clear();
 	}
 }

--- a/cmux-browser/client.ts
+++ b/cmux-browser/client.ts
@@ -63,7 +63,7 @@ const STRUCTURAL_ARGS = new Set([
 	"keydown", "keyup", "select", "scroll", "scroll-into-view", "screenshot", "get", "is", "find", "frame",
 	"dialog", "download", "profiles", "cookies", "storage", "tab", "console", "errors", "highlight", "state",
 	"addinitscript", "addscript", "addstyle", "viewport", "geolocation", "geo", "offline", "trace", "network",
-	"screencast", "input", "close-surface", "list", "save", "load", "add", "rename", "delete", "clear",
+	"screencast", "input", "close-surface", "upload", "list", "save", "load", "add", "rename", "delete", "clear",
 ]);
 
 function safeCommand(args: string[]): string[] {
@@ -106,15 +106,19 @@ function redactArgv(text: string, args: string[]): string {
 
 function formatFailure(args: string[], result: ExecResult): Error {
 	const command = safeCommand(args).join(" ") || "command";
-	const detail = redactArgv(result.stderr || result.stdout || `exit ${result.code}`, args).trim();
-	if (/broken pipe|failed to write to socket|connection refused|no such file/i.test(detail)) {
+	const raw = result.stderr || result.stdout;
+	if (/broken pipe|failed to write to socket|connection refused|no such file/i.test(raw)) {
 		return new Error(
-			`cmux browser is unavailable (exit ${result.code}: ${detail}). Confirm Pi is running inside a live cmux workspace, run \`cmux ping\`, and retry.`,
+			`cmux browser is unavailable (${command}, exit ${result.code}). Confirm Pi is running inside a live cmux workspace, run \`cmux ping\`, and retry.`,
 		);
 	}
-	if (/not[_ -]supported/i.test(detail)) {
-		return new Error(`cmux/WKWebView does not support ${command} (exit ${result.code}): ${detail}`);
+	if (/not[_ -]supported/i.test(raw)) {
+		return new Error(`cmux/WKWebView does not support ${command} (exit ${result.code}).`);
 	}
+	if (args.some((arg) => VALUE_BEARING_COMMANDS.has(arg))) {
+		return new Error(`cmux ${command} failed (exit ${result.code}); cmux diagnostics were suppressed because this invocation contained sensitive arguments.`);
+	}
+	const detail = redactArgv(raw || `exit ${result.code}`, args).trim();
 	return new Error(`cmux ${command} failed (exit ${result.code}): ${detail}`);
 }
 
@@ -219,7 +223,14 @@ export class CmuxBrowserClient {
 				input.dispatchEvent(new Event('change', { bubbles: true }));
 				return { name: file.name, size: file.size, files: input.files?.length ?? 0 };
 			})()`;
-			return await evalScript(script);
+			await evalScript(script);
+			return {
+				args: ["browser", "<surface>", "upload"],
+				stdout: JSON.stringify({ ok: true, uploaded: true }),
+				stderr: "",
+				json: { ok: true, uploaded: true },
+				surface: target,
+			};
 		} finally {
 			await evalScript("delete globalThis.__piCmuxUploadBase64").catch(() => undefined);
 		}

--- a/cmux-browser/e2e.ts
+++ b/cmux-browser/e2e.ts
@@ -1,0 +1,62 @@
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { promisify } from "node:util";
+import { CmuxBrowserClient, type ExecCmux } from "./client.ts";
+
+const execFileAsync = promisify(execFile);
+
+async function main() {
+	const baseUrl = process.argv[2];
+	const fixtureDir = process.argv[3];
+	if (!baseUrl || !fixtureDir) throw new Error("usage: npx tsx e2e.ts <base-url> <fixture-dir>");
+
+	const execCmux: ExecCmux = async (args, { signal, timeout }) => {
+		try {
+			const { stdout, stderr } = await execFileAsync("cmux", args, { signal, timeout, maxBuffer: 2 * 1024 * 1024 });
+			return { stdout, stderr, code: 0 };
+		} catch (error: any) {
+			return {
+				stdout: error?.stdout ?? "",
+				stderr: error?.stderr ?? error?.message ?? String(error),
+				code: typeof error?.code === "number" ? error.code : 1,
+				killed: Boolean(error?.killed),
+			};
+		}
+	};
+
+	const client = new CmuxBrowserClient(execCmux);
+	let surface: string | undefined;
+	try {
+		const opened = await client.open(baseUrl, undefined);
+		surface = opened.surface;
+		if (!surface) throw new Error(`open returned no surface: ${opened.stdout}`);
+		await client.browser(surface, ["wait", "--load-state", "complete", "--timeout-ms", "15000"], undefined, 20_000);
+		const snapshot = await client.browser(surface, ["snapshot", "--interactive"]);
+		if (!/Name/.test(snapshot.stdout) || !/Upload/.test(snapshot.stdout)) throw new Error(`snapshot missing fixture controls: ${snapshot.stdout}`);
+		await client.browser(surface, ["fill", "--selector", "#name", "--text", "Pi", "--snapshot-after"]);
+		await client.browser(surface, ["click", "--selector", "#hello", "--snapshot-after"]);
+		await client.browser(surface, ["wait", "--text", "Hello Pi", "--timeout-ms", "5000"]);
+		await client.upload(surface, "#upload", `${fixtureDir}/upload.txt`, fixtureDir);
+		await client.browser(surface, ["wait", "--text", "upload.txt", "--timeout-ms", "5000"]);
+		const screenshotPath = `${fixtureDir}/browser.png`;
+		await client.browser(surface, ["screenshot", "--out", screenshotPath], undefined, 30_000);
+		if ((await stat(screenshotPath)).size === 0) throw new Error("screenshot is empty");
+		await client.browser(surface, ["click", "--selector", "#download"]);
+		const downloadPath = `${fixtureDir}/download.txt`;
+		await client.browser(surface, ["download", "wait", "--path", downloadPath, "--timeout-ms", "10000"], undefined, 15_000);
+		if ((await readFile(downloadPath, "utf8")).trim() !== "synthetic download") throw new Error("download content mismatch");
+		await client.browser(surface, ["tab", "new", `${baseUrl}?tab=2`]);
+		const tabs = await client.browser(surface, ["tab", "list"]);
+		if (!tabs.stdout.includes("tab")) throw new Error(`tab list did not report tabs: ${tabs.stdout}`);
+		await client.browser(surface, ["console", "list"]);
+		await client.browser(surface, ["errors", "list"]);
+		console.log(JSON.stringify({ ok: true, surface, screenshotPath, downloadPath }));
+	} finally {
+		if (surface) await client.closeSurface(surface).catch(() => undefined);
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/cmux-browser/e2e.ts
+++ b/cmux-browser/e2e.ts
@@ -1,9 +1,23 @@
 import { execFile } from "node:child_process";
-import { readFile, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+import { open as openFile, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { CmuxBrowserClient, type ExecCmux } from "./client.ts";
+import { snapshotRef } from "./policy.ts";
 
 const execFileAsync = promisify(execFile);
+
+function refFor(payload: unknown, label: string): string {
+	const snapshot = payload && typeof payload === "object" && !Array.isArray(payload)
+		? (payload as Record<string, unknown>).snapshot
+		: undefined;
+	if (typeof snapshot !== "string") throw new Error("snapshot response did not contain documented snapshot text");
+	const line = snapshot.split("\n").find((candidate) => candidate.includes(label));
+	const ref = line?.match(/\bref=(e[1-9][0-9]*)\b/)?.[1];
+	return snapshotRef(ref, `find ${label}`);
+}
 
 async function main() {
 	const baseUrl = process.argv[2];
@@ -25,38 +39,40 @@ async function main() {
 	};
 
 	const client = new CmuxBrowserClient(execCmux);
-	let surface: string | undefined;
+	const screenshotPath = join(fixtureDir, `${randomUUID()}.png`);
 	try {
-		const opened = await client.open(baseUrl, undefined);
-		surface = opened.surface;
-		if (!surface) throw new Error(`open returned no surface: ${opened.stdout}`);
-		await client.browser(surface, ["wait", "--load-state", "complete", "--timeout-ms", "15000"], undefined, 20_000);
-		const snapshot = await client.browser(surface, ["snapshot", "--interactive"]);
-		if (!/Name/.test(snapshot.stdout) || !/Upload/.test(snapshot.stdout)) throw new Error(`snapshot missing fixture controls: ${snapshot.stdout}`);
-		await client.browser(surface, ["fill", "--selector", "#name", "--text", "Pi", "--snapshot-after"]);
-		await client.browser(surface, ["click", "--selector", "#hello", "--snapshot-after"]);
-		await client.browser(surface, ["wait", "--text", "Hello Pi", "--timeout-ms", "5000"]);
-		await client.upload(surface, "#upload", `${fixtureDir}/upload.txt`, fixtureDir);
-		await client.browser(surface, ["wait", "--text", "upload.txt", "--timeout-ms", "5000"]);
-		const screenshotPath = `${fixtureDir}/browser.png`;
-		await client.browser(surface, ["screenshot", "--out", screenshotPath], undefined, 30_000);
-		if ((await stat(screenshotPath)).size === 0) throw new Error("screenshot is empty");
-		await client.browser(surface, ["click", "--selector", "#download"]);
-		const downloadPath = `${fixtureDir}/download.txt`;
-		await client.browser(surface, ["download", "wait", "--path", downloadPath, "--timeout-ms", "10000"], undefined, 15_000);
-		if ((await readFile(downloadPath, "utf8")).trim() !== "synthetic download") throw new Error("download content mismatch");
-		await client.browser(surface, ["tab", "new", `${baseUrl}?tab=2`]);
-		const tabs = await client.browser(surface, ["tab", "list"]);
-		if (!tabs.stdout.includes("tab")) throw new Error(`tab list did not report tabs: ${tabs.stdout}`);
-		await client.browser(surface, ["console", "list"]);
-		await client.browser(surface, ["errors", "list"]);
-		console.log(JSON.stringify({ ok: true, surface, screenshotPath, downloadPath }));
+		const opened = await client.open(baseUrl);
+		if (!opened.surface || opened.exposure !== "synthetic") throw new Error("open returned no synthetic owned-surface result");
+		await client.browser(["wait", "--load-state", "complete", "--timeout-ms", "15000"], undefined, 20_000);
+
+		const before = await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
+		if (before.exposure !== "captured") throw new Error("snapshot was not classified as captured output");
+		const buttonRef = refFor(before.json, "Say hello");
+		await client.browser(["click", buttonRef]);
+
+		const after = await client.browser(["snapshot"], undefined, 20_000, { capture: true });
+		if (!after.stdout.includes("Clicked")) throw new Error("ref click did not update the native page");
+
+		await client.browser(["screenshot", "--out", screenshotPath], undefined, 30_000);
+		let handle;
+		try {
+			handle = await openFile(screenshotPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+			const metadata = await handle.stat();
+			if (!metadata.isFile() || metadata.size === 0) throw new Error("screenshot is empty or not a regular file");
+		} finally {
+			await handle?.close().catch(() => undefined);
+		}
+
+		await client.browser(["console", "list"], undefined, 20_000, { capture: true });
+		await client.browser(["errors", "list"], undefined, 20_000, { capture: true });
+		console.log(JSON.stringify({ ok: true, surface: "owned", native_ref_click: true, screenshot: true }));
 	} finally {
-		if (surface) await client.closeSurface(surface).catch(() => undefined);
+		await client.closeAll();
+		await rm(screenshotPath, { force: true }).catch(() => undefined);
 	}
 }
 
 main().catch((error) => {
-	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	console.error(error instanceof Error ? error.message : String(error));
 	process.exitCode = 1;
 });

--- a/cmux-browser/e2e.ts
+++ b/cmux-browser/e2e.ts
@@ -1,32 +1,16 @@
 import { execFile } from "node:child_process";
-import { constants } from "node:fs";
-import { open as openFile, rm } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { join } from "node:path";
 import { promisify } from "node:util";
 import { CmuxBrowserClient, type ExecCmux } from "./client.ts";
-import { snapshotRef } from "./policy.ts";
 
 const execFileAsync = promisify(execFile);
 
-function refFor(payload: unknown, label: string): string {
-	const snapshot = payload && typeof payload === "object" && !Array.isArray(payload)
-		? (payload as Record<string, unknown>).snapshot
-		: undefined;
-	if (typeof snapshot !== "string") throw new Error("snapshot response did not contain documented snapshot text");
-	const line = snapshot.split("\n").find((candidate) => candidate.includes(label));
-	const ref = line?.match(/\bref=(e[1-9][0-9]*)\b/)?.[1];
-	return snapshotRef(ref, `find ${label}`);
-}
-
 async function main() {
 	const baseUrl = process.argv[2];
-	const fixtureDir = process.argv[3];
-	if (!baseUrl || !fixtureDir) throw new Error("usage: npx tsx e2e.ts <base-url> <fixture-dir>");
+	if (!baseUrl) throw new Error("usage: npx tsx e2e.ts <base-url>");
 
 	const execCmux: ExecCmux = async (args, { signal, timeout }) => {
 		try {
-			const { stdout, stderr } = await execFileAsync("cmux", args, { signal, timeout, maxBuffer: 2 * 1024 * 1024 });
+			const { stdout, stderr } = await execFileAsync("cmux", args, { signal, timeout, maxBuffer: 12 * 1024 * 1024 });
 			return { stdout, stderr, code: 0 };
 		} catch (error: any) {
 			return {
@@ -38,38 +22,39 @@ async function main() {
 		}
 	};
 
+	const version = await execCmux(["--version"], { timeout: 5_000 });
+	if (version.killed || version.code !== 0 || !/^cmux 0\.64\.13(?:\s|$)/.test(version.stdout.trim())) {
+		throw new Error("E2E requires exactly cmux 0.64.13");
+	}
+
 	const client = new CmuxBrowserClient(execCmux);
-	const screenshotPath = join(fixtureDir, `${randomUUID()}.png`);
+	let verifiedSnapshot = false;
 	try {
 		const opened = await client.open(baseUrl);
-		if (!opened.surface || opened.exposure !== "synthetic") throw new Error("open returned no synthetic owned-surface result");
-		await client.browser(["wait", "--load-state", "complete", "--timeout-ms", "15000"], undefined, 20_000);
-
-		const before = await client.browser(["snapshot", "--interactive"], undefined, 20_000, { capture: true });
-		if (before.exposure !== "captured") throw new Error("snapshot was not classified as captured output");
-		const buttonRef = refFor(before.json, "Say hello");
-		await client.browser(["click", buttonRef]);
-
-		const after = await client.browser(["snapshot"], undefined, 20_000, { capture: true });
-		if (!after.stdout.includes("Clicked")) throw new Error("ref click did not update the native page");
-
-		await client.browser(["screenshot", "--out", screenshotPath], undefined, 30_000);
-		let handle;
-		try {
-			handle = await openFile(screenshotPath, constants.O_RDONLY | constants.O_NOFOLLOW);
-			const metadata = await handle.stat();
-			if (!metadata.isFile() || metadata.size === 0) throw new Error("screenshot is empty or not a regular file");
-		} finally {
-			await handle?.close().catch(() => undefined);
+		if (!opened.surface || opened.exposure !== "synthetic") {
+			throw new Error("open returned no synthetic owned-surface result");
 		}
 
-		await client.browser(["console", "list"], undefined, 20_000, { capture: true });
-		await client.browser(["errors", "list"], undefined, 20_000, { capture: true });
-		console.log(JSON.stringify({ ok: true, surface: "owned", native_ref_click: true, screenshot: true }));
+		let snapshotText = "";
+		let observedOrigin: string | undefined;
+		for (let attempt = 0; attempt < 20; attempt += 1) {
+			const snapshot = await client.browser(["snapshot", "--interactive"], undefined, 20_000, { captureSnapshot: true });
+			if (snapshot.exposure !== "captured") throw new Error("snapshot was not classified as captured output");
+			snapshotText = snapshot.stdout;
+			observedOrigin = snapshot.observedOrigin;
+			if (/\bbutton\b.*\[ref=e[1-9][0-9]*\]/.test(snapshotText)) break;
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+		if (!/\bbutton\b.*\[ref=e[1-9][0-9]*\]/.test(snapshotText)) {
+			throw new Error("native accessibility snapshot did not load the fixture structure");
+		}
+		if (observedOrigin !== new URL(baseUrl).origin) throw new Error("snapshot origin did not match the fixture origin");
+		verifiedSnapshot = true;
 	} finally {
-		await client.closeAll();
-		await rm(screenshotPath, { force: true }).catch(() => undefined);
+		if (!await client.closeAll()) throw new Error("native surface cleanup was not exactly acknowledged");
 	}
+	if (!verifiedSnapshot) throw new Error("native snapshot verification did not complete");
+	console.log(JSON.stringify({ ok: true, surface: "closed", native_accessibility_snapshot: true, cleanup_confirmed: true }));
 }
 
 main().catch((error) => {

--- a/cmux-browser/extension.test.ts
+++ b/cmux-browser/extension.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { access, writeFile } from "node:fs/promises";
+import test from "node:test";
+import cmuxBrowserExtension from "./index.ts";
+
+const SURFACE = "123e4567-e89b-42d3-a456-426614174000";
+
+type ExecOutput = { stdout?: string; stderr?: string; code?: number };
+
+type RegisteredTool = {
+	execute: (id: string, params: any, signal: AbortSignal | undefined, update: unknown, ctx: any) => Promise<any>;
+};
+
+function extensionHarness(outputs: ExecOutput[] = []) {
+	const calls: string[][] = [];
+	const tools = new Map<string, RegisteredTool>();
+	const handlers = new Map<string, (...args: any[]) => unknown>();
+	const pi = {
+		exec: async (_command: string, args: string[]) => {
+			calls.push(args);
+			const next = outputs.shift() ?? {};
+			return { stdout: next.stdout ?? JSON.stringify({ ok: true }), stderr: next.stderr ?? "", code: next.code ?? 0 };
+		},
+		on: (name: string, handler: (...args: any[]) => unknown) => handlers.set(name, handler),
+		registerTool: (tool: RegisteredTool & { name: string }) => tools.set(tool.name, tool),
+		registerCommand: () => undefined,
+	};
+	cmuxBrowserExtension(pi as any);
+	return { calls, handlers, pi, tools };
+}
+
+function uiContext(confirm: (title: string, message: string) => Promise<boolean> = async () => true) {
+	return {
+		hasUI: true,
+		mode: "tui",
+		ui: {
+			confirm,
+			notify: () => undefined,
+			setStatus: () => undefined,
+			theme: { fg: (_name: string, value: string) => value },
+		},
+	};
+}
+
+async function openOwned(tool: RegisteredTool, ctx: any): Promise<void> {
+	await tool.execute("open", { action: "open", url: "https://example.com/start" }, undefined, undefined, ctx);
+}
+
+test("registered tools deny shared-profile or origin access before invoking cmux", async () => {
+	for (const decisions of [[false], [true, false]]) {
+		let offset = 0;
+		const ctx = uiContext(async () => decisions[offset++] ?? false);
+		const { calls, tools } = extensionHarness();
+		await assert.rejects(
+			() => openOwned(tools.get("browser_navigate")!, ctx),
+			/shared cmux profile access was not approved|browser origin access was not approved/i,
+		);
+		assert.equal(calls.length, 0);
+	}
+});
+
+test("registered inspect emits exact documented get argv after revalidating origin", async () => {
+	const origin = JSON.stringify({ url: "https://example.com/private?ordinary=hidden" });
+	const { calls, tools } = extensionHarness([
+		{ stdout: JSON.stringify({ surface_id: SURFACE }) },
+		{ stdout: origin },
+		{ stdout: origin },
+		{ stdout: JSON.stringify({ snapshot: '- button "Submit" [ref=e4]' }) },
+		{ stdout: origin },
+		{ stdout: origin },
+		{ stdout: JSON.stringify({ value: "button" }) },
+	]);
+	const ctx = uiContext();
+	await openOwned(tools.get("browser_navigate")!, ctx);
+	await tools.get("browser_inspect")!.execute(
+		"snapshot",
+		{ action: "snapshot", interactive: true },
+		undefined,
+		undefined,
+		ctx,
+	);
+	await tools.get("browser_inspect")!.execute(
+		"inspect",
+		{ action: "get", property: "attr", target: "e4", attribute: "role" },
+		undefined,
+		undefined,
+		ctx,
+	);
+	assert.deepEqual(calls[6]?.slice(3), [
+		"browser", SURFACE, "get", "attr", "--selector", "e4", "--attr", "role",
+	]);
+});
+
+test("registered consequential action refuses an origin change while approval is pending", async () => {
+	const originA = JSON.stringify({ url: "https://example.com/one" });
+	const originB = JSON.stringify({ url: "https://other.example/two" });
+	const { calls, tools } = extensionHarness([
+		{ stdout: JSON.stringify({ surface_id: SURFACE }) },
+		{ stdout: originA },
+		{ stdout: originA },
+		{ stdout: originB },
+	]);
+	const ctx = uiContext();
+	await openOwned(tools.get("browser_navigate")!, ctx);
+	await assert.rejects(
+		() => tools.get("browser_interact")!.execute(
+			"click", { action: "click", target: "e1" }, undefined, undefined, ctx,
+		),
+		/origin changed while approval was pending/,
+	);
+	assert.equal(calls.some((args) => args.includes("click")), false);
+});
+
+test("registered screenshot returns bounded image content and removes its private path", async () => {
+	const calls: string[][] = [];
+	const tools = new Map<string, RegisteredTool>();
+	let screenshotPath: string | undefined;
+	const origin = JSON.stringify({ url: "https://example.com/private" });
+	let originReads = 0;
+	const pi = {
+		exec: async (_command: string, args: string[]) => {
+			calls.push(args);
+			if (args.includes("open")) return { stdout: JSON.stringify({ surface_id: SURFACE }), stderr: "", code: 0 };
+			if (args.includes("screenshot")) {
+				screenshotPath = args.at(-1);
+				await writeFile(screenshotPath!, "png-bytes", { mode: 0o666 });
+				return { stdout: JSON.stringify({ path: screenshotPath }), stderr: "", code: 0 };
+			}
+			if (args.includes("url")) {
+				originReads += 1;
+				return { stdout: origin, stderr: "", code: 0 };
+			}
+			return { stdout: JSON.stringify({ ok: true }), stderr: "", code: 0 };
+		},
+		on: () => undefined,
+		registerTool: (tool: RegisteredTool & { name: string }) => tools.set(tool.name, tool),
+		registerCommand: () => undefined,
+	};
+	cmuxBrowserExtension(pi as any);
+	const ctx = uiContext();
+	await openOwned(tools.get("browser_navigate")!, ctx);
+	const result = await tools.get("browser_inspect")!.execute(
+		"screenshot", { action: "screenshot" }, undefined, undefined, ctx,
+	);
+	assert.equal(originReads, 3);
+	assert.equal(result.content[1].type, "image");
+	assert.equal(Buffer.from(result.content[1].data, "base64").toString("utf8"), "png-bytes");
+	assert.ok(screenshotPath);
+	await assert.rejects(() => access(screenshotPath!));
+});
+
+test("registered screenshot removes its private path and suppresses raw failure diagnostics", async () => {
+	const tools = new Map<string, RegisteredTool>();
+	let screenshotPath: string | undefined;
+	const secret = "SCREENSHOT_FAILURE_SECRET_53";
+	const origin = JSON.stringify({ url: "https://example.com/private" });
+	const pi = {
+		exec: async (_command: string, args: string[]) => {
+			if (args.includes("open")) return { stdout: JSON.stringify({ surface_id: SURFACE }), stderr: "", code: 0 };
+			if (args.includes("url")) return { stdout: origin, stderr: "", code: 0 };
+			if (args.includes("screenshot")) {
+				screenshotPath = args.at(-1);
+				await writeFile(screenshotPath!, "partial-image", { mode: 0o600 });
+				return { stdout: "", stderr: `${secret} at ${screenshotPath}`, code: 1 };
+			}
+			return { stdout: JSON.stringify({ ok: true }), stderr: "", code: 0 };
+		},
+		on: () => undefined,
+		registerTool: (tool: RegisteredTool & { name: string }) => tools.set(tool.name, tool),
+		registerCommand: () => undefined,
+	};
+	cmuxBrowserExtension(pi as any);
+	const ctx = uiContext();
+	await openOwned(tools.get("browser_navigate")!, ctx);
+	await assert.rejects(
+		() => tools.get("browser_inspect")!.execute(
+			"screenshot", { action: "screenshot" }, undefined, undefined, ctx,
+		),
+		(error: Error) => !error.message.includes(secret) && !error.message.includes(screenshotPath!)
+			&& /Raw diagnostics were suppressed/.test(error.message),
+	);
+	assert.ok(screenshotPath);
+	await assert.rejects(() => access(screenshotPath!));
+});

--- a/cmux-browser/extension.test.ts
+++ b/cmux-browser/extension.test.ts
@@ -1,32 +1,42 @@
 import assert from "node:assert/strict";
-import { access, writeFile } from "node:fs/promises";
 import test from "node:test";
 import cmuxBrowserExtension from "./index.ts";
 
 const SURFACE = "123e4567-e89b-42d3-a456-426614174000";
 
-type ExecOutput = { stdout?: string; stderr?: string; code?: number };
+type ExecOutput = { stdout?: string; stderr?: string; code?: number; killed?: boolean };
 
 type RegisteredTool = {
+	executionMode?: "parallel" | "sequential";
 	execute: (id: string, params: any, signal: AbortSignal | undefined, update: unknown, ctx: any) => Promise<any>;
 };
 
-function extensionHarness(outputs: ExecOutput[] = []) {
+function extensionHarness(outputs: ExecOutput[] = [], version = "cmux 0.64.13 (93) [reviewed]") {
 	const calls: string[][] = [];
 	const tools = new Map<string, RegisteredTool>();
 	const handlers = new Map<string, (...args: any[]) => unknown>();
 	const pi = {
 		exec: async (_command: string, args: string[]) => {
-			calls.push(args);
+			const separator = args.indexOf("--");
+			const cmuxArgs = separator >= 0 ? args.slice(separator + 1) : args;
+			if (cmuxArgs.length === 1 && cmuxArgs[0] === "--version") {
+				return { stdout: version, stderr: "", code: 0, killed: false };
+			}
+			calls.push(cmuxArgs);
 			const next = outputs.shift() ?? {};
-			return { stdout: next.stdout ?? JSON.stringify({ ok: true }), stderr: next.stderr ?? "", code: next.code ?? 0 };
+			return {
+				stdout: next.stdout ?? JSON.stringify({ ok: true }),
+				stderr: next.stderr ?? "",
+				code: next.code ?? 0,
+				killed: next.killed,
+			};
 		},
 		on: (name: string, handler: (...args: any[]) => unknown) => handlers.set(name, handler),
 		registerTool: (tool: RegisteredTool & { name: string }) => tools.set(tool.name, tool),
 		registerCommand: () => undefined,
 	};
 	cmuxBrowserExtension(pi as any);
-	return { calls, handlers, pi, tools };
+	return { calls, handlers, tools };
 }
 
 function uiContext(confirm: (title: string, message: string) => Promise<boolean> = async () => true) {
@@ -43,8 +53,34 @@ function uiContext(confirm: (title: string, message: string) => Promise<boolean>
 }
 
 async function openOwned(tool: RegisteredTool, ctx: any): Promise<void> {
-	await tool.execute("open", { action: "open", url: "https://example.com/start" }, undefined, undefined, ctx);
+	await tool.execute("open", { action: "open", url: "https://example.com/" }, undefined, undefined, ctx);
 }
+
+function snapshot(origin: string, text: string, refs: Record<string, unknown> = {}) {
+	return {
+		stdout: JSON.stringify({
+			url: `${origin}/private?token=RAW_URL_SECRET`,
+			snapshot: text,
+			refs,
+			page: { text: "RAW_PAGE_SECRET", html: "<input value=RAW_HTML_SECRET>" },
+		}),
+	};
+}
+
+test("only navigation and atomic read-only snapshot tools are registered sequentially", () => {
+	const { tools } = extensionHarness();
+	assert.deepEqual([...tools.keys()].sort(), ["browser_inspect", "browser_navigate"]);
+	for (const tool of tools.values()) assert.equal(tool.executionMode, "sequential");
+});
+
+test("an unreviewed cmux version is refused before browser access", async () => {
+	const { calls, tools } = extensionHarness([], "cmux 0.64.14 (94) [unreviewed]");
+	await assert.rejects(
+		() => openOwned(tools.get("browser_navigate")!, uiContext()),
+		/requires exactly cmux 0\.64\.13/,
+	);
+	assert.equal(calls.length, 0);
+});
 
 test("registered tools deny shared-profile or origin access before invoking cmux", async () => {
 	for (const decisions of [[false], [true, false]]) {
@@ -59,126 +95,80 @@ test("registered tools deny shared-profile or origin access before invoking cmux
 	}
 });
 
-test("registered inspect emits exact documented get argv after revalidating origin", async () => {
-	const origin = JSON.stringify({ url: "https://example.com/private?ordinary=hidden" });
+test("snapshot strips all element names, including credential values behind misleading roles", async () => {
+	const secret = "MANUALLY_ENTERED_PASSWORD_53";
 	const { calls, tools } = extensionHarness([
 		{ stdout: JSON.stringify({ surface_id: SURFACE }) },
-		{ stdout: origin },
-		{ stdout: origin },
-		{ stdout: JSON.stringify({ snapshot: '- button "Submit" [ref=e4]' }) },
-		{ stdout: origin },
-		{ stdout: origin },
-		{ stdout: JSON.stringify({ value: "button" }) },
+		snapshot("https://example.com", `- button "${secret}" [ref=e4]\n- button "Submit" [ref=e5]`, {
+			e4: { role: "button", name: secret },
+			e5: { role: "button", name: "Submit" },
+		}),
 	]);
 	const ctx = uiContext();
 	await openOwned(tools.get("browser_navigate")!, ctx);
-	await tools.get("browser_inspect")!.execute(
+	const result = await tools.get("browser_inspect")!.execute(
 		"snapshot",
 		{ action: "snapshot", interactive: true },
 		undefined,
 		undefined,
 		ctx,
 	);
-	await tools.get("browser_inspect")!.execute(
-		"inspect",
-		{ action: "get", property: "attr", target: "e4", attribute: "role" },
-		undefined,
-		undefined,
-		ctx,
-	);
-	assert.deepEqual(calls[6]?.slice(3), [
-		"browser", SURFACE, "get", "attr", "--selector", "e4", "--attr", "role",
-	]);
+	assert.equal(result.content[0].text, "- button [ref=e4]\n- button [ref=e5]");
+	assert.equal(JSON.stringify(result).includes(secret), false);
+	assert.equal(JSON.stringify(result).includes("RAW_PAGE_SECRET"), false);
+	assert.deepEqual(calls[1]?.slice(3), ["browser", SURFACE, "snapshot", "--interactive"]);
 });
 
-test("registered consequential action refuses an origin change while approval is pending", async () => {
-	const originA = JSON.stringify({ url: "https://example.com/one" });
-	const originB = JSON.stringify({ url: "https://other.example/two" });
-	const { calls, tools } = extensionHarness([
+test("an unapproved snapshot origin is approved before a fresh same-origin snapshot is released", async () => {
+	const prompts: string[] = [];
+	const { tools } = extensionHarness([
 		{ stdout: JSON.stringify({ surface_id: SURFACE }) },
-		{ stdout: originA },
-		{ stdout: originA },
-		{ stdout: originB },
+		snapshot("https://redirected.example", '- document "private first capture"'),
+		snapshot("https://redirected.example", '- document "fresh"\n- text "approved fresh capture"'),
 	]);
-	const ctx = uiContext();
-	await openOwned(tools.get("browser_navigate")!, ctx);
-	await assert.rejects(
-		() => tools.get("browser_interact")!.execute(
-			"click", { action: "click", target: "e1" }, undefined, undefined, ctx,
-		),
-		/origin changed while approval was pending/,
-	);
-	assert.equal(calls.some((args) => args.includes("click")), false);
-});
-
-test("registered screenshot returns bounded image content and removes its private path", async () => {
-	const calls: string[][] = [];
-	const tools = new Map<string, RegisteredTool>();
-	let screenshotPath: string | undefined;
-	const origin = JSON.stringify({ url: "https://example.com/private" });
-	let originReads = 0;
-	const pi = {
-		exec: async (_command: string, args: string[]) => {
-			calls.push(args);
-			if (args.includes("open")) return { stdout: JSON.stringify({ surface_id: SURFACE }), stderr: "", code: 0 };
-			if (args.includes("screenshot")) {
-				screenshotPath = args.at(-1);
-				await writeFile(screenshotPath!, "png-bytes", { mode: 0o666 });
-				return { stdout: JSON.stringify({ path: screenshotPath }), stderr: "", code: 0 };
-			}
-			if (args.includes("url")) {
-				originReads += 1;
-				return { stdout: origin, stderr: "", code: 0 };
-			}
-			return { stdout: JSON.stringify({ ok: true }), stderr: "", code: 0 };
-		},
-		on: () => undefined,
-		registerTool: (tool: RegisteredTool & { name: string }) => tools.set(tool.name, tool),
-		registerCommand: () => undefined,
-	};
-	cmuxBrowserExtension(pi as any);
-	const ctx = uiContext();
+	const ctx = uiContext(async (_title, message) => {
+		prompts.push(message);
+		return true;
+	});
 	await openOwned(tools.get("browser_navigate")!, ctx);
 	const result = await tools.get("browser_inspect")!.execute(
-		"screenshot", { action: "screenshot" }, undefined, undefined, ctx,
+		"snapshot", { action: "snapshot" }, undefined, undefined, ctx,
 	);
-	assert.equal(originReads, 3);
-	assert.equal(result.content[1].type, "image");
-	assert.equal(Buffer.from(result.content[1].data, "base64").toString("utf8"), "png-bytes");
-	assert.ok(screenshotPath);
-	await assert.rejects(() => access(screenshotPath!));
+	assert.equal(result.content[0].text, '- document\n- text "approved fresh capture"');
+	assert.equal(result.content[0].text.includes("first capture"), false);
+	assert.ok(prompts.some((message) => message.includes("https://redirected.example")));
 });
 
-test("registered screenshot removes its private path and suppresses raw failure diagnostics", async () => {
-	const tools = new Map<string, RegisteredTool>();
-	let screenshotPath: string | undefined;
-	const secret = "SCREENSHOT_FAILURE_SECRET_53";
-	const origin = JSON.stringify({ url: "https://example.com/private" });
-	const pi = {
-		exec: async (_command: string, args: string[]) => {
-			if (args.includes("open")) return { stdout: JSON.stringify({ surface_id: SURFACE }), stderr: "", code: 0 };
-			if (args.includes("url")) return { stdout: origin, stderr: "", code: 0 };
-			if (args.includes("screenshot")) {
-				screenshotPath = args.at(-1);
-				await writeFile(screenshotPath!, "partial-image", { mode: 0o600 });
-				return { stdout: "", stderr: `${secret} at ${screenshotPath}`, code: 1 };
-			}
-			return { stdout: JSON.stringify({ ok: true }), stderr: "", code: 0 };
-		},
-		on: () => undefined,
-		registerTool: (tool: RegisteredTool & { name: string }) => tools.set(tool.name, tool),
-		registerCommand: () => undefined,
-	};
-	cmuxBrowserExtension(pi as any);
+test("snapshot refuses content when the atomically reported origin changes during approval", async () => {
+	const { tools } = extensionHarness([
+		{ stdout: JSON.stringify({ surface_id: SURFACE }) },
+		snapshot("https://redirected.example", '- document "FIRST_SECRET"'),
+		snapshot("https://other.example", '- document "SECOND_SECRET"'),
+	]);
 	const ctx = uiContext();
 	await openOwned(tools.get("browser_navigate")!, ctx);
 	await assert.rejects(
 		() => tools.get("browser_inspect")!.execute(
-			"screenshot", { action: "screenshot" }, undefined, undefined, ctx,
+			"snapshot", { action: "snapshot" }, undefined, undefined, ctx,
 		),
-		(error: Error) => !error.message.includes(secret) && !error.message.includes(screenshotPath!)
-			&& /Raw diagnostics were suppressed/.test(error.message),
+		(error: Error) => /origin changed while approval was pending/.test(error.message)
+			&& !error.message.includes("FIRST_SECRET") && !error.message.includes("SECOND_SECRET"),
 	);
-	assert.ok(screenshotPath);
-	await assert.rejects(() => access(screenshotPath!));
+});
+
+test("a failed shutdown close blocks opens after extension replacement", async () => {
+	const first = extensionHarness([
+		{ stdout: JSON.stringify({ surface_id: SURFACE }) },
+		{ code: 1, stderr: "shutdown close failed" },
+	]);
+	const ctx = uiContext();
+	await openOwned(first.tools.get("browser_navigate")!, ctx);
+	await first.handlers.get("session_shutdown")!({ reason: "reload" }, ctx);
+
+	const replacement = extensionHarness();
+	await assert.rejects(
+		() => openOwned(replacement.tools.get("browser_navigate")!, ctx),
+		/open lifecycle is uncertain/,
+	);
+	assert.equal(replacement.calls.length, 0);
 });

--- a/cmux-browser/index.ts
+++ b/cmux-browser/index.ts
@@ -1,48 +1,21 @@
-import { readFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { truncateHead } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { CmuxBrowserClient, type BrowserCommandResult } from "./client.ts";
+import { INSPECTION_ATTRIBUTES, inspectionArguments, navigationTarget, snapshotRef, toolResult, type BrowserDetails, type NavigationTarget } from "./policy.ts";
+import { readPrivateImage } from "./private-image.ts";
 
-interface BrowserDetails {
-	action: string;
-	surface?: string;
-	command: string[];
-	json?: unknown;
-	output?: string;
-	path?: string;
-}
-
-function compactOutput(result: BrowserCommandResult): string {
-	const raw = result.stdout.trim() || result.stderr.trim() || "ok";
-	const truncated = truncateHead(raw, { maxBytes: 50 * 1024, maxLines: 2_000 });
-	return truncated.truncated
-		? `${truncated.content}\n\n[Output truncated: ${truncated.outputLines}/${truncated.totalLines} lines, ${truncated.outputBytes}/${truncated.totalBytes} bytes]`
-		: truncated.content;
-}
-
-function toolResult(action: string, result: BrowserCommandResult, path?: string) {
-	const output = compactOutput(result);
-	const details: BrowserDetails = {
-		action,
-		surface: result.surface,
-		command: result.args,
-		json: result.json,
-		output,
-		path,
-	};
-	return { content: [{ type: "text" as const, text: output }], details };
-}
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 
 function renderCall(name: string) {
-	return (args: { action?: string; surface?: string }, theme: any) =>
+	return (args: { action?: string }, theme: any) =>
 		new Text(
-			`${theme.fg("toolTitle", theme.bold(name))} ${theme.fg("accent", args.action ?? "")} ${theme.fg("dim", args.surface ?? "active surface")}`,
+			`${theme.fg("toolTitle", theme.bold(name))} ${theme.fg("accent", args.action ?? "")}`,
 			0,
 			0,
 		);
@@ -54,37 +27,87 @@ function renderResult(result: { details?: BrowserDetails }, options: { expanded:
 	if (!details) return new Text(theme.fg("success", "✓ browser operation complete"), 0, 0);
 	let text = `${theme.fg("success", "✓")} ${details.action}`;
 	if (details.surface) text += ` ${theme.fg("dim", details.surface)}`;
-	if (details.path) text += ` ${theme.fg("dim", details.path)}`;
 	if (options.expanded && details.output) text += `\n${theme.fg("toolOutput", details.output)}`;
 	return new Text(text, 0, 0);
 }
 
-function recoverSurface(ctx: any): string | undefined {
-	const branch = ctx.sessionManager.getBranch();
-	for (let index = branch.length - 1; index >= 0; index--) {
-		const entry = branch[index];
-		if (entry?.type !== "message" || entry.message?.role !== "toolResult") continue;
-		if (!entry.message.toolName?.startsWith("browser_")) continue;
-		const surface = entry.message.details?.surface;
-		if (typeof surface === "string" && surface.trim()) return surface;
-	}
-	return undefined;
-}
-
 export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 	const client = new CmuxBrowserClient((args, options) => pi.exec("cmux", args, options));
+	const approvedOrigins = new Set<string>();
+	let sharedProfileApproved = false;
+	let privateRootPromise: Promise<string> | undefined;
+
+	async function privateRoot(): Promise<string> {
+		privateRootPromise ??= mkdtemp(join(tmpdir(), "pi-cmux-browser-")).then(async (path) => {
+			await chmod(path, 0o700);
+			return path;
+		});
+		return privateRootPromise;
+	}
+
+	async function cleanupPrivateRoot(): Promise<void> {
+		if (!privateRootPromise) return;
+		const root = await privateRootPromise.catch(() => undefined);
+		if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
+		privateRootPromise = undefined;
+	}
+
+	async function approveSharedProfile(ctx: any): Promise<void> {
+		if (sharedProfileApproved) return;
+		if (!ctx.hasUI) throw new Error("cmux profile access requires approval in Pi TUI mode.");
+		const approved = await ctx.ui.confirm(
+			"Use cmux's currently selected browser profile?",
+			"cmux 0.64.13 cannot select a profile when automation opens a browser surface. The new pane therefore uses cmux's current profile, which may be shared with other cmux panes. For stronger isolation, cancel, select a dedicated profile in cmux, then retry. The extension will not read, create, switch, clear, or delete profiles.",
+		);
+		if (!approved) throw new Error("Shared cmux profile access was not approved.");
+		sharedProfileApproved = true;
+	}
+
+	async function approveOrigin(ctx: any, target: NavigationTarget, purpose: string): Promise<void> {
+		if (approvedOrigins.has(target.origin)) return;
+		if (!ctx.hasUI) throw new Error("New browser origins require approval in Pi TUI mode.");
+		const approved = await ctx.ui.confirm(
+			"Allow model browser access to this origin?",
+			`${target.origin}\n\nPurpose: ${purpose}\n\nThis uses cmux's currently selected browser profile. Credentials and tokens must be entered manually in the native pane.`,
+		);
+		if (!approved) throw new Error("Browser origin access was not approved.");
+		approvedOrigins.add(target.origin);
+	}
+
+	async function currentApprovedOrigin(ctx: any, signal: AbortSignal | undefined, purpose: string): Promise<string> {
+		const origin = await client.currentOrigin(signal);
+		await approveOrigin(ctx, { url: origin, origin }, purpose);
+		const revalidatedOrigin = await client.currentOrigin(signal);
+		if (revalidatedOrigin !== origin) {
+			throw new Error("The browser origin changed while approval was pending; action refused. Review the native pane and retry.");
+		}
+		return origin;
+	}
+
+	async function approveSensitiveAction(ctx: any, signal: AbortSignal | undefined, action: string): Promise<string> {
+		const origin = await currentApprovedOrigin(ctx, signal, action);
+		if (!ctx.hasUI) throw new Error("Consequential browser actions require approval in Pi TUI mode.");
+		const approved = await ctx.ui.confirm(
+			`Allow browser action: ${action}?`,
+			`${origin}\n\nReview the native browser pane first. Do not approve credential entry, purchases, submissions, deletions, permission changes, or other external side effects unless you explicitly requested them.`,
+		);
+		if (!approved) throw new Error(`Browser action ${action} was not approved.`);
+		const revalidatedOrigin = await client.currentOrigin(signal);
+		if (revalidatedOrigin !== origin) {
+			throw new Error("The browser origin changed while approval was pending; action refused. Review the native pane and retry.");
+		}
+		return origin;
+	}
 
 	pi.on("session_start", (_event, ctx) => {
-		client.setActiveSurface(recoverSurface(ctx));
-		if (ctx.mode === "tui") {
-			ctx.ui.setStatus(
-				"cmux-browser",
-				ctx.ui.theme.fg("dim", client.getActiveSurface() ? "browser ready" : "browser idle"),
-			);
-		}
+		if (ctx.mode === "tui") ctx.ui.setStatus("cmux-browser", ctx.ui.theme.fg("dim", "browser idle"));
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
+	pi.on("session_shutdown", async (_event, ctx) => {
+		await client.closeAll();
+		await cleanupPrivateRoot();
+		approvedOrigins.clear();
+		sharedProfileApproved = false;
 		if (ctx.hasUI) ctx.ui.setStatus("cmux-browser", undefined);
 	});
 
@@ -92,43 +115,48 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		name: "browser_navigate",
 		label: "Browser Navigate",
 		description:
-			"Open and navigate the native cmux browser pane. New panes always open beside the calling Pi workspace with focus=false. Use open first; later calls reuse the active surface unless surface is provided.",
-		promptSnippet: "Open or navigate the native cmux browser pane without stealing focus",
+			"Open and navigate one extension-owned native cmux browser pane. New origins require approval, new panes never steal focus, and local/custom URL schemes are refused.",
+		promptSnippet: "Open or navigate the owned native cmux browser pane without stealing focus",
 		promptGuidelines: [
-			"Use browser_navigate action=open to create a native cmux browser surface; do not launch an external browser process.",
-			"After browser_navigate changes the page, use browser_inspect action=snapshot to obtain fresh element refs.",
+			"Use action=open once; later calls reuse only this Pi session's owned surface.",
+			"Never put credentials, tokens, signed secrets, or local-file URLs in navigation parameters; ask the user to enter them in the native pane.",
 		],
 		parameters: Type.Object({
-			action: StringEnum(["open", "goto", "back", "forward", "reload", "url", "title", "status", "close"] as const),
-			url: Type.Optional(Type.String({ description: "URL for open or goto" })),
-			surface: Type.Optional(Type.String({ description: "cmux surface UUID/ref; defaults to the active surface" })),
-			workspace: Type.Optional(Type.String({ description: "Optional cmux workspace UUID/ref for open" })),
+			action: StringEnum(["open", "goto", "reload", "origin", "close"] as const),
+			url: Type.Optional(Type.String({ description: "Absolute http(s) URL or exactly about:blank" })),
 		}),
-		async execute(_id, params, signal) {
+		async execute(_id, params, signal, _update, ctx) {
 			let result: BrowserCommandResult;
 			switch (params.action) {
-				case "open":
+				case "open": {
 					if (!params.url) throw new Error("url is required for open");
-					result = await client.open(params.url, params.workspace, signal);
+					const target = navigationTarget(params.url);
+					await approveSharedProfile(ctx);
+					await approveOrigin(ctx, target, "open a native browser surface");
+					result = await client.open(target.url, signal);
 					break;
-				case "goto":
+				}
+				case "goto": {
 					if (!params.url) throw new Error("url is required for goto");
-					result = await client.browser(params.surface, ["goto", params.url, "--snapshot-after"], signal, 30_000);
+					const target = navigationTarget(params.url);
+					await approveOrigin(ctx, target, "navigate the active surface");
+					result = await client.browser(["goto", target.url], signal, 30_000, { success: { ok: true, navigated: true } });
 					break;
-				case "back":
-				case "forward":
+				}
 				case "reload":
-					result = await client.browser(params.surface, [params.action, "--snapshot-after"], signal, 30_000);
+					await currentApprovedOrigin(ctx, signal, "reload the active page");
+					result = await client.browser(["reload"], signal, 30_000, { success: { ok: true, navigated: true } });
 					break;
-				case "url":
-				case "title":
-					result = await client.browser(params.surface, ["get", params.action], signal);
+				case "origin": {
+					const origin = await currentApprovedOrigin(ctx, signal, "read the active page origin");
+					result = {
+						command: ["browser", "get"], stdout: origin, stderr: "", surface: client.getActiveSurface(), exposure: "captured",
+					};
 					break;
-				case "status":
-					result = await client.run(["browser", "status"], signal);
-					break;
+				}
 				case "close":
-					result = await client.closeSurface(params.surface, signal);
+					result = await client.closeActive(signal);
+					approvedOrigins.clear();
 					break;
 			}
 			return toolResult(params.action, result);
@@ -141,27 +169,26 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		name: "browser_inspect",
 		label: "Browser Inspect",
 		description:
-			"Inspect or debug the active native cmux browser: accessibility/DOM snapshot, text/html/value/attributes/count/box/styles, page JavaScript, screenshot, console, errors, or highlight. Outputs are capped at 50KB/2000 lines.",
-		promptSnippet: "Snapshot, inspect, screenshot, or debug the native cmux browser",
+			"Inspect the approved origin on the owned native cmux browser surface: accessibility/DOM snapshot, bounded property reads, screenshots, console, errors, or highlight. Arbitrary page JavaScript is intentionally not exposed.",
+		promptSnippet: "Snapshot, inspect, screenshot, or debug the owned native cmux browser",
 		promptGuidelines: [
-			"Use browser_inspect action=snapshot with interactive=true before browser_interact, and obtain fresh refs after DOM or navigation changes.",
-			"Use browser_inspect action=screenshot when visual evidence matters; it returns the PNG to the model and saves it at path.",
+			"Use snapshot with interactive=true before browser_interact; obtain fresh refs after DOM or navigation changes.",
+			"Screenshots require explicit approval, are capped at 10 MiB, and are deleted from the private temp root immediately after reading.",
 		],
 		parameters: Type.Object({
-			action: StringEnum(["snapshot", "get", "eval", "screenshot", "console", "errors", "highlight"] as const),
-			surface: Type.Optional(Type.String()),
+			action: StringEnum(["snapshot", "get", "screenshot", "console", "errors", "highlight"] as const),
 			interactive: Type.Optional(Type.Boolean({ default: true })),
 			compact: Type.Optional(Type.Boolean()),
 			max_depth: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
-			selector: Type.Optional(Type.String()),
-			property: Type.Optional(StringEnum(["url", "title", "text", "html", "value", "attr", "count", "box", "styles"] as const)),
-			attribute: Type.Optional(Type.String()),
-			style_property: Type.Optional(Type.String()),
-			script: Type.Optional(Type.String()),
-			output_path: Type.Optional(Type.String({ description: "PNG path for screenshot; defaults to a temp file" })),
+			target: Type.Optional(Type.String({ description: "Fresh snapshot ref such as e3" })),
+			property: Type.Optional(StringEnum(["text", "attr", "count", "box"] as const)),
+			attribute: Type.Optional(StringEnum(INSPECTION_ATTRIBUTES, { description: "Allowlisted non-value metadata attribute when property=attr." })),
 		}),
 		async execute(_id, params, signal, _update, ctx) {
+			if (params.action === "screenshot") await approveSensitiveAction(ctx, signal, "share a screenshot with the model");
+			else await currentApprovedOrigin(ctx, signal, `inspect page (${params.action})`);
 			let args: string[];
+			let capture = true;
 			let screenshotPath: string | undefined;
 			switch (params.action) {
 				case "snapshot":
@@ -169,42 +196,36 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 					if (params.interactive !== false) args.push("--interactive");
 					if (params.compact) args.push("--compact");
 					if (params.max_depth) args.push("--max-depth", String(params.max_depth));
-					if (params.selector) args.push("--selector", params.selector);
 					break;
 				case "get":
 					if (!params.property) throw new Error("property is required for get");
-					args = ["get", params.property];
-					if (params.selector) args.push("--selector", params.selector);
-					if (params.property === "attr") {
-						if (!params.attribute) throw new Error("attribute is required for get attr");
-						args.push("--attr", params.attribute);
-					}
-					if (params.property === "styles" && params.style_property) args.push("--property", params.style_property);
-					break;
-				case "eval":
-					if (!params.script) throw new Error("script is required for eval");
-					args = ["eval", "--script", params.script];
+					args = inspectionArguments(params.property, params.target ?? "", params.attribute);
 					break;
 				case "screenshot":
-					screenshotPath = resolve(ctx.cwd, params.output_path?.replace(/^@/, "") ?? `${tmpdir()}/pi-cmux-${randomUUID()}.png`);
+					screenshotPath = join(await privateRoot(), `${randomUUID()}.png`);
 					args = ["screenshot", "--out", screenshotPath];
+					capture = false;
 					break;
 				case "console":
 				case "errors":
 					args = [params.action, "list"];
 					break;
 				case "highlight":
-					if (!params.selector) throw new Error("selector is required for highlight");
-					args = ["highlight", "--selector", params.selector];
+					args = ["highlight", "--selector", snapshotRef(params.target, "highlight")];
+					capture = false;
 					break;
 			}
-			const result = await client.browser(params.surface, args, signal, params.action === "screenshot" ? 30_000 : 20_000);
-			const response = toolResult(params.action, result, screenshotPath);
-			if (screenshotPath) {
-				const data = (await readFile(screenshotPath)).toString("base64");
-				response.content.push({ type: "image" as const, data, mimeType: "image/png" } as any);
+			try {
+				const result = await client.browser(args, signal, params.action === "screenshot" ? 30_000 : 20_000, capture ? { capture: true } : undefined);
+				const response = toolResult(params.action, result);
+				if (screenshotPath) {
+					const data = await readPrivateImage(screenshotPath, MAX_IMAGE_BYTES);
+					response.content.push({ type: "image" as const, data, mimeType: "image/png" } as any);
+				}
+				return response;
+			} finally {
+				if (screenshotPath) await rm(screenshotPath, { force: true }).catch(() => undefined);
 			}
-			return response;
 		},
 		renderCall: renderCall("inspect"),
 		renderResult,
@@ -214,158 +235,94 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		name: "browser_interact",
 		label: "Browser Interact",
 		description:
-			"Interact with the active native cmux browser using a fresh snapshot ref or CSS selector. Supports click, double click, hover, focus, fill, type, key events, select, checkbox, scrolling, waits, and scroll-into-view.",
-		promptSnippet: "Interact with snapshot refs or selectors in the native cmux browser",
+			"Interact with fresh snapshot refs on the approved origin. Text/value entry and arbitrary CSS selectors are intentionally absent so credentials and other values never enter process arguments; enter them manually in the native pane.",
+		promptSnippet: "Interact with fresh snapshot refs on the owned native cmux browser",
 		promptGuidelines: [
-			"Use browser_interact with fresh browser_inspect snapshot refs; re-snapshot after navigation, modal changes, or major DOM updates.",
-			"Prefer browser_interact fill over type when replacing an input value, and use wait instead of polling snapshots.",
+			"Use fresh snapshot refs and re-snapshot after navigation or major DOM changes.",
+			"Ask the user to enter all text, selections, credentials, tokens, and one-time codes directly in the native pane.",
 		],
 		parameters: Type.Object({
-			action: StringEnum(["click", "dblclick", "hover", "focus", "fill", "type", "press", "keydown", "keyup", "select", "check", "uncheck", "scroll", "scroll_into_view", "wait"] as const),
-			surface: Type.Optional(Type.String()),
-			target: Type.Optional(Type.String({ description: "Fresh element ref or CSS selector" })),
-			text: Type.Optional(Type.String()),
-			key: Type.Optional(Type.String()),
-			value: Type.Optional(Type.String()),
-			dx: Type.Optional(Type.Number()),
-			dy: Type.Optional(Type.Number()),
-			wait_text: Type.Optional(Type.String()),
-			url: Type.Optional(Type.String()),
-			url_contains: Type.Optional(Type.String()),
+			action: StringEnum(["click", "dblclick", "hover", "focus", "press", "check", "uncheck", "scroll", "scroll_into_view", "wait"] as const),
+			target: Type.Optional(Type.String({ description: "Fresh snapshot ref such as e3" })),
+			key: Type.Optional(StringEnum(["Enter", "Tab", "Escape", "Backspace", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End", "PageUp", "PageDown", "Space"] as const)),
+			dx: Type.Optional(Type.Number({ minimum: -10000, maximum: 10000 })),
+			dy: Type.Optional(Type.Number({ minimum: -10000, maximum: 10000 })),
 			load_state: Type.Optional(StringEnum(["interactive", "complete"] as const)),
-			function_js: Type.Optional(Type.String()),
 			timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 120_000, default: 15_000 })),
 		}),
-		async execute(_id, params, signal) {
+		async execute(_id, params, signal, _update, ctx) {
+			const consequential = ["click", "dblclick", "press", "check", "uncheck"].includes(params.action);
+			if (consequential) await approveSensitiveAction(ctx, signal, params.action);
+			else await currentApprovedOrigin(ctx, signal, params.action);
 			let args: string[];
 			const simpleTarget = ["click", "dblclick", "hover", "focus", "check", "uncheck", "scroll_into_view"].includes(params.action);
 			if (simpleTarget) {
-				if (!params.target) throw new Error(`target is required for ${params.action}`);
-				args = [params.action === "scroll_into_view" ? "scroll-into-view" : params.action, params.target, "--snapshot-after"];
-			} else if (params.action === "fill" || params.action === "type") {
-				if (!params.target || params.text === undefined) throw new Error(`target and text are required for ${params.action}`);
-				args = [params.action, params.target, params.text, "--snapshot-after"];
-			} else if (["press", "keydown", "keyup"].includes(params.action)) {
-				if (!params.key) throw new Error(`key is required for ${params.action}`);
-				args = [params.action, "--key", params.key, "--snapshot-after"];
-			} else if (params.action === "select") {
-				if (!params.target || params.value === undefined) throw new Error("target and value are required for select");
-				args = ["select", params.target, params.value, "--snapshot-after"];
+				const target = snapshotRef(params.target, params.action);
+				args = [params.action === "scroll_into_view" ? "scroll-into-view" : params.action, target];
+			} else if (params.action === "press") {
+				if (!params.key) throw new Error("key is required for press");
+				args = ["press", "--key", params.key];
 			} else if (params.action === "scroll") {
 				args = ["scroll"];
-				if (params.target) args.push("--selector", params.target);
+				if (params.target) args.push("--selector", snapshotRef(params.target, "scroll"));
 				if (params.dx !== undefined) args.push("--dx", String(params.dx));
 				if (params.dy !== undefined) args.push("--dy", String(params.dy));
-				args.push("--snapshot-after");
 			} else {
 				args = ["wait"];
-				if (params.target) args.push("--selector", params.target);
-				if (params.wait_text) args.push("--text", params.wait_text);
-				if (params.url) args.push("--url", params.url);
-				if (params.url_contains) args.push("--url-contains", params.url_contains);
+				if (params.target) args.push("--selector", snapshotRef(params.target, "wait"));
 				if (params.load_state) args.push("--load-state", params.load_state);
-				if (params.function_js) args.push("--function", params.function_js);
-				if (args.length === 1) throw new Error("wait requires target, wait_text, url, url_contains, load_state, or function_js");
+				if (args.length === 1) throw new Error("wait requires target or load_state");
 				args.push("--timeout-ms", String(params.timeout_ms ?? 15_000));
 			}
 			const timeout = params.action === "wait" ? (params.timeout_ms ?? 15_000) + 5_000 : 30_000;
-			return toolResult(params.action, await client.browser(params.surface, args, signal, timeout));
+			return toolResult(params.action, await client.browser(args, signal, timeout, { success: { ok: true, interacted: true } }));
 		},
 		renderCall: renderCall("interact"),
 		renderResult,
 	});
 
 	pi.registerTool({
-		name: "browser_session",
-		label: "Browser Session",
+		name: "browser_download",
+		label: "Browser Download",
 		description:
-			"Manage native cmux browser tabs, profile/state lifecycle, downloads, and explicit local-file uploads. Auth stays in cmux's supported profile/data store; this tool does not read credential stores or print uploaded file contents.",
-		promptSnippet: "Manage tabs, browser state/profiles, uploads, and downloads",
+			"Wait for a download managed by the owned native cmux browser. Download host paths and raw cmux output are intentionally not returned.",
+		promptSnippet: "Wait for a user-approved download on the owned browser",
 		promptGuidelines: [
-			"Use browser_session state_save/state_load or cmux profiles for supported authenticated browser continuity; never scrape credential stores.",
-			"Use browser_session upload only with an explicit local path and file-input selector; the operation sends that file to the currently loaded page without printing its contents.",
+			"Ask the user to handle uploads, credentials, and any downloaded-file opening directly in the native pane or filesystem.",
 		],
 		parameters: Type.Object({
-			action: StringEnum(["tab_list", "tab_new", "tab_switch", "tab_close", "state_save", "state_load", "profile_list", "profile_add", "profile_rename", "profile_delete", "download_wait", "upload"] as const),
-			surface: Type.Optional(Type.String()),
-			url: Type.Optional(Type.String()),
-			index: Type.Optional(Type.Integer({ minimum: 0 })),
-			path: Type.Optional(Type.String()),
-			selector: Type.Optional(Type.String()),
-			name: Type.Optional(Type.String()),
-			new_name: Type.Optional(Type.String()),
+			action: StringEnum(["wait"] as const),
 			timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 120_000, default: 30_000 })),
 		}),
 		async execute(_id, params, signal, _update, ctx) {
-			if (params.action === "upload") {
-				if (!params.path || !params.selector) throw new Error("path and selector are required for upload");
-				if (!ctx.hasUI) throw new Error("Browser uploads require interactive approval in Pi TUI/RPC mode.");
-				const absolutePath = resolve(ctx.cwd, params.path.replace(/^@/, ""));
-				const approved = await ctx.ui.confirm(
-					"Upload local file to this page?",
-					`${absolutePath}\n\nTarget: ${params.selector}`,
-				);
-				if (!approved) throw new Error("Browser upload cancelled by user.");
-				return toolResult(params.action, await client.upload(params.surface, params.selector, params.path, ctx.cwd, signal));
-			}
-			if (params.action === "profile_delete") {
-				if (!params.name) throw new Error("name is required for profile_delete");
-				if (!ctx.hasUI || !(await ctx.ui.confirm("Delete cmux browser profile?", params.name))) {
-					throw new Error("Browser profile deletion cancelled by user.");
-				}
-			}
-			let args: string[];
-			switch (params.action) {
-				case "tab_list": args = ["tab", "list"]; break;
-				case "tab_new": args = ["tab", "new", ...(params.url ? [params.url] : [])]; break;
-				case "tab_switch":
-				case "tab_close":
-					if (params.index === undefined) throw new Error(`index is required for ${params.action}`);
-					args = ["tab", params.action === "tab_switch" ? "switch" : "close", String(params.index)];
-					break;
-				case "state_save":
-				case "state_load":
-					if (!params.path) throw new Error(`path is required for ${params.action}`);
-					args = ["state", params.action === "state_save" ? "save" : "load", resolve(ctx.cwd, params.path.replace(/^@/, ""))];
-					break;
-				case "profile_list": args = ["profiles", "list"]; break;
-				case "profile_add":
-					if (!params.name) throw new Error("name is required for profile_add");
-					args = ["profiles", "add", params.name];
-					break;
-				case "profile_rename":
-					if (!params.name || !params.new_name) throw new Error("name and new_name are required for profile_rename");
-					args = ["profiles", "rename", params.name, params.new_name];
-					break;
-				case "profile_delete":
-					if (!params.name) throw new Error("name is required for profile_delete");
-					args = ["profiles", "delete", params.name];
-					break;
-				case "download_wait":
-					args = ["download", "wait", "--timeout-ms", String(params.timeout_ms ?? 30_000)];
-					if (params.path) args.push("--path", resolve(ctx.cwd, params.path.replace(/^@/, "")));
-					break;
-				default: throw new Error(`Unsupported session action: ${params.action}`);
-			}
-			const timeout = params.action === "download_wait" ? (params.timeout_ms ?? 30_000) + 5_000 : 30_000;
-			const isProfileAction = params.action.startsWith("profile_");
-			const result = isProfileAction
-				? await client.run(["browser", ...args], signal, timeout)
-				: await client.browser(params.surface, args, signal, timeout);
+			await approveSensitiveAction(ctx, signal, "wait for a cmux-managed download");
+			const timeout = (params.timeout_ms ?? 30_000) + 5_000;
+			const result = await client.browser(
+				["download", "wait", "--timeout-ms", String(params.timeout_ms ?? 30_000)],
+				signal,
+				timeout,
+				{ success: { ok: true, download_ready: true } },
+			);
 			return toolResult(params.action, result);
 		},
-		renderCall: renderCall("session"),
+		renderCall: renderCall("download"),
 		renderResult,
 	});
 
 	pi.registerCommand("browser", {
-		description: "Open a URL in a native cmux browser pane without moving focus",
+		description: "Open or navigate the owned native cmux browser pane without moving focus",
 		handler: async (args, ctx) => {
-			const url = args.trim() || "about:blank";
 			try {
-				const result = await client.open(url, undefined);
+				const target = navigationTarget(args.trim() || "about:blank");
+				await approveSharedProfile(ctx);
+				approvedOrigins.add(target.origin); // Direct slash-command input is explicit user authorization for this origin.
+				if (client.getActiveSurface()) {
+					await client.browser(["goto", target.url], undefined, 30_000, { success: { ok: true, navigated: true } });
+				} else {
+					await client.open(target.url);
+				}
 				ctx.ui.setStatus("cmux-browser", ctx.ui.theme.fg("success", "browser ready"));
-				ctx.ui.notify(`Opened native browser ${result.surface ?? "surface"} without changing focus`, "info");
+				ctx.ui.notify("Native browser ready on the owned surface", "info");
 			} catch (error) {
 				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 			}

--- a/cmux-browser/index.ts
+++ b/cmux-browser/index.ts
@@ -1,0 +1,374 @@
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { truncateHead } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { CmuxBrowserClient, type BrowserCommandResult } from "./client.ts";
+
+interface BrowserDetails {
+	action: string;
+	surface?: string;
+	command: string[];
+	json?: unknown;
+	output?: string;
+	path?: string;
+}
+
+function compactOutput(result: BrowserCommandResult): string {
+	const raw = result.stdout.trim() || result.stderr.trim() || "ok";
+	const truncated = truncateHead(raw, { maxBytes: 50 * 1024, maxLines: 2_000 });
+	return truncated.truncated
+		? `${truncated.content}\n\n[Output truncated: ${truncated.outputLines}/${truncated.totalLines} lines, ${truncated.outputBytes}/${truncated.totalBytes} bytes]`
+		: truncated.content;
+}
+
+function toolResult(action: string, result: BrowserCommandResult, path?: string) {
+	const output = compactOutput(result);
+	const details: BrowserDetails = {
+		action,
+		surface: result.surface,
+		command: result.args,
+		json: result.json,
+		output,
+		path,
+	};
+	return { content: [{ type: "text" as const, text: output }], details };
+}
+
+function renderCall(name: string) {
+	return (args: { action?: string; surface?: string }, theme: any) =>
+		new Text(
+			`${theme.fg("toolTitle", theme.bold(name))} ${theme.fg("accent", args.action ?? "")} ${theme.fg("dim", args.surface ?? "active surface")}`,
+			0,
+			0,
+		);
+}
+
+function renderResult(result: { details?: BrowserDetails }, options: { expanded: boolean; isPartial: boolean }, theme: any) {
+	if (options.isPartial) return new Text(theme.fg("warning", "Working with native cmux browser…"), 0, 0);
+	const details = result.details;
+	if (!details) return new Text(theme.fg("success", "✓ browser operation complete"), 0, 0);
+	let text = `${theme.fg("success", "✓")} ${details.action}`;
+	if (details.surface) text += ` ${theme.fg("dim", details.surface)}`;
+	if (details.path) text += ` ${theme.fg("dim", details.path)}`;
+	if (options.expanded && details.output) text += `\n${theme.fg("toolOutput", details.output)}`;
+	return new Text(text, 0, 0);
+}
+
+function recoverSurface(ctx: any): string | undefined {
+	const branch = ctx.sessionManager.getBranch();
+	for (let index = branch.length - 1; index >= 0; index--) {
+		const entry = branch[index];
+		if (entry?.type !== "message" || entry.message?.role !== "toolResult") continue;
+		if (!entry.message.toolName?.startsWith("browser_")) continue;
+		const surface = entry.message.details?.surface;
+		if (typeof surface === "string" && surface.trim()) return surface;
+	}
+	return undefined;
+}
+
+export default function cmuxBrowserExtension(pi: ExtensionAPI) {
+	const client = new CmuxBrowserClient((args, options) => pi.exec("cmux", args, options));
+
+	pi.on("session_start", (_event, ctx) => {
+		client.setActiveSurface(recoverSurface(ctx));
+		if (ctx.mode === "tui") {
+			ctx.ui.setStatus(
+				"cmux-browser",
+				ctx.ui.theme.fg("dim", client.getActiveSurface() ? "browser ready" : "browser idle"),
+			);
+		}
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (ctx.hasUI) ctx.ui.setStatus("cmux-browser", undefined);
+	});
+
+	pi.registerTool({
+		name: "browser_navigate",
+		label: "Browser Navigate",
+		description:
+			"Open and navigate the native cmux browser pane. New panes always open beside the calling Pi workspace with focus=false. Use open first; later calls reuse the active surface unless surface is provided.",
+		promptSnippet: "Open or navigate the native cmux browser pane without stealing focus",
+		promptGuidelines: [
+			"Use browser_navigate action=open to create a native cmux browser surface; do not launch an external browser process.",
+			"After browser_navigate changes the page, use browser_inspect action=snapshot to obtain fresh element refs.",
+		],
+		parameters: Type.Object({
+			action: StringEnum(["open", "goto", "back", "forward", "reload", "url", "title", "status", "close"] as const),
+			url: Type.Optional(Type.String({ description: "URL for open or goto" })),
+			surface: Type.Optional(Type.String({ description: "cmux surface UUID/ref; defaults to the active surface" })),
+			workspace: Type.Optional(Type.String({ description: "Optional cmux workspace UUID/ref for open" })),
+		}),
+		async execute(_id, params, signal) {
+			let result: BrowserCommandResult;
+			switch (params.action) {
+				case "open":
+					if (!params.url) throw new Error("url is required for open");
+					result = await client.open(params.url, params.workspace, signal);
+					break;
+				case "goto":
+					if (!params.url) throw new Error("url is required for goto");
+					result = await client.browser(params.surface, ["goto", params.url, "--snapshot-after"], signal, 30_000);
+					break;
+				case "back":
+				case "forward":
+				case "reload":
+					result = await client.browser(params.surface, [params.action, "--snapshot-after"], signal, 30_000);
+					break;
+				case "url":
+				case "title":
+					result = await client.browser(params.surface, ["get", params.action], signal);
+					break;
+				case "status":
+					result = await client.run(["browser", "status"], signal);
+					break;
+				case "close":
+					result = await client.closeSurface(params.surface, signal);
+					break;
+			}
+			return toolResult(params.action, result);
+		},
+		renderCall: renderCall("browser"),
+		renderResult,
+	});
+
+	pi.registerTool({
+		name: "browser_inspect",
+		label: "Browser Inspect",
+		description:
+			"Inspect or debug the active native cmux browser: accessibility/DOM snapshot, text/html/value/attributes/count/box/styles, page JavaScript, screenshot, console, errors, or highlight. Outputs are capped at 50KB/2000 lines.",
+		promptSnippet: "Snapshot, inspect, screenshot, or debug the native cmux browser",
+		promptGuidelines: [
+			"Use browser_inspect action=snapshot with interactive=true before browser_interact, and obtain fresh refs after DOM or navigation changes.",
+			"Use browser_inspect action=screenshot when visual evidence matters; it returns the PNG to the model and saves it at path.",
+		],
+		parameters: Type.Object({
+			action: StringEnum(["snapshot", "get", "eval", "screenshot", "console", "errors", "highlight"] as const),
+			surface: Type.Optional(Type.String()),
+			interactive: Type.Optional(Type.Boolean({ default: true })),
+			compact: Type.Optional(Type.Boolean()),
+			max_depth: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
+			selector: Type.Optional(Type.String()),
+			property: Type.Optional(StringEnum(["url", "title", "text", "html", "value", "attr", "count", "box", "styles"] as const)),
+			attribute: Type.Optional(Type.String()),
+			style_property: Type.Optional(Type.String()),
+			script: Type.Optional(Type.String()),
+			output_path: Type.Optional(Type.String({ description: "PNG path for screenshot; defaults to a temp file" })),
+		}),
+		async execute(_id, params, signal, _update, ctx) {
+			let args: string[];
+			let screenshotPath: string | undefined;
+			switch (params.action) {
+				case "snapshot":
+					args = ["snapshot"];
+					if (params.interactive !== false) args.push("--interactive");
+					if (params.compact) args.push("--compact");
+					if (params.max_depth) args.push("--max-depth", String(params.max_depth));
+					if (params.selector) args.push("--selector", params.selector);
+					break;
+				case "get":
+					if (!params.property) throw new Error("property is required for get");
+					args = ["get", params.property];
+					if (params.selector) args.push("--selector", params.selector);
+					if (params.property === "attr") {
+						if (!params.attribute) throw new Error("attribute is required for get attr");
+						args.push("--attr", params.attribute);
+					}
+					if (params.property === "styles" && params.style_property) args.push("--property", params.style_property);
+					break;
+				case "eval":
+					if (!params.script) throw new Error("script is required for eval");
+					args = ["eval", "--script", params.script];
+					break;
+				case "screenshot":
+					screenshotPath = resolve(ctx.cwd, params.output_path?.replace(/^@/, "") ?? `${tmpdir()}/pi-cmux-${randomUUID()}.png`);
+					args = ["screenshot", "--out", screenshotPath];
+					break;
+				case "console":
+				case "errors":
+					args = [params.action, "list"];
+					break;
+				case "highlight":
+					if (!params.selector) throw new Error("selector is required for highlight");
+					args = ["highlight", "--selector", params.selector];
+					break;
+			}
+			const result = await client.browser(params.surface, args, signal, params.action === "screenshot" ? 30_000 : 20_000);
+			const response = toolResult(params.action, result, screenshotPath);
+			if (screenshotPath) {
+				const data = (await readFile(screenshotPath)).toString("base64");
+				response.content.push({ type: "image" as const, data, mimeType: "image/png" } as any);
+			}
+			return response;
+		},
+		renderCall: renderCall("inspect"),
+		renderResult,
+	});
+
+	pi.registerTool({
+		name: "browser_interact",
+		label: "Browser Interact",
+		description:
+			"Interact with the active native cmux browser using a fresh snapshot ref or CSS selector. Supports click, double click, hover, focus, fill, type, key events, select, checkbox, scrolling, waits, and scroll-into-view.",
+		promptSnippet: "Interact with snapshot refs or selectors in the native cmux browser",
+		promptGuidelines: [
+			"Use browser_interact with fresh browser_inspect snapshot refs; re-snapshot after navigation, modal changes, or major DOM updates.",
+			"Prefer browser_interact fill over type when replacing an input value, and use wait instead of polling snapshots.",
+		],
+		parameters: Type.Object({
+			action: StringEnum(["click", "dblclick", "hover", "focus", "fill", "type", "press", "keydown", "keyup", "select", "check", "uncheck", "scroll", "scroll_into_view", "wait"] as const),
+			surface: Type.Optional(Type.String()),
+			target: Type.Optional(Type.String({ description: "Fresh element ref or CSS selector" })),
+			text: Type.Optional(Type.String()),
+			key: Type.Optional(Type.String()),
+			value: Type.Optional(Type.String()),
+			dx: Type.Optional(Type.Number()),
+			dy: Type.Optional(Type.Number()),
+			wait_text: Type.Optional(Type.String()),
+			url: Type.Optional(Type.String()),
+			url_contains: Type.Optional(Type.String()),
+			load_state: Type.Optional(StringEnum(["interactive", "complete"] as const)),
+			function_js: Type.Optional(Type.String()),
+			timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 120_000, default: 15_000 })),
+		}),
+		async execute(_id, params, signal) {
+			let args: string[];
+			const simpleTarget = ["click", "dblclick", "hover", "focus", "check", "uncheck", "scroll_into_view"].includes(params.action);
+			if (simpleTarget) {
+				if (!params.target) throw new Error(`target is required for ${params.action}`);
+				args = [params.action === "scroll_into_view" ? "scroll-into-view" : params.action, params.target, "--snapshot-after"];
+			} else if (params.action === "fill" || params.action === "type") {
+				if (!params.target || params.text === undefined) throw new Error(`target and text are required for ${params.action}`);
+				args = [params.action, params.target, params.text, "--snapshot-after"];
+			} else if (["press", "keydown", "keyup"].includes(params.action)) {
+				if (!params.key) throw new Error(`key is required for ${params.action}`);
+				args = [params.action, "--key", params.key, "--snapshot-after"];
+			} else if (params.action === "select") {
+				if (!params.target || params.value === undefined) throw new Error("target and value are required for select");
+				args = ["select", params.target, params.value, "--snapshot-after"];
+			} else if (params.action === "scroll") {
+				args = ["scroll"];
+				if (params.target) args.push("--selector", params.target);
+				if (params.dx !== undefined) args.push("--dx", String(params.dx));
+				if (params.dy !== undefined) args.push("--dy", String(params.dy));
+				args.push("--snapshot-after");
+			} else {
+				args = ["wait"];
+				if (params.target) args.push("--selector", params.target);
+				if (params.wait_text) args.push("--text", params.wait_text);
+				if (params.url) args.push("--url", params.url);
+				if (params.url_contains) args.push("--url-contains", params.url_contains);
+				if (params.load_state) args.push("--load-state", params.load_state);
+				if (params.function_js) args.push("--function", params.function_js);
+				if (args.length === 1) throw new Error("wait requires target, wait_text, url, url_contains, load_state, or function_js");
+				args.push("--timeout-ms", String(params.timeout_ms ?? 15_000));
+			}
+			const timeout = params.action === "wait" ? (params.timeout_ms ?? 15_000) + 5_000 : 30_000;
+			return toolResult(params.action, await client.browser(params.surface, args, signal, timeout));
+		},
+		renderCall: renderCall("interact"),
+		renderResult,
+	});
+
+	pi.registerTool({
+		name: "browser_session",
+		label: "Browser Session",
+		description:
+			"Manage native cmux browser tabs, profile/state lifecycle, downloads, and explicit local-file uploads. Auth stays in cmux's supported profile/data store; this tool does not read credential stores or print uploaded file contents.",
+		promptSnippet: "Manage tabs, browser state/profiles, uploads, and downloads",
+		promptGuidelines: [
+			"Use browser_session state_save/state_load or cmux profiles for supported authenticated browser continuity; never scrape credential stores.",
+			"Use browser_session upload only with an explicit local path and file-input selector; the operation sends that file to the currently loaded page without printing its contents.",
+		],
+		parameters: Type.Object({
+			action: StringEnum(["tab_list", "tab_new", "tab_switch", "tab_close", "state_save", "state_load", "profile_list", "profile_add", "profile_rename", "profile_delete", "download_wait", "upload"] as const),
+			surface: Type.Optional(Type.String()),
+			url: Type.Optional(Type.String()),
+			index: Type.Optional(Type.Integer({ minimum: 0 })),
+			path: Type.Optional(Type.String()),
+			selector: Type.Optional(Type.String()),
+			name: Type.Optional(Type.String()),
+			new_name: Type.Optional(Type.String()),
+			timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 120_000, default: 30_000 })),
+		}),
+		async execute(_id, params, signal, _update, ctx) {
+			if (params.action === "upload") {
+				if (!params.path || !params.selector) throw new Error("path and selector are required for upload");
+				if (!ctx.hasUI) throw new Error("Browser uploads require interactive approval in Pi TUI/RPC mode.");
+				const absolutePath = resolve(ctx.cwd, params.path.replace(/^@/, ""));
+				const approved = await ctx.ui.confirm(
+					"Upload local file to this page?",
+					`${absolutePath}\n\nTarget: ${params.selector}`,
+				);
+				if (!approved) throw new Error("Browser upload cancelled by user.");
+				return toolResult(params.action, await client.upload(params.surface, params.selector, params.path, ctx.cwd, signal), absolutePath);
+			}
+			if (params.action === "profile_delete") {
+				if (!params.name) throw new Error("name is required for profile_delete");
+				if (!ctx.hasUI || !(await ctx.ui.confirm("Delete cmux browser profile?", params.name))) {
+					throw new Error("Browser profile deletion cancelled by user.");
+				}
+			}
+			let args: string[];
+			switch (params.action) {
+				case "tab_list": args = ["tab", "list"]; break;
+				case "tab_new": args = ["tab", "new", ...(params.url ? [params.url] : [])]; break;
+				case "tab_switch":
+				case "tab_close":
+					if (params.index === undefined) throw new Error(`index is required for ${params.action}`);
+					args = ["tab", params.action === "tab_switch" ? "switch" : "close", String(params.index)];
+					break;
+				case "state_save":
+				case "state_load":
+					if (!params.path) throw new Error(`path is required for ${params.action}`);
+					args = ["state", params.action === "state_save" ? "save" : "load", resolve(ctx.cwd, params.path.replace(/^@/, ""))];
+					break;
+				case "profile_list": args = ["profiles", "list"]; break;
+				case "profile_add":
+					if (!params.name) throw new Error("name is required for profile_add");
+					args = ["profiles", "add", params.name];
+					break;
+				case "profile_rename":
+					if (!params.name || !params.new_name) throw new Error("name and new_name are required for profile_rename");
+					args = ["profiles", "rename", params.name, params.new_name];
+					break;
+				case "profile_delete":
+					if (!params.name) throw new Error("name is required for profile_delete");
+					args = ["profiles", "delete", params.name];
+					break;
+				case "download_wait":
+					args = ["download", "wait", "--timeout-ms", String(params.timeout_ms ?? 30_000)];
+					if (params.path) args.push("--path", resolve(ctx.cwd, params.path.replace(/^@/, "")));
+					break;
+				default: throw new Error(`Unsupported session action: ${params.action}`);
+			}
+			const timeout = params.action === "download_wait" ? (params.timeout_ms ?? 30_000) + 5_000 : 30_000;
+			const isProfileAction = params.action.startsWith("profile_");
+			const result = isProfileAction
+				? await client.run(["browser", ...args], signal, timeout)
+				: await client.browser(params.surface, args, signal, timeout);
+			return toolResult(params.action, result, params.path);
+		},
+		renderCall: renderCall("session"),
+		renderResult,
+	});
+
+	pi.registerCommand("browser", {
+		description: "Open a URL in a native cmux browser pane without moving focus",
+		handler: async (args, ctx) => {
+			const url = args.trim() || "about:blank";
+			try {
+				const result = await client.open(url, undefined);
+				ctx.ui.setStatus("cmux-browser", ctx.ui.theme.fg("success", "browser ready"));
+				ctx.ui.notify(`Opened native browser ${result.surface ?? "surface"} without changing focus`, "info");
+			} catch (error) {
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+			}
+		},
+	});
+}

--- a/cmux-browser/index.ts
+++ b/cmux-browser/index.ts
@@ -306,7 +306,7 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 					`${absolutePath}\n\nTarget: ${params.selector}`,
 				);
 				if (!approved) throw new Error("Browser upload cancelled by user.");
-				return toolResult(params.action, await client.upload(params.surface, params.selector, params.path, ctx.cwd, signal), absolutePath);
+				return toolResult(params.action, await client.upload(params.surface, params.selector, params.path, ctx.cwd, signal));
 			}
 			if (params.action === "profile_delete") {
 				if (!params.name) throw new Error("name is required for profile_delete");
@@ -352,7 +352,7 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 			const result = isProfileAction
 				? await client.run(["browser", ...args], signal, timeout)
 				: await client.browser(params.surface, args, signal, timeout);
-			return toolResult(params.action, result, params.path);
+			return toolResult(params.action, result);
 		},
 		renderCall: renderCall("session"),
 		renderResult,

--- a/cmux-browser/index.ts
+++ b/cmux-browser/index.ts
@@ -1,16 +1,44 @@
-import { chmod, mkdtemp, rm } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { CmuxBrowserClient, type BrowserCommandResult } from "./client.ts";
-import { INSPECTION_ATTRIBUTES, inspectionArguments, navigationTarget, snapshotRef, toolResult, type BrowserDetails, type NavigationTarget } from "./policy.ts";
-import { readPrivateImage } from "./private-image.ts";
+import { CmuxBrowserClient, type BrowserCommandResult, type BrowserLifecycleBlock, type ExecCmux } from "./client.ts";
+import { navigationTarget, toolResult, type BrowserDetails, type NavigationTarget } from "./policy.ts";
 
-const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_CMUX_OUTPUT_BYTES = 10 * 1024 * 1024;
+const BOUNDED_CMUX_RUNNER = String.raw`
+const { spawn } = require("node:child_process");
+const child = spawn("cmux", process.argv.slice(1), { stdio: ["ignore", "pipe", "pipe"] });
+const limit = ${MAX_CMUX_OUTPUT_BYTES};
+let written = 0;
+let exceeded = false;
+const forward = (source, target) => source.on("data", (chunk) => {
+	if (exceeded) return;
+	const remaining = limit - written;
+	if (chunk.length > remaining) {
+		if (remaining > 0) target.write(chunk.subarray(0, remaining));
+		written = limit;
+		exceeded = true;
+		child.kill("SIGKILL");
+		return;
+	}
+	written += chunk.length;
+	target.write(chunk);
+});
+forward(child.stdout, process.stdout);
+forward(child.stderr, process.stderr);
+const stop = () => child.kill("SIGKILL");
+process.on("SIGTERM", stop);
+process.on("SIGINT", stop);
+child.on("error", () => process.exit(127));
+child.on("close", (code, signal) => process.exit(exceeded ? 124 : signal ? 125 : (code ?? 1)));
+`;
+const PROCESS_LIFECYCLE_KEY = Symbol.for("pi-extensions.cmux-browser.lifecycle-block.v1");
+
+function sharedLifecycleBlock(): BrowserLifecycleBlock {
+	const registry = globalThis as unknown as Record<symbol, BrowserLifecycleBlock | undefined>;
+	return registry[PROCESS_LIFECYCLE_KEY] ??= { blocked: false };
+}
 
 function renderCall(name: string) {
 	return (args: { action?: string }, theme: any) =>
@@ -32,24 +60,25 @@ function renderResult(result: { details?: BrowserDetails }, options: { expanded:
 }
 
 export default function cmuxBrowserExtension(pi: ExtensionAPI) {
-	const client = new CmuxBrowserClient((args, options) => pi.exec("cmux", args, options));
+	const execCmux: ExecCmux = (args, options) => pi.exec(
+		process.execPath,
+		["-e", BOUNDED_CMUX_RUNNER, "--", ...args],
+		options,
+	);
+	const client = new CmuxBrowserClient(execCmux, sharedLifecycleBlock());
 	const approvedOrigins = new Set<string>();
 	let sharedProfileApproved = false;
-	let privateRootPromise: Promise<string> | undefined;
 
-	async function privateRoot(): Promise<string> {
-		privateRootPromise ??= mkdtemp(join(tmpdir(), "pi-cmux-browser-")).then(async (path) => {
-			await chmod(path, 0o700);
-			return path;
-		});
-		return privateRootPromise;
-	}
-
-	async function cleanupPrivateRoot(): Promise<void> {
-		if (!privateRootPromise) return;
-		const root = await privateRootPromise.catch(() => undefined);
-		if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
-		privateRootPromise = undefined;
+	async function requireExactCmuxVersion(signal?: AbortSignal): Promise<void> {
+		let result;
+		try {
+			result = await execCmux(["--version"], { signal, timeout: 5_000 });
+		} catch {
+			throw new Error("Could not verify the required cmux 0.64.13 runtime; operation refused.");
+		}
+		if (result.killed || result.code !== 0 || !/^cmux 0\.64\.13(?:\s|$)/.test(result.stdout.trim())) {
+			throw new Error("This extension requires exactly cmux 0.64.13; operation refused before browser access.");
+		}
 	}
 
 	async function approveSharedProfile(ctx: any): Promise<void> {
@@ -79,24 +108,32 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		await approveOrigin(ctx, { url: origin, origin }, purpose);
 		const revalidatedOrigin = await client.currentOrigin(signal);
 		if (revalidatedOrigin !== origin) {
-			throw new Error("The browser origin changed while approval was pending; action refused. Review the native pane and retry.");
+			throw new Error("The browser origin changed while approval was pending; operation refused. Review the native pane and retry.");
 		}
 		return origin;
 	}
 
-	async function approveSensitiveAction(ctx: any, signal: AbortSignal | undefined, action: string): Promise<string> {
-		const origin = await currentApprovedOrigin(ctx, signal, action);
-		if (!ctx.hasUI) throw new Error("Consequential browser actions require approval in Pi TUI mode.");
-		const approved = await ctx.ui.confirm(
-			`Allow browser action: ${action}?`,
-			`${origin}\n\nReview the native browser pane first. Do not approve credential entry, purchases, submissions, deletions, permission changes, or other external side effects unless you explicitly requested them.`,
-		);
-		if (!approved) throw new Error(`Browser action ${action} was not approved.`);
-		const revalidatedOrigin = await client.currentOrigin(signal);
-		if (revalidatedOrigin !== origin) {
-			throw new Error("The browser origin changed while approval was pending; action refused. Review the native pane and retry.");
+	async function captureApprovedSnapshot(
+		ctx: any,
+		args: string[],
+		signal: AbortSignal | undefined,
+	): Promise<BrowserCommandResult> {
+		let result = await client.browser(args, signal, 20_000, { captureSnapshot: true });
+		if (result.exposure !== "captured" || !result.observedOrigin) {
+			throw new Error("Could not bind the accessibility snapshot to a browser origin; operation refused.");
 		}
-		return origin;
+		const observedOrigin = result.observedOrigin;
+		const wasApproved = approvedOrigins.has(observedOrigin);
+		await approveOrigin(ctx, { url: observedOrigin, origin: observedOrigin }, "inspect the accessibility snapshot");
+		if (!wasApproved) {
+			// The first snapshot remains private while approval is pending. Capture again so
+			// the released text and its origin come from one cmux operation after approval.
+			result = await client.browser(args, signal, 20_000, { captureSnapshot: true });
+			if (result.exposure !== "captured" || result.observedOrigin !== observedOrigin) {
+				throw new Error("The browser origin changed while approval was pending; snapshot refused.");
+			}
+		}
+		return result;
 	}
 
 	pi.on("session_start", (_event, ctx) => {
@@ -105,7 +142,6 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		await client.closeAll();
-		await cleanupPrivateRoot();
 		approvedOrigins.clear();
 		sharedProfileApproved = false;
 		if (ctx.hasUI) ctx.ui.setStatus("cmux-browser", undefined);
@@ -115,17 +151,19 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		name: "browser_navigate",
 		label: "Browser Navigate",
 		description:
-			"Open and navigate one extension-owned native cmux browser pane. New origins require approval, new panes never steal focus, and local/custom URL schemes are refused.",
+			"Open or navigate one extension-owned native cmux browser pane to an approved origin root. Paths, queries, fragments, local/custom schemes, and focus theft are refused.",
 		promptSnippet: "Open or navigate the owned native cmux browser pane without stealing focus",
 		promptGuidelines: [
 			"Use action=open once; later calls reuse only this Pi session's owned surface.",
 			"Never put credentials, tokens, signed secrets, or local-file URLs in navigation parameters; ask the user to enter them in the native pane.",
 		],
 		parameters: Type.Object({
-			action: StringEnum(["open", "goto", "reload", "origin", "close"] as const),
-			url: Type.Optional(Type.String({ description: "Absolute http(s) URL or exactly about:blank" })),
+			action: StringEnum(["open", "goto", "origin", "close"] as const),
+			url: Type.Optional(Type.String({ description: "Absolute http(s) origin root (no path/query/fragment) or exactly about:blank" })),
 		}),
+		executionMode: "sequential",
 		async execute(_id, params, signal, _update, ctx) {
+			await requireExactCmuxVersion(signal);
 			let result: BrowserCommandResult;
 			switch (params.action) {
 				case "open": {
@@ -140,13 +178,9 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 					if (!params.url) throw new Error("url is required for goto");
 					const target = navigationTarget(params.url);
 					await approveOrigin(ctx, target, "navigate the active surface");
-					result = await client.browser(["goto", target.url], signal, 30_000, { success: { ok: true, navigated: true } });
+					result = await client.browser(["goto", target.url], signal, 30_000, { success: "navigated" });
 					break;
 				}
-				case "reload":
-					await currentApprovedOrigin(ctx, signal, "reload the active page");
-					result = await client.browser(["reload"], signal, 30_000, { success: { ok: true, navigated: true } });
-					break;
 				case "origin": {
 					const origin = await currentApprovedOrigin(ctx, signal, "read the active page origin");
 					result = {
@@ -169,143 +203,27 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		name: "browser_inspect",
 		label: "Browser Inspect",
 		description:
-			"Inspect the approved origin on the owned native cmux browser surface: accessibility/DOM snapshot, bounded property reads, screenshots, console, errors, or highlight. Arbitrary page JavaScript is intentionally not exposed.",
-		promptSnippet: "Snapshot, inspect, screenshot, or debug the owned native cmux browser",
+			"Read a bounded, element-name-redacted structural accessibility snapshot from one atomically reported and approved origin. Raw page text, HTML, URLs, screenshots, console output, and arbitrary page JavaScript are not exposed.",
+		promptSnippet: "Read the approved native cmux page's accessibility snapshot",
 		promptGuidelines: [
-			"Use snapshot with interactive=true before browser_interact; obtain fresh refs after DOM or navigation changes.",
-			"Screenshots require explicit approval, are capped at 10 MiB, and are deleted from the private temp root immediately after reading.",
+			"Snapshot is read-only. Perform interactions, credential entry, downloads, and screenshots manually in the visible native pane.",
 		],
 		parameters: Type.Object({
-			action: StringEnum(["snapshot", "get", "screenshot", "console", "errors", "highlight"] as const),
+			action: StringEnum(["snapshot"] as const),
 			interactive: Type.Optional(Type.Boolean({ default: true })),
 			compact: Type.Optional(Type.Boolean()),
 			max_depth: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
-			target: Type.Optional(Type.String({ description: "Fresh snapshot ref such as e3" })),
-			property: Type.Optional(StringEnum(["text", "attr", "count", "box"] as const)),
-			attribute: Type.Optional(StringEnum(INSPECTION_ATTRIBUTES, { description: "Allowlisted non-value metadata attribute when property=attr." })),
 		}),
+		executionMode: "sequential",
 		async execute(_id, params, signal, _update, ctx) {
-			if (params.action === "screenshot") await approveSensitiveAction(ctx, signal, "share a screenshot with the model");
-			else await currentApprovedOrigin(ctx, signal, `inspect page (${params.action})`);
-			let args: string[];
-			let capture = true;
-			let screenshotPath: string | undefined;
-			switch (params.action) {
-				case "snapshot":
-					args = ["snapshot"];
-					if (params.interactive !== false) args.push("--interactive");
-					if (params.compact) args.push("--compact");
-					if (params.max_depth) args.push("--max-depth", String(params.max_depth));
-					break;
-				case "get":
-					if (!params.property) throw new Error("property is required for get");
-					args = inspectionArguments(params.property, params.target ?? "", params.attribute);
-					break;
-				case "screenshot":
-					screenshotPath = join(await privateRoot(), `${randomUUID()}.png`);
-					args = ["screenshot", "--out", screenshotPath];
-					capture = false;
-					break;
-				case "console":
-				case "errors":
-					args = [params.action, "list"];
-					break;
-				case "highlight":
-					args = ["highlight", "--selector", snapshotRef(params.target, "highlight")];
-					capture = false;
-					break;
-			}
-			try {
-				const result = await client.browser(args, signal, params.action === "screenshot" ? 30_000 : 20_000, capture ? { capture: true } : undefined);
-				const response = toolResult(params.action, result);
-				if (screenshotPath) {
-					const data = await readPrivateImage(screenshotPath, MAX_IMAGE_BYTES);
-					response.content.push({ type: "image" as const, data, mimeType: "image/png" } as any);
-				}
-				return response;
-			} finally {
-				if (screenshotPath) await rm(screenshotPath, { force: true }).catch(() => undefined);
-			}
+			await requireExactCmuxVersion(signal);
+			const args = ["snapshot"];
+			if (params.interactive !== false) args.push("--interactive");
+			if (params.compact) args.push("--compact");
+			if (params.max_depth) args.push("--max-depth", String(params.max_depth));
+			return toolResult(params.action, await captureApprovedSnapshot(ctx, args, signal));
 		},
 		renderCall: renderCall("inspect"),
-		renderResult,
-	});
-
-	pi.registerTool({
-		name: "browser_interact",
-		label: "Browser Interact",
-		description:
-			"Interact with fresh snapshot refs on the approved origin. Text/value entry and arbitrary CSS selectors are intentionally absent so credentials and other values never enter process arguments; enter them manually in the native pane.",
-		promptSnippet: "Interact with fresh snapshot refs on the owned native cmux browser",
-		promptGuidelines: [
-			"Use fresh snapshot refs and re-snapshot after navigation or major DOM changes.",
-			"Ask the user to enter all text, selections, credentials, tokens, and one-time codes directly in the native pane.",
-		],
-		parameters: Type.Object({
-			action: StringEnum(["click", "dblclick", "hover", "focus", "press", "check", "uncheck", "scroll", "scroll_into_view", "wait"] as const),
-			target: Type.Optional(Type.String({ description: "Fresh snapshot ref such as e3" })),
-			key: Type.Optional(StringEnum(["Enter", "Tab", "Escape", "Backspace", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End", "PageUp", "PageDown", "Space"] as const)),
-			dx: Type.Optional(Type.Number({ minimum: -10000, maximum: 10000 })),
-			dy: Type.Optional(Type.Number({ minimum: -10000, maximum: 10000 })),
-			load_state: Type.Optional(StringEnum(["interactive", "complete"] as const)),
-			timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 120_000, default: 15_000 })),
-		}),
-		async execute(_id, params, signal, _update, ctx) {
-			const consequential = ["click", "dblclick", "press", "check", "uncheck"].includes(params.action);
-			if (consequential) await approveSensitiveAction(ctx, signal, params.action);
-			else await currentApprovedOrigin(ctx, signal, params.action);
-			let args: string[];
-			const simpleTarget = ["click", "dblclick", "hover", "focus", "check", "uncheck", "scroll_into_view"].includes(params.action);
-			if (simpleTarget) {
-				const target = snapshotRef(params.target, params.action);
-				args = [params.action === "scroll_into_view" ? "scroll-into-view" : params.action, target];
-			} else if (params.action === "press") {
-				if (!params.key) throw new Error("key is required for press");
-				args = ["press", "--key", params.key];
-			} else if (params.action === "scroll") {
-				args = ["scroll"];
-				if (params.target) args.push("--selector", snapshotRef(params.target, "scroll"));
-				if (params.dx !== undefined) args.push("--dx", String(params.dx));
-				if (params.dy !== undefined) args.push("--dy", String(params.dy));
-			} else {
-				args = ["wait"];
-				if (params.target) args.push("--selector", snapshotRef(params.target, "wait"));
-				if (params.load_state) args.push("--load-state", params.load_state);
-				if (args.length === 1) throw new Error("wait requires target or load_state");
-				args.push("--timeout-ms", String(params.timeout_ms ?? 15_000));
-			}
-			const timeout = params.action === "wait" ? (params.timeout_ms ?? 15_000) + 5_000 : 30_000;
-			return toolResult(params.action, await client.browser(args, signal, timeout, { success: { ok: true, interacted: true } }));
-		},
-		renderCall: renderCall("interact"),
-		renderResult,
-	});
-
-	pi.registerTool({
-		name: "browser_download",
-		label: "Browser Download",
-		description:
-			"Wait for a download managed by the owned native cmux browser. Download host paths and raw cmux output are intentionally not returned.",
-		promptSnippet: "Wait for a user-approved download on the owned browser",
-		promptGuidelines: [
-			"Ask the user to handle uploads, credentials, and any downloaded-file opening directly in the native pane or filesystem.",
-		],
-		parameters: Type.Object({
-			action: StringEnum(["wait"] as const),
-			timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 120_000, default: 30_000 })),
-		}),
-		async execute(_id, params, signal, _update, ctx) {
-			await approveSensitiveAction(ctx, signal, "wait for a cmux-managed download");
-			const timeout = (params.timeout_ms ?? 30_000) + 5_000;
-			const result = await client.browser(
-				["download", "wait", "--timeout-ms", String(params.timeout_ms ?? 30_000)],
-				signal,
-				timeout,
-				{ success: { ok: true, download_ready: true } },
-			);
-			return toolResult(params.action, result);
-		},
-		renderCall: renderCall("download"),
 		renderResult,
 	});
 
@@ -313,11 +231,12 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 		description: "Open or navigate the owned native cmux browser pane without moving focus",
 		handler: async (args, ctx) => {
 			try {
+				await requireExactCmuxVersion();
 				const target = navigationTarget(args.trim() || "about:blank");
 				await approveSharedProfile(ctx);
 				approvedOrigins.add(target.origin); // Direct slash-command input is explicit user authorization for this origin.
 				if (client.getActiveSurface()) {
-					await client.browser(["goto", target.url], undefined, 30_000, { success: { ok: true, navigated: true } });
+					await client.browser(["goto", target.url], undefined, 30_000, { success: "navigated" });
 				} else {
 					await client.open(target.url);
 				}

--- a/cmux-browser/index.ts
+++ b/cmux-browser/index.ts
@@ -150,7 +150,7 @@ export default function cmuxBrowserExtension(pi: ExtensionAPI) {
 				case "origin": {
 					const origin = await currentApprovedOrigin(ctx, signal, "read the active page origin");
 					result = {
-						command: ["browser", "get"], stdout: origin, stderr: "", surface: client.getActiveSurface(), exposure: "captured",
+						command: ["browser", "get"], stdout: origin, surface: client.getActiveSurface(), exposure: "captured",
 					};
 					break;
 				}

--- a/cmux-browser/policy.ts
+++ b/cmux-browser/policy.ts
@@ -1,0 +1,115 @@
+import type { BrowserCommandResult } from "./client.ts";
+
+export interface BrowserDetails {
+	action: string;
+	surface?: string;
+	command: string[];
+	output?: string;
+}
+
+export interface NavigationTarget {
+	url: string;
+	origin: string;
+}
+
+const MAX_TOOL_OUTPUT_BYTES = 50 * 1024;
+const SENSITIVE_QUERY_KEY = /(?:^|[_-])(auth|authorization|code|credential|key|password|secret|session|sig|signature|token)(?:$|[_-])/i;
+const SENSITIVE_COMPACT_KEY = /(?:token|secret|password|credential|authorization|session|signature)/i;
+const SENSITIVE_EXACT_KEY = new Set(["apikey", "auth", "code", "key", "sig"]);
+const SAFE_SYNTHETIC_KEYS = new Set([
+	"ok", "opened", "navigated", "closed", "interacted", "updated", "download_ready",
+]);
+
+export const INSPECTION_ATTRIBUTES = [
+	"role", "aria-label", "aria-checked", "aria-disabled", "aria-expanded", "aria-hidden", "aria-selected", "alt", "name", "title", "type",
+] as const;
+const SAFE_INSPECTION_ATTRIBUTES = new Set<string>(INSPECTION_ATTRIBUTES);
+
+export function snapshotRef(value: string | undefined, action: string): string {
+	if (!value || !/^e[1-9][0-9]*$/.test(value)) {
+		throw new Error(`${action} requires a fresh snapshot ref such as e3; arbitrary CSS selectors are not accepted.`);
+	}
+	return value;
+}
+
+export function inspectionArguments(property: string, target: string, attribute?: string): string[] {
+	const ref = snapshotRef(target, "get");
+	if (property === "attr") {
+		if (!attribute) throw new Error("attribute is required when property=attr.");
+		if (!SAFE_INSPECTION_ATTRIBUTES.has(attribute)) {
+			throw new Error("Only the documented non-value metadata attributes are available; inspect sensitive values manually in cmux.");
+		}
+		return ["get", "attr", "--selector", ref, "--attr", attribute];
+	}
+	if (property === "text" || property === "count" || property === "box") {
+		return ["get", property, "--selector", ref];
+	}
+	throw new Error("Unsupported inspection property.");
+}
+
+function isSensitiveParameterKey(key: string): boolean {
+	const compact = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+	return SENSITIVE_QUERY_KEY.test(key) || SENSITIVE_COMPACT_KEY.test(compact) || SENSITIVE_EXACT_KEY.has(compact);
+}
+
+export function navigationTarget(raw: string): NavigationTarget {
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new Error("Navigation requires an absolute http(s) URL or exactly about:blank.");
+	}
+	if (url.protocol === "about:" && url.href === "about:blank") return { url: url.href, origin: "about:blank" };
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error("Only http:, https:, and exactly about:blank are allowed. Open local/custom schemes manually in cmux.");
+	}
+	if (url.username || url.password) throw new Error("URLs containing credentials are not allowed; authenticate in the native pane.");
+	for (const key of url.searchParams.keys()) {
+		if (isSensitiveParameterKey(key)) {
+			throw new Error("URLs with credential-like parameters are not allowed; navigate manually in the native pane.");
+		}
+	}
+	if (url.hash) {
+		let fragment: string;
+		try {
+			fragment = decodeURIComponent(url.hash.slice(1));
+		} catch {
+			throw new Error("Navigation URL fragments must use valid percent encoding.");
+		}
+		for (const part of fragment.split(/[?&;]/)) {
+			const equals = part.indexOf("=");
+			if (equals >= 0 && isSensitiveParameterKey(part.slice(0, equals).replace(/^.*\//, ""))) {
+				throw new Error("URLs with credential-like parameters are not allowed; navigate manually in the native pane.");
+			}
+		}
+	}
+	return { url: url.href, origin: url.origin };
+}
+
+export function compactOutput(result: BrowserCommandResult): string {
+	if (result.exposure === "synthetic") {
+		const safe: Record<string, boolean | number> = {};
+		if (result.json && typeof result.json === "object" && !Array.isArray(result.json)) {
+			for (const [key, value] of Object.entries(result.json)) {
+				if (SAFE_SYNTHETIC_KEYS.has(key) && (typeof value === "boolean" || typeof value === "number")) safe[key] = value;
+			}
+		}
+		return JSON.stringify(Object.keys(safe).length > 0 ? safe : { ok: true });
+	}
+
+	const raw = result.stdout.trim() || result.stderr.trim() || "ok";
+	const bytes = Buffer.from(raw, "utf8");
+	if (bytes.length <= MAX_TOOL_OUTPUT_BYTES) return raw;
+	return `${bytes.subarray(0, MAX_TOOL_OUTPUT_BYTES).toString("utf8")}\n\n[Output truncated at ${MAX_TOOL_OUTPUT_BYTES} bytes]`;
+}
+
+export function toolResult(action: string, result: BrowserCommandResult) {
+	const output = compactOutput(result);
+	const details: BrowserDetails = {
+		action,
+		surface: result.surface ? "owned" : undefined,
+		command: result.command,
+		output,
+	};
+	return { content: [{ type: "text" as const, text: output }], details };
+}

--- a/cmux-browser/policy.ts
+++ b/cmux-browser/policy.ts
@@ -13,11 +13,8 @@ export interface NavigationTarget {
 }
 
 const MAX_TOOL_OUTPUT_BYTES = 50 * 1024;
-const SENSITIVE_QUERY_KEY = /(?:^|[_-])(auth|authorization|code|credential|key|password|secret|session|sig|signature|token)(?:$|[_-])/i;
-const SENSITIVE_COMPACT_KEY = /(?:token|secret|password|credential|authorization|session|signature)/i;
-const SENSITIVE_EXACT_KEY = new Set(["apikey", "auth", "code", "key", "sig"]);
 const SAFE_SYNTHETIC_KEYS = new Set([
-	"ok", "opened", "navigated", "closed", "interacted", "updated", "download_ready",
+	"ok", "opened", "navigated", "closed", "interacted", "download_ready",
 ]);
 
 export const INSPECTION_ATTRIBUTES = [
@@ -47,11 +44,6 @@ export function inspectionArguments(property: string, target: string, attribute?
 	throw new Error("Unsupported inspection property.");
 }
 
-function isSensitiveParameterKey(key: string): boolean {
-	const compact = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
-	return SENSITIVE_QUERY_KEY.test(key) || SENSITIVE_COMPACT_KEY.test(compact) || SENSITIVE_EXACT_KEY.has(compact);
-}
-
 export function navigationTarget(raw: string): NavigationTarget {
 	let url: URL;
 	try {
@@ -64,35 +56,17 @@ export function navigationTarget(raw: string): NavigationTarget {
 		throw new Error("Only http:, https:, and exactly about:blank are allowed. Open local/custom schemes manually in cmux.");
 	}
 	if (url.username || url.password) throw new Error("URLs containing credentials are not allowed; authenticate in the native pane.");
-	for (const key of url.searchParams.keys()) {
-		if (isSensitiveParameterKey(key)) {
-			throw new Error("URLs with credential-like parameters are not allowed; navigate manually in the native pane.");
-		}
+	if (url.pathname !== "/" || url.search || url.hash) {
+		throw new Error("Model navigation is limited to an origin root with no path, query, or fragment; navigate deeper manually in the native pane.");
 	}
-	if (url.hash) {
-		let fragment: string;
-		try {
-			fragment = decodeURIComponent(url.hash.slice(1));
-		} catch {
-			throw new Error("Navigation URL fragments must use valid percent encoding.");
-		}
-		for (const part of fragment.split(/[?&;]/)) {
-			const equals = part.indexOf("=");
-			if (equals >= 0 && isSensitiveParameterKey(part.slice(0, equals).replace(/^.*\//, ""))) {
-				throw new Error("URLs with credential-like parameters are not allowed; navigate manually in the native pane.");
-			}
-		}
-	}
-	return { url: url.href, origin: url.origin };
+	return { url: `${url.origin}/`, origin: url.origin };
 }
 
 export function compactOutput(result: BrowserCommandResult): string {
 	if (result.exposure === "synthetic") {
-		const safe: Record<string, boolean | number> = {};
-		if (result.json && typeof result.json === "object" && !Array.isArray(result.json)) {
-			for (const [key, value] of Object.entries(result.json)) {
-				if (SAFE_SYNTHETIC_KEYS.has(key) && (typeof value === "boolean" || typeof value === "number")) safe[key] = value;
-			}
+		const safe: Record<string, boolean> = {};
+		for (const [key, value] of Object.entries(result.output)) {
+			if (SAFE_SYNTHETIC_KEYS.has(key) && typeof value === "boolean") safe[key] = value;
 		}
 		return JSON.stringify(Object.keys(safe).length > 0 ? safe : { ok: true });
 	}

--- a/cmux-browser/policy.ts
+++ b/cmux-browser/policy.ts
@@ -97,7 +97,7 @@ export function compactOutput(result: BrowserCommandResult): string {
 		return JSON.stringify(Object.keys(safe).length > 0 ? safe : { ok: true });
 	}
 
-	const raw = result.stdout.trim() || result.stderr.trim() || "ok";
+	const raw = result.stdout.trim() || "ok";
 	const bytes = Buffer.from(raw, "utf8");
 	if (bytes.length <= MAX_TOOL_OUTPUT_BYTES) return raw;
 	return `${bytes.subarray(0, MAX_TOOL_OUTPUT_BYTES).toString("utf8")}\n\n[Output truncated at ${MAX_TOOL_OUTPUT_BYTES} bytes]`;

--- a/cmux-browser/private-image.ts
+++ b/cmux-browser/private-image.ts
@@ -1,0 +1,57 @@
+import { constants } from "node:fs";
+import { open, rm } from "node:fs/promises";
+
+class PrivateImagePolicyError extends Error {}
+
+function policyError(message: string): PrivateImagePolicyError {
+	return new PrivateImagePolicyError(message);
+}
+
+/**
+ * Read a cmux-produced image through the same no-follow file descriptor used for
+ * validation, then remove its private temporary pathname on every outcome.
+ */
+export async function readPrivateImage(path: string, maxBytes: number): Promise<string> {
+	if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) throw policyError("cmux screenshot byte limit was invalid.");
+	let handle;
+	try {
+		handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+		const before = await handle.stat();
+		if (!before.isFile()) throw policyError("cmux screenshot output was not a regular file.");
+		if (before.nlink !== 1) throw policyError("cmux screenshot output was not a private standalone file.");
+		if (typeof process.getuid === "function" && before.uid !== process.getuid()) {
+			throw policyError("cmux screenshot output was not owned by the current user.");
+		}
+		if (before.size > maxBytes) throw policyError(`cmux screenshot exceeded the ${maxBytes} byte safety limit.`);
+
+		// Validate the already-open descriptor before changing permissions so an
+		// unexpected directory/device/link target is never modified by this helper.
+		await handle.chmod(0o600);
+		const metadata = await handle.stat();
+		if (!metadata.isFile() || metadata.dev !== before.dev || metadata.ino !== before.ino || metadata.nlink !== 1) {
+			throw policyError("cmux screenshot output changed during secure validation.");
+		}
+		if ((metadata.mode & 0o077) !== 0) {
+			throw policyError("cmux screenshot permissions could not be restricted to the current user.");
+		}
+		if (metadata.size > maxBytes) throw policyError(`cmux screenshot exceeded the ${maxBytes} byte safety limit.`);
+
+		// Do not trust the pre-read stat alone: the file could grow after validation.
+		// A fixed max+1 buffer makes the memory bound hold under that race too.
+		const buffer = Buffer.allocUnsafe(maxBytes + 1);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		if (offset > maxBytes) throw policyError(`cmux screenshot exceeded the ${maxBytes} byte safety limit.`);
+		return buffer.subarray(0, offset).toString("base64");
+	} catch (error) {
+		if (error instanceof PrivateImagePolicyError) throw error;
+		throw new Error("cmux screenshot output could not be read securely.");
+	} finally {
+		await handle?.close().catch(() => undefined);
+		await rm(path, { force: true }).catch(() => undefined);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "keywords": [
     "pi-package"
   ],
+  "scripts": {
+    "test:cmux-browser": "tsx --test cmux-browser/client.test.ts && node --no-warnings --test cmux-browser/extension.test.ts",
+    "typecheck:cmux-browser": "tsc --noEmit --allowImportingTsExtensions --moduleResolution bundler --module preserve --target es2022 --skipLibCheck cmux-browser/*.ts",
+    "test:cmux-browser:e2e": "scripts/test-cmux-browser-e2e.sh"
+  },
   "pi": {
     "extensions": [
       "./agent-guidance/agent-guidance.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test:cmux-browser": "tsx --test cmux-browser/client.test.ts && node --no-warnings --test cmux-browser/extension.test.ts",
-    "typecheck:cmux-browser": "tsc --noEmit --allowImportingTsExtensions --moduleResolution bundler --module preserve --target es2022 --skipLibCheck cmux-browser/*.ts",
+    "typecheck:cmux-browser": "tsc --noEmit --strict --allowImportingTsExtensions --moduleResolution bundler --module preserve --target es2022 --skipLibCheck cmux-browser/*.ts",
     "test:cmux-browser:e2e": "scripts/test-cmux-browser-e2e.sh"
   },
   "pi": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       "./arcade/tetris.ts",
       "./arcade/mario-not/mario-not.ts",
       "./code-actions/index.ts",
+      "./cmux-browser/index.ts",
       "./files-widget/index.ts",
       "./raw-paste/index.ts",
       "./pi-ralph-wiggum/index.ts",
@@ -38,6 +39,8 @@
     "@earendil-works/pi-agent-core": "^0.80.3",
     "@earendil-works/pi-ai": "^0.80.3",
     "@earendil-works/pi-coding-agent": "^0.80.3",
-    "@earendil-works/pi-tui": "^0.80.3"
+    "@earendil-works/pi-tui": "^0.80.3",
+    "tsx": "^4.23.0",
+    "typescript": "^7.0.2"
   }
 }

--- a/scripts/test-cmux-browser-e2e.sh
+++ b/scripts/test-cmux-browser-e2e.sh
@@ -19,17 +19,12 @@ cat >"$fixture_dir/index.html" <<'HTML'
 <!doctype html>
 <meta charset="utf-8">
 <title>Pi cmux browser E2E</title>
-<label>Name <input id="name" aria-label="Name"></label>
 <button id="hello">Say hello</button>
-<label>Upload <input id="upload" type="file" aria-label="Upload"></label>
-<a id="download" download="download.txt" href="data:text/plain,synthetic%20download">Download</a>
 <output id="status">Ready</output>
 <script>
-  hello.addEventListener('click', () => { status.textContent = `Hello ${name.value}`; });
-  upload.addEventListener('change', () => { status.textContent = upload.files?.[0]?.name ?? 'missing'; });
+  hello.addEventListener('click', () => { status.textContent = 'Clicked'; });
 </script>
 HTML
-printf '%s\n' 'synthetic upload' >"$fixture_dir/upload.txt"
 
 python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$fixture_dir" >"$server_log" 2>&1 &
 server_pid=$!

--- a/scripts/test-cmux-browser-e2e.sh
+++ b/scripts/test-cmux-browser-e2e.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/pi-cmux-browser-e2e.XXXXXX")"
+server_log="$fixture_dir/server.log"
+server_pid=""
+
+cleanup() {
+  if [[ -n "$server_pid" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$fixture_dir"
+}
+trap cleanup EXIT INT TERM
+
+cat >"$fixture_dir/index.html" <<'HTML'
+<!doctype html>
+<meta charset="utf-8">
+<title>Pi cmux browser E2E</title>
+<label>Name <input id="name" aria-label="Name"></label>
+<button id="hello">Say hello</button>
+<label>Upload <input id="upload" type="file" aria-label="Upload"></label>
+<a id="download" download="download.txt" href="data:text/plain,synthetic%20download">Download</a>
+<output id="status">Ready</output>
+<script>
+  hello.addEventListener('click', () => { status.textContent = `Hello ${name.value}`; });
+  upload.addEventListener('change', () => { status.textContent = upload.files?.[0]?.name ?? 'missing'; });
+</script>
+HTML
+printf '%s\n' 'synthetic upload' >"$fixture_dir/upload.txt"
+
+python3 -u -m http.server 0 --bind 127.0.0.1 --directory "$fixture_dir" >"$server_log" 2>&1 &
+server_pid=$!
+
+port=""
+for _ in {1..50}; do
+  port="$(grep -Eo 'port [0-9]+' "$server_log" | awk '{print $2}' | tail -1 || true)"
+  [[ -n "$port" ]] && break
+  sleep 0.1
+done
+if [[ -z "$port" ]]; then
+  echo "Local fixture server did not start" >&2
+  cat "$server_log" >&2
+  exit 1
+fi
+
+cmux browser status | grep -qx enabled || {
+  echo "cmux browser automation is not enabled; run: cmux browser enable" >&2
+  exit 1
+}
+cmux ping >/dev/null
+
+"$repo_root/node_modules/.bin/tsx" "$repo_root/cmux-browser/e2e.ts" "http://127.0.0.1:$port/" "$fixture_dir"


### PR DESCRIPTION
## Summary
- add typed Pi tools over cmux's supported native WKWebView browser CLI
- provide background navigation, snapshots/ref interaction, screenshots, bounded diagnostics, and download readiness
- enforce extension-owned surfaces, approved origins, fresh snapshot refs, synthetic mutation results, and private screenshot files
- intentionally omit upload, automated value entry, eval/script injection, tabs, profile/state mutation, arbitrary selectors, and caller-selected host paths
- document the public Codex/Pi/cmux route audit, shared-profile boundary, unsupported WKWebView/CDP operations, recovery, install, and rollback

## Security remediation at `704f7d3`
- removed automated upload and every other exposed value-bearing browser capability
- fixed argv validation to documented extension-generated shapes only
- suppress raw stdout/stderr for sensitive and mutation commands; retain only allowlisted synthetic metadata
- accept only the strict top-level UUID returned by the extension's own `browser open`
- require origin approval and revalidation for inspect/interaction; reject unsafe URL schemes, credentials, and credential-like parameters
- constrain actions to refs from the latest successful snapshot
- generate screenshot paths under a private session directory and validate/read/delete them through an `O_NOFOLLOW` descriptor with owner/link/size/permission checks
- close all owned surfaces during extension shutdown

## Evidence at `704f7d3`
- `npm run test:cmux-browser` — 30/30 passing
- `npm run typecheck:cmux-browser` — passing
- `git diff --check` — passing
- isolated Pi extension-load smoke — passing
- path-filtered macOS CI added in `.github/workflows/cmux-browser.yml`

## Draft gate: native E2E pending
The native cmux test remains implemented in `scripts/test-cmux-browser-e2e.sh`, using a local synthetic page and private temporary directory. It must pass from a fresh process launched directly inside a healthy cmux workspace before this PR is marked ready. The current session is not authorized/valid for live cmux socket testing, so the PR remains draft.

Closes #53
