### PR TITLE
Make Agent Skill README validation opt-in

### DIFF
--- a/extending-pi/skill-creator/CHANGELOG.md
+++ b/extending-pi/skill-creator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.3 - 2026-07-16
+- Keep `README.md` optional during ordinary Agent Skill validation, matching the documented Agent Skills format.
+- Add `--require-readme` for publishing workflows that require a README and Installation section.
+- Add regression tests for both validation modes.
+
 ## 0.3.2 - 2026-05-13
 - Rename artifact terminology from Pi skills to Agent Skills while keeping Pi-specific discovery and packaging guidance where relevant.
 - Refresh Pi discovery notes to include `.agents/skills` compatibility paths.

--- a/extending-pi/skill-creator/README.md
+++ b/extending-pi/skill-creator/README.md
@@ -16,3 +16,9 @@ scripts/validate_skill.py /path/to/my-skill
 # or, equivalently:
 uv run scripts/validate_skill.py /path/to/my-skill
 ```
+
+`README.md` is optional for ordinary Agent Skill validation. For a publishable human-facing package, require a README with an Installation section explicitly:
+
+```bash
+scripts/validate_skill.py --require-readme /path/to/my-skill
+```

--- a/extending-pi/skill-creator/SKILL.md
+++ b/extending-pi/skill-creator/SKILL.md
@@ -97,12 +97,18 @@ SKILL.md is the agent's interface to the skill.
 
 ### 8) Validate and test
 
-- Run the bundled validator at `scripts/validate_skill.py` from this `skill-creator` directory (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed):
+- Run the bundled validator at `scripts/validate_skill.py` from this `skill-creator` directory (uses [`uv`](https://docs.astral.sh/uv/) via a PEP 723 shebang, so PyYAML is provisioned in an ephemeral environment — no system install needed). A skill needs only `SKILL.md`; `README.md` remains optional:
 
 ```bash
 scripts/validate_skill.py /path/to/my-skill
 # or, equivalently:
 uv run scripts/validate_skill.py /path/to/my-skill
