### PR TITLE
perf(files-widget): reduce startup work

### DIFF
--- a/files-widget/CHANGELOG.md
+++ b/files-widget/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this extension will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Reduce Pi startup work by checking required commands directly on `PATH` instead of spawning `which`/`where`, and load the file-browser implementation only when `/readfiles` is invoked.
+
 ## [0.2.0] - 2026-07-04
 
 ### Added

--- a/files-widget/index.ts
+++ b/files-widget/index.ts
@@ -10,7 +10,6 @@ import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 
-import { createFileBrowser } from "./browser";
 import { POLL_INTERVAL_MS } from "./constants";
 import { formatCommentMessage } from "./comment";
 import { hasCommand } from "./utils";
@@ -57,6 +56,7 @@ export default function editorExtension(pi: ExtensionAPI): void {
         return;
       }
       const initialPath = resolved.path;
+      const { createFileBrowser } = await import("./browser");
 
       await ctx.ui.custom<void>((tui, theme, _kb, done) => {
         let pollInterval: ReturnType<typeof setInterval> | null = null;

--- a/files-widget/utils.ts
+++ b/files-widget/utils.ts
@@ -1,19 +1,34 @@
-import { accessSync, constants } from "node:fs";
-import { delimiter, join } from "node:path";
+import { accessSync, constants, statSync } from "node:fs";
+import { extname, join } from "node:path";
 
-export function hasCommand(cmd: string): boolean {
-  const pathEntries = (process.env.PATH ?? "").split(delimiter);
-  const extensions = process.platform === "win32"
-    ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
+export interface CommandLookupOptions {
+  platform?: NodeJS.Platform;
+  path?: string;
+  pathExt?: string;
+  cwd?: string;
+}
+
+export function hasCommand(cmd: string, options: CommandLookupOptions = {}): boolean {
+  const platform = options.platform ?? process.platform;
+  const pathValue = options.path ?? process.env.PATH ?? "";
+  const pathEntries = pathValue.split(platform === "win32" ? ";" : ":");
+  const searchDirectories = platform === "win32"
+    ? [options.cwd ?? process.cwd(), ...pathEntries]
+    : pathEntries;
+  const extensions = platform === "win32" && !extname(cmd)
+    ? (options.pathExt ?? process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
     : [""];
-  const accessMode = process.platform === "win32" ? constants.F_OK : constants.X_OK;
+  const accessMode = platform === "win32" ? constants.F_OK : constants.X_OK;
 
-  for (const rawEntry of pathEntries) {
-    const entry = rawEntry.replace(/^"|"$/g, "") || ".";
+  for (const rawDirectory of searchDirectories) {
+    const directory = platform === "win32" && rawDirectory.startsWith('"') && rawDirectory.endsWith('"')
+      ? rawDirectory.slice(1, -1)
+      : rawDirectory;
     for (const extension of extensions) {
       try {
-        accessSync(join(entry, `${cmd}${extension}`), accessMode);
-        return true;
+        const candidate = join(directory || ".", `${cmd}${extension}`);
+        accessSync(candidate, accessMode);
+        if (statSync(candidate).isFile()) return true;
       } catch {
         // Continue searching PATH.
       }

--- a/files-widget/utils.ts
+++ b/files-widget/utils.ts
@@ -1,13 +1,26 @@
-import { execSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
 
 export function hasCommand(cmd: string): boolean {
-  try {
-    const checkCmd = process.platform === "win32" ? "where" : "which";
-    execSync(`${checkCmd} ${cmd}`, { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
+  const pathEntries = (process.env.PATH ?? "").split(delimiter);
+  const extensions = process.platform === "win32"
+    ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
+    : [""];
+  const accessMode = process.platform === "win32" ? constants.F_OK : constants.X_OK;
+
+  for (const rawEntry of pathEntries) {
+    const entry = rawEntry.replace(/^"|"$/g, "") || ".";
+    for (const extension of extensions) {
+      try {
+        accessSync(join(entry, `${cmd}${extension}`), accessMode);
+        return true;
+      } catch {
+        // Continue searching PATH.
+      }
+    }
   }
+
+  return false;
 }
 
 export function isUntrackedStatus(status?: string): boolean {

--- a/tests/files-widget-utils.test.mjs
+++ b/tests/files-widget-utils.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { hasCommand } from "../files-widget/utils.ts";
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), "files-widget-command-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function createFile(path, mode = 0o755) {
+  writeFileSync(path, "#!/bin/sh\n");
+  chmodSync(path, mode);
+}
+
+test("POSIX lookup accepts executable files and executable symlinks", (t) => {
+  const root = fixture(t);
+  createFile(join(root, "present"));
+  symlinkSync(join(root, "present"), join(root, "linked"));
+
+  assert.equal(hasCommand("present", { platform: "linux", path: root }), true);
+  assert.equal(hasCommand("linked", { platform: "linux", path: root }), true);
+});
+
+test("POSIX lookup rejects missing, non-executable, and directory entries", (t) => {
+  const root = fixture(t);
+  createFile(join(root, "not-executable"), 0o644);
+  mkdirSync(join(root, "directory"));
+
+  assert.equal(hasCommand("missing", { platform: "linux", path: root }), false);
+  assert.equal(hasCommand("not-executable", { platform: "linux", path: root }), false);
+  assert.equal(hasCommand("directory", { platform: "linux", path: root }), false);
+});
+
+test("POSIX treats quotes in PATH entries literally", (t) => {
+  const root = fixture(t);
+  createFile(join(root, "present"));
+
+  assert.equal(hasCommand("present", { platform: "linux", path: `"${root}"` }), false);
+});
+
+test("Windows lookup searches cwd before PATH and applies PATHEXT", (t) => {
+  const root = fixture(t);
+  const cwd = join(root, "cwd");
+  const pathDirectory = join(root, "path");
+  mkdirSync(cwd);
+  mkdirSync(pathDirectory);
+  createFile(join(cwd, "from-cwd.RUN"), 0o644);
+  createFile(join(pathDirectory, "from-path.RUN"), 0o644);
+
+  const options = { platform: "win32", cwd, path: pathDirectory, pathExt: ".RUN;.EXE" };
+  assert.equal(hasCommand("from-cwd", options), true);
+  assert.equal(hasCommand("from-path", options), true);
+  assert.equal(hasCommand("from-cwd.EXE", options), false);
+  assert.equal(hasCommand("missing", options), false);
+});
+
+test("Windows strips matching quotes around search directories", (t) => {
+  const root = fixture(t);
+  const pathDirectory = join(root, "quoted path");
+  mkdirSync(pathDirectory);
+  createFile(join(pathDirectory, "present.EXE"), 0o644);
+
+  assert.equal(hasCommand("present", {
+    platform: "win32",
+    cwd: join(root, "empty-cwd"),
+    path: `"${pathDirectory}"`,
+    pathExt: ".EXE",
+  }), true);
+});


### PR DESCRIPTION
## Summary
- replace three synchronous `which`/`where` subprocesses with direct executable lookup on `PATH`
- defer the 11-module file-browser graph until `/readfiles` is invoked
- preserve dependency notifications and `/readfiles` behavior

## Benchmark
Isolated `PI_CODING_AGENT_DIR`, offline RPC startup, no session/resources/context, 10s hard timeout. Thirty paired old/new samples for files-widget alone; 15 paired samples for the full 13-extension package. Cold uses a fresh config per process; warm reuses a primed config. p95 is nearest-rank. OS filesystem caches were not forcibly purged, and host wall time was noisy, so Pi's internal extension-import timer is the strongest attribution signal.

### files-widget alone (30 samples)
| | old | new |
|---|---:|---:|
| cold import median / p95 | 17 / 30 ms | 8.5 / 15 ms |
| warm import median / p95 | 15 / 31 ms | 8 / 12 ms |
| cold paired wall overhead median | 39.5 ms | 19.9 ms |
| warm paired wall overhead median | 31.4 ms | 2.1 ms |

### full package (15 samples)
| | old | new |
|---|---:|---:|
| cold files-widget import median / p95 | 9 / 12 ms | 2 / 3 ms |
| warm files-widget import median / p95 | 8 / 23 ms | 2 / 6 ms |
| cold paired wall overhead median | 34.9 ms | 21.3 ms |
| warm paired wall overhead median | 62.1 ms | 33.5 ms |

## Verification
- files-widget Pi load smoke
- all 13 repo extensions RPC startup smoke
- `/readfiles` RPC command with dependencies installed
- exact old/new missing-dependency notification parity with isolated `PATH`
- executable / missing / non-executable direct PATH lookup checks
- `npm pack --dry-run --json ./files-widget`
- `git diff --check`

No visual rendering code changed; the browser implementation is the same module, loaded at command invocation rather than process startup.
