### PR TITLE
Compose queue and raw paste with late custom editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.48] - 2026-07-16
+
+### Fixed
+- Preserve queue-steer, raw-paste, and session HUD behavior when several extensions compose around Pi's editor.
+
 ## [0.1.47] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/queue-steer/CHANGELOG.md
+++ b/queue-steer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.1] - 2026-07-16
+
+### Fixed
+
+- Recompose around editor extensions installed later, including pi-session-hud and raw-paste.
+
 ## [0.1.0] - 2026-07-16
 
 ### Added

--- a/queue-steer/index.ts
+++ b/queue-steer/index.ts
@@ -10,6 +10,15 @@ import { truncateToWidth, visibleWidth, type Component } from "@earendil-works/p
 import { FollowUpQueue, type QueuedFollowUp } from "./queue-state";
 
 const WIDGET_ID = "queue-steer.follow-ups";
+const EDITOR_FEATURES = Symbol.for("@tmustier/pi-editor-features");
+const QUEUE_STEER_FEATURE = "queue-steer";
+
+type EditorFactory = NonNullable<ReturnType<ExtensionContext["ui"]["getEditorComponent"]>>;
+type ComposedEditorFactory = EditorFactory & { [EDITOR_FEATURES]?: ReadonlySet<string> };
+
+function editorFeatures(factory: EditorFactory | undefined): ReadonlySet<string> {
+	return (factory as ComposedEditorFactory | undefined)?.[EDITOR_FEATURES] ?? new Set();
+}
 
 function compactText(item: QueuedFollowUp<ImageContent>): string {
 	const text = item.text.replace(/\s+/g, " ").trim();
@@ -137,13 +146,14 @@ export default function queueSteerExtension(pi: ExtensionAPI) {
 		}
 	};
 