+```
+
+- Before publishing a human-facing package, opt into the stricter README and Installation-section checks:
+
+```bash
+scripts/validate_skill.py --require-readme /path/to/my-skill
 ```
 
 - Load only the skill in Pi to spot warnings:

--- a/extending-pi/skill-creator/package.json
+++ b/extending-pi/skill-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-skill-creator",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Detailed guidance for creating Agent Skills (Pi-compatible Agent Skills format).",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/extending-pi/skill-creator/references/PUBLISHING.md
+++ b/extending-pi/skill-creator/references/PUBLISHING.md
@@ -2,6 +2,14 @@
 
 To share with Pi users, make the skill installable with `pi install` from an npm package, git repository, or local path.
 
+Before publishing a human-facing package, run:
+
+```bash
+scripts/validate_skill.py --require-readme /path/to/my-skill
+```
+
+This opt-in mode requires a non-empty `README.md` with an Installation section; ordinary Agent Skill validation keeps README optional.
+
 Pi can load skills from either:
 
 1. A `package.json` `pi.skills` manifest, or

--- a/extending-pi/skill-creator/scripts/validate_skill.py
+++ b/extending-pi/skill-creator/scripts/validate_skill.py
@@ -4,10 +4,10 @@
 # dependencies = ["pyyaml>=6"]
 # ///
 """
-Validate an Agent Skill directory for Agent Skills + README requirements.
+Validate an Agent Skill directory, with optional publishing README checks.
 
 Usage:
-  scripts/validate_skill.py <skill_directory>
+  scripts/validate_skill.py [--require-readme] <skill_directory>
 
 Requires `uv` (https://docs.astral.sh/uv/). The shebang above runs the script
 in an ephemeral uv-managed environment with PyYAML, so nothing is installed
@@ -18,6 +18,7 @@ into the system Python. You can also invoke it explicitly:
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -62,12 +63,14 @@ def read_frontmatter(skill_md: Path) -> tuple[dict | None, str | None]:
     return frontmatter, None
 
 
-def validate_readme(readme_path: Path) -> tuple[list[str], list[str]]:
+def validate_readme(
+    readme_path: Path, *, required: bool = False
+) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
 
     if not readme_path.exists():
-        return ["README.md not found"], warnings
+        return (["README.md not found"] if required else []), warnings
 
     content = readme_path.read_text().strip()
     if not content:
@@ -159,7 +162,9 @@ def validate_frontmatter(frontmatter: dict, skill_dir: Path) -> tuple[list[str],
     return errors, warnings
 
 
-def validate_skill(skill_path: Path) -> tuple[list[str], list[str]]:
+def validate_skill(
+    skill_path: Path, *, require_readme: bool = False
+) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
 
@@ -183,7 +188,9 @@ def validate_skill(skill_path: Path) -> tuple[list[str], list[str]]:
     errors.extend(fm_errors)
     warnings.extend(fm_warnings)
 
-    readme_errors, readme_warnings = validate_readme(skill_path / "README.md")
+    readme_errors, readme_warnings = validate_readme(
+        skill_path / "README.md", required=require_readme
+    )
     errors.extend(readme_errors)
     warnings.extend(readme_warnings)
 
@@ -191,12 +198,19 @@ def validate_skill(skill_path: Path) -> tuple[list[str], list[str]]:
 
 
 def main() -> None:
-    if len(sys.argv) != 2:
-        print("Usage: scripts/validate_skill.py <skill_directory>")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--require-readme",
+        action="store_true",
+        help="require a non-empty README.md with an Installation section",
+    )
+    parser.add_argument("skill_directory", type=Path)
+    args = parser.parse_args()
 
-    skill_path = Path(sys.argv[1]).resolve()
-    errors, warnings = validate_skill(skill_path)
+    skill_path = args.skill_directory.resolve()
+    errors, warnings = validate_skill(
+        skill_path, require_readme=args.require_readme
+    )
 
     if warnings:
         print("Warnings:")

--- a/extending-pi/skill-creator/tests/test_validate_skill.py
+++ b/extending-pi/skill-creator/tests/test_validate_skill.py
@@ -1,0 +1,63 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate_skill.py"
+SPEC = importlib.util.spec_from_file_location("validate_skill", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class ValidateSkillTests(unittest.TestCase):
+    def make_skill(self, root: Path, readme: str | None = None) -> Path:
+        skill = root / "minimal-skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\n"
+            "name: minimal-skill\n"
+            "description: A minimal valid Agent Skill fixture.\n"
+            "---\n\n"
+            "# Minimal skill\n"
+        )
+        if readme is not None:
+            (skill / "README.md").write_text(readme)
+        return skill
+
+    def test_readme_is_optional_for_agent_skill_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            errors, warnings = MODULE.validate_skill(self.make_skill(Path(tempdir)))
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_publishing_mode_requires_readme(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            errors, _ = MODULE.validate_skill(
+                self.make_skill(Path(tempdir)), require_readme=True
+            )
+        self.assertEqual(errors, ["README.md not found"])
+
+    def test_existing_readme_keeps_installation_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            errors, _ = MODULE.validate_skill(
+                self.make_skill(Path(tempdir), "# Minimal skill\n\nSummary only.\n")
+            )
+        self.assertEqual(errors, ["README.md is missing an Installation section"])
+
+    def test_valid_publishing_readme_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            errors, warnings = MODULE.validate_skill(
+                self.make_skill(
+                    Path(tempdir),
+                    "# Minimal skill\n\nSummary.\n\n## Installation\n\nInstall it.\n",
+                ),
+                require_readme=True,
+            )
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- accept a valid minimal Agent Skill containing only `SKILL.md`
- add `--require-readme` for human-facing publishing checks
- align skill, README, and publishing guidance with the optional README contract
- bump `@tmustier/pi-skill-creator` to 0.3.3

## Verification
- 4 validator regression tests passed
- minimal-skill CLI smoke passed
- strict publishing-mode failure smoke passed
- `npm pack --dry-run` passed