### PR TITLE
Add visible editable queue and steer UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.47] - 2026-07-16
+
+### Added
+- Add `queue-steer`, a visible and individually editable FIFO follow-up queue that preserves Pi's existing queue and steer keybindings.
+
 ## [0.1.42] - 2026-05-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Personal extensions for the [Pi coding agent](https://github.com/badlogic/pi-mon
 | [agent-guidance](agent-guidance/) | Switch between Claude/Codex/Gemini with model-specific guidance (CLAUDE.md, CODEX.md, GEMINI.md) |
 | [/usage](usage-extension/) | 📊 Usage statistics dashboard. See cost, tokens, and messages by provider/model across Today, This Week, Last Week, and All Time — with a compact view for narrow terminals |
 | [/paste](raw-paste/) | Paste editable text, not [paste #1 +21 lines]. Running `/paste` with optional keybinding |
+| [queue-steer](queue-steer/) | Keep queued follow-ups visible and edit them individually without changing Pi's queue or steer keybindings |
 | [/code](code-actions/) | Pick code blocks or inline snippets from assistant messages to copy, insert, or run with `/code` |
 | [session-recap](session-recap/) | While-you-were-away recap above the editor when you return to a session. Keeps you in flow while multi-clauding |
 | [arcade](arcade/) | Play minigames while your tests run: 👾 sPIce-invaders, 👻 picman, 🏓 ping, 🧩 tetris, 🍄 mario-not |
@@ -60,6 +61,7 @@ If you keep a local clone, add extensions to your `~/.pi/agent/settings.json`:
     "~/pi-extensions/pi-ralph-wiggum",
     "~/pi-extensions/agent-guidance/agent-guidance.ts",
     "~/pi-extensions/raw-paste",
+    "~/pi-extensions/queue-steer",
     "~/pi-extensions/code-actions",
     "~/pi-extensions/session-recap",
     "~/pi-extensions/usage-extension"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "MIT",
   "private": false,
   "keywords": [
@@ -17,6 +17,7 @@
       "./code-actions/index.ts",
       "./files-widget/index.ts",
       "./raw-paste/index.ts",
+      "./queue-steer/index.ts",
       "./pi-ralph-wiggum/index.ts",
       "./session-recap/index.ts",
       "./tab-status/tab-status.ts",

--- a/queue-steer/CHANGELOG.md
+++ b/queue-steer/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [0.1.0] - 2026-07-16
+
+### Added
+
+- Visible FIFO follow-up queue above Pi's editor.
+- Individual queue-item editing through the existing `Alt+Up`, `Alt+Enter`, and `Enter` interaction.
+- Send-next-now behavior when `Enter` is pressed on an empty prompt.
+- One-at-a-time automatic dispatch after each agent run settles.

--- a/queue-steer/LICENSE
+++ b/queue-steer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thomas Mustier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/queue-steer/README.md
+++ b/queue-steer/README.md
@@ -1,0 +1,49 @@
+# Queue Steer extension
+
+A Cursor-style follow-up queue for Pi: queued prompts stay visible and can be edited one at a time while the agent continues working.
+
+The extension deliberately keeps Pi's existing delivery keys:
+
+- `Enter` steers the current run at Pi's next safe turn boundary
+- `Alt+Enter` queues a follow-up until the current run settles
+- `Alt+Up` selects the queued item nearest the editor; press it again to cycle backwards
+
+Press `Enter` on an empty prompt to take the oldest follow-up out of the queue and steer with it now.
+
+While a queued item is selected, edit it in Pi's normal editor. Then:
+
+- press `Alt+Enter` to save it in place
+- press `Enter` to remove it from the follow-up queue and steer with it now
+
+Follow-ups run in FIFO order, one at a time. The next queued prompt starts only after the preceding run settles.
+
+## Install
+
+```bash
+pi install npm:@tmustier/pi-queue-steer
+```
+
+Or enable it from this repository:
+
+```json
+{
+  "packages": [
+    {
+      "source": "git:github.com/tmustier/pi-extensions",
+      "extensions": ["queue-steer/index.ts"]
+    }
+  ]
+}
+```
+
+For a one-off test:
+
+```bash
+pi -e ./queue-steer/index.ts
+```
+
+## Notes
+
+- Queue state is session-local and intentionally not written into the transcript.
+- The extension handles interactive TUI follow-ups. RPC and extension-injected messages retain Pi's native queue behavior.
+- If the current editor contains an unrelated draft, `Alt+Up` leaves it intact and asks you to send or clear it first.

--- a/queue-steer/index.ts
+++ b/queue-steer/index.ts
@@ -1,0 +1,228 @@
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
+import {
+	CustomEditor,
+	keyText,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type Theme,
+} from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
+import { FollowUpQueue, type QueuedFollowUp } from "./queue-state";
+
+const WIDGET_ID = "queue-steer.follow-ups";
+
+function compactText(item: QueuedFollowUp<ImageContent>): string {
+	const text = item.text.replace(/\s+/g, " ").trim();
+	const imageNote = item.images.length > 0 ? ` [${item.images.length} image${item.images.length === 1 ? "" : "s"}]` : "";
+	return `${text || "[image follow-up]"}${imageNote}`;
+}
+
+function fitCell(content: string, width: number): string {
+	const clipped = truncateToWidth(content, Math.max(0, width), "");
+	return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+class FollowUpWidget implements Component {
+	constructor(
+		private readonly items: QueuedFollowUp<ImageContent>[],
+		private readonly editingId: string | undefined,
+		private readonly theme: Theme,
+	) {}
+
+	render(width: number): string[] {
+		if (width < 12) {
+			return [truncateToWidth(this.theme.fg("warning", `follow-ups (${this.items.length})`), width, "")];
+		}
+
+		const border = (text: string) => this.theme.fg("warning", text);
+		const title = ` follow-ups (${this.items.length}) `;
+		const topFill = "─".repeat(Math.max(0, width - title.length - 2));
+		const lines = [border(`┌${title}${topFill}┐`)];
+		const cellWidth = width - 4;
+
+		for (const item of this.items) {
+			const selected = item.id === this.editingId;
+			const prefix = selected ? "› " : "○ ";
+			const raw = `${prefix}${compactText(item)}`;
+			const styled = selected ? this.theme.fg("accent", raw) : this.theme.fg("muted", raw);
+			lines.push(`${border("│")} ${fitCell(styled, cellWidth)} ${border("│")}`);
+		}
+
+		const dequeue = keyText("app.message.dequeue");
+		const followUp = keyText("app.message.followUp");
+		const submit = keyText("tui.input.submit");
+		const help = this.editingId
+			? `${dequeue} previous · ${followUp} save · ${submit} steer now`
+			: `${submit} send next now · ${dequeue} select/edit · ${followUp} queue`;
+		lines.push(`${border("│")} ${fitCell(this.theme.fg("dim", help), cellWidth)} ${border("│")}`);
+		lines.push(border(`└${"─".repeat(width - 2)}┘`));
+		return lines;
+	}
+
+	invalidate(): void {}
+}
+
+function userContent(item: QueuedFollowUp<ImageContent>): string | (TextContent | ImageContent)[] {
+	if (item.images.length === 0) return item.text;
+	return [{ type: "text", text: item.text }, ...item.images];
+}
+
+export default function queueSteerExtension(pi: ExtensionAPI) {
+	const queue = new FollowUpQueue<ImageContent>();
+	let editingId: string | undefined;
+	let activeContext: ExtensionContext | undefined;
+
+	const renderQueue = (ctx: ExtensionContext): void => {
+		activeContext = ctx;
+		if (ctx.mode !== "tui" || queue.length === 0) {
+			ctx.ui.setWidget(WIDGET_ID, undefined);
+			return;
+		}
+
+		const items = queue.snapshot();
+		const selected = editingId;
+		ctx.ui.setWidget(WIDGET_ID, (_tui, theme) => new FollowUpWidget(items, selected, theme));
+	};
+
+	const syncEditingDraft = (ctx: ExtensionContext): void => {
+		if (!editingId) return;
+		queue.update(editingId, ctx.ui.getEditorText());
+	};
+
+	const selectPreviousFollowUp = (ctx: ExtensionContext): void => {
+		activeContext = ctx;
+		if (queue.length === 0) {
+			ctx.ui.notify("No queued follow-ups to edit", "info");
+			return;
+		}
+
+		if (!editingId && ctx.ui.getEditorText().trim()) {
+			ctx.ui.notify("Send or clear the current draft before editing queued follow-ups", "warning");
+			return;
+		}
+
+		syncEditingDraft(ctx);
+		editingId = queue.previousId(editingId);
+		const selected = editingId ? queue.get(editingId) : undefined;
+		if (!selected) return;
+		ctx.ui.setEditorText(selected.text);
+		renderQueue(ctx);
+	};
+
+	const sendNextNow = (ctx: ExtensionContext): void => {
+		activeContext = ctx;
+		syncEditingDraft(ctx);
+		const next = queue.shift();
+		if (!next) return;
+
+		if (editingId === next.id) {
+			editingId = undefined;
+			ctx.ui.setEditorText("");
+		}
+		renderQueue(ctx);
+
+		try {
+			if (ctx.isIdle()) {
+				pi.sendUserMessage(userContent(next));
+			} else {
+				pi.sendUserMessage(userContent(next), { deliverAs: "steer" });
+			}
+		} catch (error) {
+			queue.prepend(next);
+			renderQueue(ctx);
+			ctx.ui.notify(
+				`Could not send queued follow-up: ${error instanceof Error ? error.message : String(error)}`,
+				"error",
+			);
+		}
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		activeContext = ctx;
+		renderQueue(ctx);
+		if (ctx.mode !== "tui") return;
+
+		const previousFactory = ctx.ui.getEditorComponent();
+		ctx.ui.setEditorComponent((tui, theme, keybindings) => {
+			const editor = previousFactory?.(tui, theme, keybindings) ?? new CustomEditor(tui, theme, keybindings);
+			const handleInput = editor.handleInput.bind(editor);
+			editor.handleInput = (data: string): void => {
+				if (queue.length > 0 && keybindings.matches(data, "app.message.dequeue")) {
+					selectPreviousFollowUp(ctx);
+					return;
+				}
+				if (
+					queue.length > 0 &&
+					!editingId &&
+					!editor.getText().trim() &&
+					keybindings.matches(data, "tui.input.submit")
+				) {
+					sendNextNow(ctx);
+					return;
+				}
+				handleInput(data);
+			};
+			return editor;
+		});
+	});
+
+	pi.on("input", (event, ctx) => {
+		if (event.source !== "interactive") return { action: "continue" };
+		activeContext = ctx;
+
+		if (editingId) {
+			const selectedId = editingId;
+			queue.update(selectedId, event.text, event.images);
+			editingId = undefined;
+
+			if (event.streamingBehavior === "followUp") {
+				renderQueue(ctx);
+				return { action: "handled" };
+			}
+
+			queue.remove(selectedId);
+			renderQueue(ctx);
+			return { action: "continue" };
+		}
+
+		if (event.streamingBehavior === "followUp") {
+			queue.enqueue(event.text, event.images);
+			renderQueue(ctx);
+			return { action: "handled" };
+		}
+
+		return { action: "continue" };
+	});
+
+	pi.on("agent_settled", (_event, ctx) => {
+		if (!ctx.isIdle() || queue.length === 0) return;
+		activeContext = ctx;
+		syncEditingDraft(ctx);
+
+		const next = queue.shift();
+		if (!next) return;
+		if (editingId === next.id) {
+			editingId = undefined;
+			ctx.ui.setEditorText("");
+		}
+		renderQueue(ctx);
+
+		try {
+			pi.sendUserMessage(userContent(next));
+		} catch (error) {
+			queue.prepend(next);
+			renderQueue(ctx);
+			ctx.ui.notify(
+				`Could not send queued follow-up: ${error instanceof Error ? error.message : String(error)}`,
+				"error",
+			);
+		}
+	});
+
+	pi.on("session_shutdown", () => {
+		if (activeContext?.hasUI) activeContext.ui.setWidget(WIDGET_ID, undefined);
+		activeContext = undefined;
+		editingId = undefined;
+		queue.clear();
+	});
+}

--- a/queue-steer/package.json
+++ b/queue-steer/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@tmustier/pi-queue-steer",
+  "version": "0.1.0",
+  "description": "Visible, individually editable follow-up queue for Pi without changing steering or queue keybindings.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Thomas Mustier",
+  "keywords": [
+    "pi-package"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tmustier/pi-extensions.git",
+    "directory": "queue-steer"
+  },
+  "bugs": "https://github.com/tmustier/pi-extensions/issues",
+  "homepage": "https://github.com/tmustier/pi-extensions/tree/main/queue-steer",
+  "scripts": {
+    "test": "node --experimental-strip-types --test test/*.test.ts"
+  },
+  "pi": {
+    "extensions": [
+      "index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
+  }
+}

--- a/queue-steer/queue-state.ts
+++ b/queue-steer/queue-state.ts
@@ -1,0 +1,70 @@
+export interface QueuedFollowUp<TImage = unknown> {
+	id: string;
+	text: string;
+	images: TImage[];
+}
+
+/** Small FIFO with stable ids so a visible item can be edited while the queue advances. */
+export class FollowUpQueue<TImage = unknown> {
+	private items: QueuedFollowUp<TImage>[] = [];
+	private nextId = 1;
+
+	enqueue(text: string, images: readonly TImage[] = []): QueuedFollowUp<TImage> {
+		const item = { id: `follow-up-${this.nextId++}`, text, images: [...images] };
+		this.items.push(item);
+		return this.copy(item);
+	}
+
+	prepend(item: QueuedFollowUp<TImage>): void {
+		this.items.unshift(this.copy(item));
+	}
+
+	update(id: string, text: string, images?: readonly TImage[]): boolean {
+		const item = this.items.find((candidate) => candidate.id === id);
+		if (!item) return false;
+		item.text = text;
+		if (images) item.images = [...images];
+		return true;
+	}
+
+	remove(id: string): QueuedFollowUp<TImage> | undefined {
+		const index = this.items.findIndex((item) => item.id === id);
+		if (index === -1) return undefined;
+		const [item] = this.items.splice(index, 1);
+		return item ? this.copy(item) : undefined;
+	}
+
+	shift(): QueuedFollowUp<TImage> | undefined {
+		const item = this.items.shift();
+		return item ? this.copy(item) : undefined;
+	}
+
+	get(id: string): QueuedFollowUp<TImage> | undefined {
+		const item = this.items.find((candidate) => candidate.id === id);
+		return item ? this.copy(item) : undefined;
+	}
+
+	previousId(currentId?: string): string | undefined {
+		if (this.items.length === 0) return undefined;
+		if (!currentId) return this.items.at(-1)?.id;
+		const index = this.items.findIndex((item) => item.id === currentId);
+		if (index <= 0) return this.items.at(-1)?.id;
+		return this.items[index - 1]?.id;
+	}
+
+	snapshot(): QueuedFollowUp<TImage>[] {
+		return this.items.map((item) => this.copy(item));
+	}
+
+	get length(): number {
+		return this.items.length;
+	}
+
+	clear(): void {
+		this.items = [];
+	}
+
+	private copy(item: QueuedFollowUp<TImage>): QueuedFollowUp<TImage> {
+		return { ...item, images: [...item.images] };
+	}
+}

--- a/queue-steer/test/queue-state.test.ts
+++ b/queue-steer/test/queue-state.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FollowUpQueue } from "../queue-state.ts";
+
+test("dispatches follow-ups in FIFO order", () => {
+	const queue = new FollowUpQueue<string>();
+	queue.enqueue("first", ["one.png"]);
+	queue.enqueue("second");
+
+	assert.deepEqual(queue.shift(), {
+		id: "follow-up-1",
+		text: "first",
+		images: ["one.png"],
+	});
+	assert.equal(queue.shift()?.text, "second");
+	assert.equal(queue.length, 0);
+});
+
+test("edits one item without changing its position", () => {
+	const queue = new FollowUpQueue();
+	const first = queue.enqueue("first");
+	queue.enqueue("second");
+
+	assert.equal(queue.update(first.id, "first, edited"), true);
+	assert.deepEqual(queue.snapshot().map((item) => item.text), ["first, edited", "second"]);
+});
+
+test("cycles upward from the item nearest the editor", () => {
+	const queue = new FollowUpQueue();
+	const first = queue.enqueue("first");
+	const second = queue.enqueue("second");
+	const third = queue.enqueue("third");
+
+	assert.equal(queue.previousId(), third.id);
+	assert.equal(queue.previousId(third.id), second.id);
+	assert.equal(queue.previousId(second.id), first.id);
+	assert.equal(queue.previousId(first.id), third.id);
+});
+
+test("restores a failed dispatch at the front", () => {
+	const queue = new FollowUpQueue();
+	queue.enqueue("first");
+	queue.enqueue("second");
+	const first = queue.shift();
+	assert.ok(first);
+	queue.prepend(first);
+
+	assert.deepEqual(queue.snapshot().map((item) => item.text), ["first", "second"]);
+});


### PR DESCRIPTION
## Summary
- add a visible FIFO follow-up queue above Pi's editor
- preserve Pi's existing Enter steering and Alt+Enter queueing bindings
- edit queued prompts individually with the configured dequeue binding
- send the next queued prompt now by pressing Enter on an empty editor
- compose with existing custom editors such as raw-paste

## Verification
- `npm --prefix queue-steer test`
- strict `tsc --noEmit`
- interactive tmux run: queued two prompts during a long tool call, edited one in place, observed FIFO dispatch, and steered with Enter
- interactive tmux run with both raw-paste and queue-steer loaded