-	pi.on("session_start", (_event, ctx) => {
-		activeContext = ctx;
-		renderQueue(ctx);
+	const installEditor = (ctx: ExtensionContext): void => {
 		if (ctx.mode !== "tui") return;
 
 		const previousFactory = ctx.ui.getEditorComponent();
-		ctx.ui.setEditorComponent((tui, theme, keybindings) => {
+		const features = editorFeatures(previousFactory);
+		if (features.has(QUEUE_STEER_FEATURE)) return;
+
+		const factory = ((tui, theme, keybindings) => {
 			const editor = previousFactory?.(tui, theme, keybindings) ?? new CustomEditor(tui, theme, keybindings);
 			const handleInput = editor.handleInput.bind(editor);
 			editor.handleInput = (data: string): void => {
@@ -163,7 +173,20 @@ export default function queueSteerExtension(pi: ExtensionAPI) {
 				handleInput(data);
 			};
 			return editor;
-		});
+		}) as ComposedEditorFactory;
+		factory[EDITOR_FEATURES] = new Set([...features, QUEUE_STEER_FEATURE]);
+		ctx.ui.setEditorComponent(factory);
+	};
+
+	pi.on("session_start", (_event, ctx) => {
+		activeContext = ctx;
+		renderQueue(ctx);
+		installEditor(ctx);
+	});
+
+	// Recompose after late-installed editor chrome, such as pi-session-hud.
+	pi.on("agent_start", (_event, ctx) => {
+		installEditor(ctx);
 	});
 
 	pi.on("input", (event, ctx) => {

--- a/queue-steer/package.json
+++ b/queue-steer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-queue-steer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Visible, individually editable follow-up queue for Pi without changing steering or queue keybindings.",
   "type": "module",
   "license": "MIT",

--- a/raw-paste/CHANGELOG.md
+++ b/raw-paste/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.4] - 2026-07-16
+
+### Fixed
+- Compose with other custom editors instead of replacing them.
+- Recompose after late-installed editor chrome such as pi-session-hud.
+
 ## [0.1.3] - 2026-05-07
 
 ### Changed

--- a/raw-paste/index.ts
+++ b/raw-paste/index.ts
@@ -3,33 +3,39 @@ import { CustomEditor, type ExtensionAPI, type ExtensionContext } from "@earendi
 const PASTE_START = "\x1b[200~";
 const PASTE_END = "\x1b[201~";
 const PASTE_END_LEN = PASTE_END.length;
+const EDITOR_FEATURES = Symbol.for("@tmustier/pi-editor-features");
+const RAW_PASTE_FEATURE = "raw-paste";
 
-class RawPasteEditor extends CustomEditor {
+type EditorFactory = NonNullable<ReturnType<ExtensionContext["ui"]["getEditorComponent"]>>;
+type ComposedEditorFactory = EditorFactory & { [EDITOR_FEATURES]?: ReadonlySet<string> };
+
+function editorFeatures(factory: EditorFactory | undefined): ReadonlySet<string> {
+	return (factory as ComposedEditorFactory | undefined)?.[EDITOR_FEATURES] ?? new Set();
+}
+
+class RawPasteController {
 	private rawPasteArmed = false;
 	private rawPasteBuffer = "";
 	private isInRawPaste = false;
-	private onArm?: () => void;
 
 	constructor(
-		tui: ConstructorParameters<typeof CustomEditor>[0],
-		theme: ConstructorParameters<typeof CustomEditor>[1],
-		keybindings: ConstructorParameters<typeof CustomEditor>[2],
-		onArm?: () => void,
-	) {
-		super(tui, theme, keybindings);
-		this.onArm = onArm;
-	}
+		private readonly sendInput: (data: string) => void,
+		private readonly insertText?: (text: string) => void,
+		private readonly onArm?: () => void,
+	) {}
 
-	armRawPaste(): void {
+	arm(): void {
 		this.rawPasteArmed = true;
 		this.onArm?.();
 	}
 
-	private flushRawPaste(content: string): void {
+	private flush(content: string): void {
 		const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-		for (const char of normalized) {
-			super.handleInput(char);
+		if (this.insertText) {
+			this.insertText(normalized);
+			return;
 		}
+		for (const char of normalized) this.sendInput(char);
 	}
 
 	private handleRawPasteInput(data: string): boolean {
@@ -52,12 +58,8 @@ class RawPasteEditor extends CustomEditor {
 				this.isInRawPaste = false;
 				this.rawPasteArmed = false;
 
-				if (pasteContent.length > 0) {
-					this.flushRawPaste(pasteContent);
-				}
-				if (remaining.length > 0) {
-					this.handleInput(remaining);
-				}
+				if (pasteContent.length > 0) this.flush(pasteContent);
+				if (remaining.length > 0 && !this.handleInput(remaining)) this.sendInput(remaining);
 			}
 			return true;
 		}
@@ -65,41 +67,62 @@ class RawPasteEditor extends CustomEditor {
 		return handled;
 	}
 
-	handleInput(data: string): void {
-		if (this.rawPasteArmed || this.isInRawPaste) {
-			if (this.handleRawPasteInput(data)) {
-				return;
-			}
-		}
-
-		super.handleInput(data);
+	handleInput(data: string): boolean {
+		return (this.rawPasteArmed || this.isInRawPaste) && this.handleRawPasteInput(data);
 	}
 }
 
 export default function (pi: ExtensionAPI) {
-	let editor: RawPasteEditor | null = null;
+	let controller: RawPasteController | undefined;
 
 	const notifyArmed = (ctx: ExtensionContext): void => {
-		if (!ctx.hasUI) return;
-		ctx.ui.notify("Raw paste armed. Paste now.", "info");
+		if (ctx.hasUI) ctx.ui.notify("Raw paste armed. Paste now.", "info");
+	};
+
+	const installEditor = (ctx: ExtensionContext): void => {
+		if (ctx.mode !== "tui") return;
+
+		const previousFactory = ctx.ui.getEditorComponent();
+		const features = editorFeatures(previousFactory);
+		if (features.has(RAW_PASTE_FEATURE)) return;
+
+		const factory = ((tui, theme, keybindings) => {
+			const editor = previousFactory?.(tui, theme, keybindings) ?? new CustomEditor(tui, theme, keybindings);
+			const handleInput = editor.handleInput.bind(editor);
+			controller = new RawPasteController(
+				handleInput,
+				editor.insertTextAtCursor?.bind(editor),
+				() => notifyArmed(ctx),
+			);
+			editor.handleInput = (data: string): void => {
+				if (!controller?.handleInput(data)) handleInput(data);
+			};
+			return editor;
+		}) as ComposedEditorFactory;
+		factory[EDITOR_FEATURES] = new Set([...features, RAW_PASTE_FEATURE]);
+		ctx.ui.setEditorComponent(factory);
 	};
 
 	const armRawPaste = (ctx: ExtensionContext): void => {
-		if (!editor) {
+		installEditor(ctx);
+		if (!controller) {
 			if (ctx.hasUI) ctx.ui.notify("Raw paste editor not ready.", "warning");
 			return;
 		}
-
-		editor.armRawPaste();
+		controller.arm();
 	};
 
 	pi.on("session_start", (_event, ctx) => {
-		if (!ctx.hasUI) return;
+		installEditor(ctx);
+	});
 
-		ctx.ui.setEditorComponent((tui, theme, keybindings) => {
-			editor = new RawPasteEditor(tui, theme, keybindings, () => notifyArmed(ctx));
-			return editor;
-		});
+	// Recompose after late-installed editor chrome, such as pi-session-hud.
+	pi.on("agent_start", (_event, ctx) => {
+		installEditor(ctx);
+	});
+
+	pi.on("session_shutdown", () => {
+		controller = undefined;
 	});
 
 	pi.registerCommand("paste", {
@@ -108,5 +131,4 @@ export default function (pi: ExtensionAPI) {
 			armRawPaste(ctx);
 		},
 	});
-
 }

--- a/raw-paste/package.json
+++ b/raw-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-raw-paste",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "One-shot raw paste support for Pi (/paste).",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Summary
- make queue-steer and raw-paste wrap the active editor instead of replacing its behavior
- tag composed factories to avoid duplicate wrappers
- recompose at agent start after late editor chrome such as pi-session-hud
- preserve raw paste insertion through the wrapped editor

## Verification
- `npm --prefix queue-steer test`
- strict `tsc --noEmit` across queue-steer and raw-paste
- interactive tmux run with raw-paste, queue-steer, and pi-session-hud loaded in production order
- queued two prompts, selected and edited one with Alt+Up/Alt+Enter, steered with Enter, and observed FIFO completion
- armed `/paste` while the HUD editor remained active
