### PR TITLE
feat(usage-extension): Last 30 Days period tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.48] - 2026-07-17
+
+### Added
+- `usage-extension` 0.5.0: new Last 30 Days period tab (rolling 30 calendar days including today).
+
 ## [0.1.47] - 2026-07-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -11,7 +11,9 @@ const NOW = new Date(2026, 6, 15, 12, 0, 0);
 const TS_TODAY = new Date(2026, 6, 15, 9, 0, 0).getTime();
 const TS_THIS_WEEK = new Date(2026, 6, 14, 10, 0, 0).getTime(); // Tuesday this week
 const TS_LAST_WEEK = new Date(2026, 6, 10, 10, 0, 0).getTime(); // Friday last week
-const TS_OLD = new Date(2026, 5, 1, 10, 0, 0).getTime(); // 1 June
+const TS_OLD = new Date(2026, 5, 1, 10, 0, 0).getTime(); // 1 June — outside the 30-day window
+const TS_30D_EDGE_IN = new Date(2026, 5, 16, 0, 0, 0).getTime(); // midnight 29 days before 15 July — first instant inside
+const TS_30D_EDGE_OUT = new Date(2026, 5, 15, 23, 59, 59).getTime(); // one second earlier — outside
 
 function fixture(t) {
 	const root = mkdtempSync(join(tmpdir(), "usage-data-"));
@@ -170,6 +172,10 @@ test("collectUsageData aggregates periods, providers, and dedupes branched histo
 	assert.equal(data.thisWeek.totals.messages, 2); // today + Tuesday
 	assert.equal(data.lastWeek.totals.messages, 1);
 	assert.equal(data.lastWeek.totals.cost, 1);
+	// All three unique messages fall inside the rolling 30-day window.
+	assert.equal(data.last30Days.totals.messages, 3);
+	assert.equal(data.last30Days.totals.cost, 7);
+	assert.equal(data.last30Days.totals.sessions, 2);
 
 	// Provider breakdown.
 	const anthropic = data.allTime.providers.get("anthropic");
@@ -179,6 +185,29 @@ test("collectUsageData aggregates periods, providers, and dedupes branched histo
 	assert.equal(anthropic.models.get("claude-fable-5").messages, 2);
 	assert.equal(openai.messages, 1);
 	assert.equal(openai.cost, 4);
+});
+
+test("collectUsageData buckets the rolling 30-day window from midnight 29 days back", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	writeFileSync(
+		join(sessionsDir, "a.jsonl"),
+		[
+			sessionLine("s1", TS_OLD),
+			assistantLine({ ts: TS_30D_EDGE_OUT, cost: 1 }), // outside — allTime only
+			assistantLine({ ts: TS_30D_EDGE_IN, cost: 2 }), // first instant inside the window
+			assistantLine({ ts: TS_LAST_WEEK, cost: 4 }), // last week is also within 30 days
+			assistantLine({ ts: TS_TODAY, cost: 8 }),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.allTime.totals.messages, 4);
+	assert.equal(data.last30Days.totals.messages, 3);
+	assert.equal(data.last30Days.totals.cost, 14);
+	assert.equal(data.last30Days.totals.sessions, 1);
+	// The 30-day window overlaps but does not replace the week buckets.
+	assert.equal(data.lastWeek.totals.cost, 4);
+	assert.equal(data.today.totals.cost, 8);
 });
 
 test("collectUsageData ignores files without a session header", async (t) => {

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0] - 2026-07-17
+
+### Added
+- **Last 30 Days period.** New tab between Last Week and All Time covering the last 30 calendar days including today (from midnight 29 days back, DST-safe). Available in both the table and insights views.
+
 ## [0.4.0] - 2026-07-17
 
 ### Performance

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -7,7 +7,7 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 ## Compatibility
 
 - **Pi version:** 0.42.4+
-- **Last updated:** 2026-07-17 (0.4.0)
+- **Last updated:** 2026-07-17 (0.5.0)
 
 ## Installation
 
@@ -83,6 +83,7 @@ The insights currently shown:
 | **Today** | From midnight (00:00) today |
 | **This Week** | From Monday 00:00 of the current week |
 | **Last Week** | Previous week (Monday 00:00 → this Monday 00:00) |
+| **Last 30 Days** | Rolling window: the last 30 calendar days including today (from midnight 29 days back) |
 | **All Time** | All recorded sessions |
 
 Use `Tab` or `←`/`→` to switch between periods.

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -85,12 +85,13 @@ export interface UsageData {
 	today: TimeFilteredStats;
 	thisWeek: TimeFilteredStats;
 	lastWeek: TimeFilteredStats;
+	last30Days: TimeFilteredStats;
 	allTime: TimeFilteredStats;
 }
 
-export type TabName = "today" | "thisWeek" | "lastWeek" | "allTime";
+export type TabName = "today" | "thisWeek" | "lastWeek" | "last30Days" | "allTime";
 
-export const TAB_ORDER: TabName[] = ["today", "thisWeek", "lastWeek", "allTime"];
+export const TAB_ORDER: TabName[] = ["today", "thisWeek", "lastWeek", "last30Days", "allTime"];
 
 export interface SessionMessage {
 	provider: string;
@@ -396,6 +397,7 @@ function emptyUsageData(): UsageData {
 		today: emptyTimeFilteredStats(),
 		thisWeek: emptyTimeFilteredStats(),
 		lastWeek: emptyTimeFilteredStats(),
+		last30Days: emptyTimeFilteredStats(),
 		allTime: emptyTimeFilteredStats(),
 	};
 }
@@ -415,7 +417,13 @@ function accumulateStats(
 	target.tokens.cacheWrite += tokens.cacheWrite;
 }
 
-function getPeriodsForTimestamp(timestamp: number, todayMs: number, weekStartMs: number, lastWeekStartMs: number): TabName[] {
+function getPeriodsForTimestamp(
+	timestamp: number,
+	todayMs: number,
+	weekStartMs: number,
+	lastWeekStartMs: number,
+	last30DaysStartMs: number
+): TabName[] {
 	const periods: TabName[] = ["allTime"];
 	if (timestamp >= todayMs) periods.push("today");
 	if (timestamp >= weekStartMs) {
@@ -423,6 +431,7 @@ function getPeriodsForTimestamp(timestamp: number, todayMs: number, weekStartMs:
 	} else if (timestamp >= lastWeekStartMs) {
 		periods.push("lastWeek");
 	}
+	if (timestamp >= last30DaysStartMs) periods.push("last30Days");
 	return periods;
 }
 
@@ -433,10 +442,11 @@ function addMessagesToUsageData(
 	todayMs: number,
 	weekStartMs: number,
 	lastWeekStartMs: number,
+	last30DaysStartMs: number,
 	rawByPeriod: Record<TabName, PeriodRawData>,
 	globalSessionSpans: Map<string, GlobalSessionSpan>
 ): void {
-	const sessionContributed = { today: false, thisWeek: false, lastWeek: false, allTime: false };
+	const sessionContributed = { today: false, thisWeek: false, lastWeek: false, last30Days: false, allTime: false };
 
 	for (const msg of messages) {
 		// Track real per-session lifetime across every message we see, regardless of
@@ -451,7 +461,7 @@ function addMessagesToUsageData(
 			}
 		}
 
-		const periods = getPeriodsForTimestamp(msg.timestamp, todayMs, weekStartMs, lastWeekStartMs);
+		const periods = getPeriodsForTimestamp(msg.timestamp, todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs);
 		const tokens = {
 			// Count fresh tokens processed this turn.
 			// Include cacheWrite because those prompt tokens were newly written and billed.
@@ -503,6 +513,7 @@ function addMessagesToUsageData(
 	if (sessionContributed.today) data.today.totals.sessions++;
 	if (sessionContributed.thisWeek) data.thisWeek.totals.sessions++;
 	if (sessionContributed.lastWeek) data.lastWeek.totals.sessions++;
+	if (sessionContributed.last30Days) data.last30Days.totals.sessions++;
 	if (sessionContributed.allTime) data.allTime.totals.sessions++;
 }
 
@@ -548,6 +559,12 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 	const startOfLastWeek = new Date(startOfWeek);
 	startOfLastWeek.setDate(startOfLastWeek.getDate() - 7);
 	const lastWeekStartMs = startOfLastWeek.getTime();
+
+	// Rolling 30-day window: the last 30 calendar days including today,
+	// i.e. from midnight 29 days before today. setDate handles DST correctly.
+	const startOfLast30Days = new Date(startOfToday);
+	startOfLast30Days.setDate(startOfLast30Days.getDate() - 29);
+	const last30DaysStartMs = startOfLast30Days.getTime();
 
 	// 1. Discover session files.
 	const filePaths = await getAllSessionFiles(sessionsDir, signal);
@@ -647,6 +664,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 		today: emptyPeriodRawData(),
 		thisWeek: emptyPeriodRawData(),
 		lastWeek: emptyPeriodRawData(),
+		last30Days: emptyPeriodRawData(),
 		allTime: emptyPeriodRawData(),
 	};
 	const globalSessionSpans = new Map<string, GlobalSessionSpan>();
@@ -680,6 +698,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 			todayMs,
 			weekStartMs,
 			lastWeekStartMs,
+			last30DaysStartMs,
 			rawByPeriod,
 			globalSessionSpans
 		);

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -210,6 +210,7 @@ const TAB_LABELS: Record<TabName, string> = {
 	today: "Today",
 	thisWeek: "This Week",
 	lastWeek: "Last Week",
+	last30Days: "Last 30 Days",
 	allTime: "All Time",
 };
 

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
Adds a **Last 30 Days** tab to `/usage`, between Last Week and All Time — a rolling window covering the last 30 calendar days including today (from midnight 29 days back, DST-safe via `setDate`). Works in both table and insights views.

- Overlaps the week buckets (a last-week message is also in the 30-day window), matching how the existing periods already overlap `allTime`.
- Cache format unchanged — period bucketing happens at aggregation time, so existing caches stay valid and warm opens stay ~0.3–0.5 s (verified on the real corpus: `last30Days` $13.3k sits between `lastWeek` $5.6k and `allTime` $18.5k).
- Tests: boundary inclusion at midnight −29d, exclusion one second earlier, week-bucket overlap. 21/21 pass, `tsc --strict` clean on `data.ts`.
- Versions: usage-extension 0.4.0 → 0.5.0, repo 0.1.47 → 0.1.48 (no publish/tag).