### PR TITLE
feat(usage): interactive graph explorer view (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.49] - 2026-07-17
+
+### Added
+- `usage-extension` 0.6.0: interactive graph explorer view (cost/tokens/messages/reasoning over time, grouped by provider/model/thinking level, cumulative or per-bucket, with legend filtering). Cache format bumped to v2. See `usage-extension/CHANGELOG.md`.
+
 ## [0.1.48] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -27,7 +27,7 @@ function sessionLine(id, ts) {
 	return JSON.stringify({ type: "session", version: 3, id, timestamp: new Date(ts).toISOString(), cwd: "/tmp" });
 }
 
-function assistantLine({ ts, provider = "anthropic", model = "claude-fable-5", cost = 1, input = 100, output = 50, cacheRead = 0, cacheWrite = 0 }) {
+function assistantLine({ ts, provider = "anthropic", model = "claude-fable-5", cost = 1, input = 100, output = 50, cacheRead = 0, cacheWrite = 0, reasoning = 0 }) {
 	return JSON.stringify({
 		type: "message",
 		id: "m1",
@@ -38,10 +38,14 @@ function assistantLine({ ts, provider = "anthropic", model = "claude-fable-5", c
 			content: [{ type: "text", text: "hi" }],
 			provider,
 			model,
-			usage: { input, output, cacheRead, cacheWrite, cost: { total: cost } },
+			usage: { input, output, cacheRead, cacheWrite, reasoning, cost: { total: cost } },
 			timestamp: ts,
 		},
 	});
+}
+
+function thinkingLine(level, ts) {
+	return JSON.stringify({ type: "thinking_level_change", id: "t1", timestamp: new Date(ts).toISOString(), thinkingLevel: level });
 }
 
 function userLine(ts, text = "hello") {
@@ -74,13 +78,49 @@ test("parseSessionBuffer extracts session id and assistant messages from compact
 	assert.deepEqual(parsed.messages[0], {
 		provider: "anthropic",
 		model: "claude-fable-5",
+		thinkingLevel: "",
 		cost: 2.5,
 		input: 10,
 		output: 20,
 		cacheRead: 30,
 		cacheWrite: 40,
+		reasoning: 0,
 		timestamp: TS_TODAY,
 	});
+});
+
+test("parseSessionBuffer attributes thinking levels by replaying change entries", async () => {
+	const content = [
+		sessionLine("s1", TS_TODAY),
+		thinkingLine("high", TS_TODAY),
+		assistantLine({ ts: TS_TODAY, cost: 1 }),
+		thinkingLine("xhigh", TS_TODAY + 1000),
+		assistantLine({ ts: TS_TODAY + 2000, cost: 2, reasoning: 55 }),
+		assistantLine({ ts: TS_TODAY + 3000, cost: 3 }),
+	].join("\n");
+
+	const parsed = await parseSessionBuffer(Buffer.from(content, "utf8"));
+	assert.deepEqual(
+		parsed.messages.map((m) => m.thinkingLevel),
+		["high", "xhigh", "xhigh"]
+	);
+	assert.equal(parsed.messages[1].reasoning, 55);
+});
+
+test("parseSessionBuffer handles spaced thinking_level_change entries and messages before any change", async () => {
+	const iso = new Date(TS_TODAY).toISOString();
+	const content = [
+		sessionLine("s1", TS_TODAY),
+		assistantLine({ ts: TS_TODAY, cost: 1 }), // before any change → unknown ("")
+		`{"type": "thinking_level_change", "id": "t", "timestamp": "${iso}", "thinkingLevel": "medium"}`,
+		assistantLine({ ts: TS_TODAY + 1000, cost: 2 }),
+	].join("\n");
+
+	const parsed = await parseSessionBuffer(Buffer.from(content, "utf8"));
+	assert.deepEqual(
+		parsed.messages.map((m) => m.thinkingLevel),
+		["", "medium"]
+	);
 });
 
 test("parseSessionBuffer handles Python-style spaced JSON", async () => {
@@ -158,6 +198,16 @@ test("collectUsageData aggregates periods, providers, and dedupes branched histo
 
 	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
 	assert.ok(data);
+
+	// Hourly buckets and bounds power the graph view.
+	assert.equal(data.bounds.nowMs, NOW.getTime());
+	const hourMs = 3_600_000;
+	const todayHour = Math.floor(TS_TODAY / hourMs) * hourMs;
+	const todayBucket = data.hourly.get(todayHour);
+	assert.ok(todayBucket, "expected an hourly bucket for the today message");
+	const todayCell = todayBucket.get("anthropic\u0000claude-fable-5\u0000");
+	assert.equal(todayCell.cost, 2);
+	assert.equal(todayCell.messages, 1);
 
 	// All time: 3 unique messages (the copy was deduped), 2 session files.
 	assert.equal(data.allTime.totals.messages, 3);
@@ -306,7 +356,7 @@ test("collectUsageData survives a corrupt cache file", async (t) => {
 
 	// Cache was rebuilt.
 	const cacheJson = JSON.parse(readFileSync(cachePath, "utf8"));
-	assert.equal(cacheJson.version, 1);
+	assert.equal(cacheJson.version, 2);
 });
 
 test("collectUsageData works with the cache disabled", async (t) => {
@@ -336,8 +386,8 @@ test("saveUsageCache/loadUsageCache round-trips file states", async (t) => {
 				parsed: {
 					sessionId: "s1",
 					messages: [
-						{ provider: "anthropic", model: "claude-fable-5", cost: 1.5, input: 10, output: 20, cacheRead: 30, cacheWrite: 40, timestamp: TS_TODAY },
-						{ provider: "openai", model: "gpt-5.6-sol", cost: 0.25, input: 1, output: 2, cacheRead: 3, cacheWrite: 4, timestamp: TS_OLD },
+						{ provider: "anthropic", model: "claude-fable-5", thinkingLevel: "xhigh", cost: 1.5, input: 10, output: 20, cacheRead: 30, cacheWrite: 40, reasoning: 7, timestamp: TS_TODAY },
+						{ provider: "openai", model: "gpt-5.6-sol", thinkingLevel: "", cost: 0.25, input: 1, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 0, timestamp: TS_OLD },
 					],
 				},
 			},
@@ -364,21 +414,35 @@ test("loadUsageCache rejects wrong versions and malformed entries", async (t) =>
 	writeFileSync(cachePath, JSON.stringify({ version: 999, names: [], files: {} }));
 	assert.equal((await loadUsageCache(cachePath)).size, 0);
 
+	// v1 caches (pre-thinking-level) must be rejected wholesale, forcing a rebuild.
 	writeFileSync(
 		cachePath,
 		JSON.stringify({
 			version: 1,
 			names: ["p", "m"],
+			files: { "/v1.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY]] } },
+		})
+	);
+	assert.equal((await loadUsageCache(cachePath)).size, 0);
+
+	writeFileSync(
+		cachePath,
+		JSON.stringify({
+			version: 2,
+			names: ["p", "m", "high"],
 			files: {
-				"/ok.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY]] },
+				"/ok.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 5]] },
 				"/bad-tuple.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1]] },
-				"/bad-name-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[7, 1, 1, 1, 1, 0, 0, TS_TODAY]] },
+				"/bad-name-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[7, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0]] },
+				"/bad-level-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 9, 0]] },
 				"/bad-shape.jsonl": { size: "x", mtimeMs: 2, sessionId: "s", messages: [] },
 			},
 		})
 	);
 	const loaded = await loadUsageCache(cachePath);
 	assert.deepEqual([...loaded.keys()], ["/ok.jsonl"]);
+	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].thinkingLevel, "high");
+	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].reasoning, 5);
 });
 
 test("loadUsageCache returns empty for a missing cache file", async (t) => {

--- a/tests/usage-graph.test.mjs
+++ b/tests/usage-graph.test.mjs
@@ -1,0 +1,343 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { makeHourlyKey } from "../usage-extension/data.ts";
+import {
+	buildGraphModel,
+	renderChart,
+	MAX_GROUP_SERIES,
+	OTHER_SERIES_KEY,
+	TOTAL_SERIES_KEY,
+} from "../usage-extension/graph.ts";
+
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+// A fixed "now": 2026-07-15 12:00 local. Today starts at midnight.
+const NOW = new Date(2026, 6, 15, 12, 0, 0).getTime();
+const TODAY = new Date(2026, 6, 15, 0, 0, 0).getTime();
+const BOUNDS = {
+	todayMs: TODAY,
+	weekStartMs: new Date(2026, 6, 13, 0, 0, 0).getTime(), // Monday
+	lastWeekStartMs: new Date(2026, 6, 6, 0, 0, 0).getTime(),
+	last30DaysStartMs: new Date(2026, 5, 16, 0, 0, 0).getTime(),
+	nowMs: NOW,
+};
+
+function cell({ messages = 1, cost = 0, input = 0, output = 0, cacheRead = 0, cacheWrite = 0, reasoning = 0 } = {}) {
+	return { messages, cost, input, output, cacheRead, cacheWrite, reasoning };
+}
+
+function hourlyFrom(entries) {
+	// entries: [hourMs, provider, model, level, cell]
+	const hourly = new Map();
+	for (const [hour, provider, model, level, c] of entries) {
+		let bucket = hourly.get(hour);
+		if (!bucket) hourly.set(hour, (bucket = new Map()));
+		bucket.set(makeHourlyKey(provider, model, level), c);
+	}
+	return hourly;
+}
+
+// =============================================================================
+// buildGraphModel
+// =============================================================================
+
+test("buildGraphModel groups by provider with a Total series first", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 1 * HOUR, "anthropic", "fable", "xhigh", cell({ cost: 3 })],
+		[TODAY + 2 * HOUR, "openai", "sol", "medium", cell({ cost: 5 })],
+		[TODAY + 2 * HOUR, "anthropic", "opus", "high", cell({ cost: 1 })],
+	]);
+
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+
+	assert.equal(model.bucketMs, HOUR);
+	assert.equal(model.series[0].key, TOTAL_SERIES_KEY);
+	assert.deepEqual(
+		model.series.map((s) => s.label),
+		["Total", "openai", "anthropic"] // ranked by period total
+	);
+	assert.equal(model.series[0].total, 9);
+	assert.equal(model.series[1].total, 5);
+	assert.equal(model.series[2].total, 4);
+	assert.equal(model.groupedTotal, 9);
+
+	// Bucket 1 (hour 1): anthropic 3; bucket 2: openai 5 + anthropic 1.
+	assert.equal(model.series[0].points[1], 3);
+	assert.equal(model.series[0].points[2], 9 - 3);
+	assert.equal(model.yMax, 6);
+});
+
+test("buildGraphModel cumulative points are running sums ending at the period total", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 1 * HOUR, "a", "m", "", cell({ cost: 1 })],
+		[TODAY + 3 * HOUR, "a", "m", "", cell({ cost: 2 })],
+		[TODAY + 5 * HOUR, "b", "m", "", cell({ cost: 4 })],
+	]);
+
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+
+	const total = model.series[0];
+	// Monotonic non-decreasing, final value = total.
+	for (let i = 1; i < total.points.length; i++) {
+		assert.ok(total.points[i] >= total.points[i - 1]);
+	}
+	assert.equal(total.points[total.points.length - 1], 7);
+	assert.equal(total.total, 7);
+});
+
+test("buildGraphModel groups by thinking level with unknown fallback and by model", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 1 * HOUR, "a", "m1", "xhigh", cell({ input: 100, output: 20, cacheWrite: 30 })],
+		[TODAY + 2 * HOUR, "a", "m2", "", cell({ input: 10, output: 5, cacheWrite: 0 })],
+	]);
+
+	const byThinking = buildGraphModel(hourly, {
+		period: "today",
+		metric: "tokens",
+		groupBy: "thinking",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.deepEqual(
+		byThinking.series.map((s) => s.label),
+		["Total", "xhigh", "unknown"]
+	);
+	assert.equal(byThinking.series[1].total, 150); // input + output + cacheWrite
+	assert.equal(byThinking.series[2].total, 15);
+
+	const byModel = buildGraphModel(hourly, {
+		period: "today",
+		metric: "messages",
+		groupBy: "model",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.deepEqual(
+		byModel.series.map((s) => s.label).sort(),
+		["Total", "m1", "m2"].sort()
+	);
+});
+
+test("buildGraphModel caps series and merges the tail into other", () => {
+	const entries = [];
+	for (let i = 0; i < MAX_GROUP_SERIES + 3; i++) {
+		entries.push([TODAY + HOUR, `prov${i}`, "m", "", cell({ cost: 100 - i })]);
+	}
+	const model = buildGraphModel(hourlyFrom(entries), {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+
+	// Total + capped groups + other
+	assert.equal(model.series.length, 1 + MAX_GROUP_SERIES + 1);
+	const other = model.series[model.series.length - 1];
+	assert.equal(other.key, OTHER_SERIES_KEY);
+	assert.equal(other.label, "other (3)");
+	// other = sum of the 3 smallest: (100-6)+(100-7)+(100-8)
+	assert.equal(other.total, 94 + 93 + 92);
+	// Sum of all group series equals the total series.
+	const groupSum = model.series.slice(1).reduce((sum, s) => sum + s.total, 0);
+	assert.equal(groupSum, model.series[0].total);
+});
+
+test("buildGraphModel respects hidden series for y-scale but keeps their points", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 1 * HOUR, "big", "m", "", cell({ cost: 100 })],
+		[TODAY + 2 * HOUR, "small", "m", "", cell({ cost: 5 })],
+	]);
+	const hidden = new Set([TOTAL_SERIES_KEY, "big"]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: false,
+		hidden,
+		bounds: BOUNDS,
+	});
+	assert.equal(model.yMax, 5, "hidden series must not drive the y-axis");
+	assert.equal(model.series.find((s) => s.key === "big").hidden, true);
+	assert.equal(model.series.find((s) => s.key === "big").total, 100);
+});
+
+test("buildGraphModel uses daily buckets and the domain rules per period", () => {
+	const hourly = hourlyFrom([
+		[BOUNDS.last30DaysStartMs + 2 * HOUR, "a", "m", "", cell({ cost: 1 })],
+		[TODAY + HOUR, "a", "m", "", cell({ cost: 2 })],
+		// Outside last30Days:
+		[BOUNDS.last30DaysStartMs - DAY, "a", "m", "", cell({ cost: 50 })],
+	]);
+
+	const m30 = buildGraphModel(hourly, {
+		period: "last30Days",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.equal(m30.bucketMs, DAY);
+	assert.equal(m30.series.length, 1); // total only
+	assert.equal(m30.series[0].total, 3, "out-of-window usage must be excluded");
+	assert.equal(m30.domainStartMs, BOUNDS.last30DaysStartMs);
+	assert.equal(m30.domainEndMs, NOW);
+
+	// lastWeek has a fixed end (this Monday), not now.
+	const lw = buildGraphModel(hourly, {
+		period: "lastWeek",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.equal(lw.domainStartMs, BOUNDS.lastWeekStartMs);
+	assert.equal(lw.domainEndMs, BOUNDS.weekStartMs);
+
+	// allTime starts at the first bucket with data.
+	const at = buildGraphModel(hourly, {
+		period: "allTime",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.equal(at.domainStartMs, BOUNDS.last30DaysStartMs - DAY);
+	assert.equal(at.series[0].total, 53);
+});
+
+test("buildGraphModel reasoning metric sums usage.reasoning", () => {
+	const hourly = hourlyFrom([
+		[TODAY + HOUR, "a", "m", "high", cell({ reasoning: 42 })],
+		[TODAY + 2 * HOUR, "a", "m", "high", cell({ reasoning: 8 })],
+	]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "reasoning",
+		groupBy: "provider",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+	assert.equal(model.series[0].total, 50);
+	assert.equal(model.series[0].points[model.series[0].points.length - 1], 50);
+});
+
+// =============================================================================
+// renderChart
+// =============================================================================
+
+const CHART_OPTS = {
+	width: 60,
+	height: 8,
+	formatValue: (v) => `$${Math.round(v)}`,
+	formatTime: (ms) => new Date(ms).toISOString().slice(0, 10),
+};
+
+test("renderChart emits height+1 lines within width and draws braille dots", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 1 * HOUR, "a", "m", "", cell({ cost: 1 })],
+		[TODAY + 5 * HOUR, "a", "m", "", cell({ cost: 5 })],
+		[TODAY + 9 * HOUR, "b", "m", "", cell({ cost: 3 })],
+	]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+
+	const lines = renderChart(model, CHART_OPTS);
+	assert.equal(lines.length, CHART_OPTS.height + 1);
+	for (const line of lines) {
+		assert.ok(line.length <= CHART_OPTS.width, `line too long: ${line.length}`);
+	}
+	const braille = lines.join("").match(/[\u2800-\u28ff]/g) ?? [];
+	assert.ok(braille.length > 10, "expected braille line dots");
+	// Axis labels present: max at top, $0 at bottom, dates on the axis line.
+	assert.ok(lines[0].includes(`$${Math.round(model.yMax)}`));
+	assert.ok(lines[CHART_OPTS.height - 1].includes("$0"));
+	assert.ok(lines[CHART_OPTS.height].includes("2026-07-15"));
+});
+
+test("renderChart routes series text through the colorize callback with the series index", () => {
+	const hourly = hourlyFrom([[TODAY + HOUR, "a", "m", "", cell({ cost: 5 })]]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+	const seen = new Set();
+	renderChart(model, {
+		...CHART_OPTS,
+		colorize: (idx, text) => {
+			seen.add(idx);
+			return text;
+		},
+	});
+	assert.ok(seen.has(-1), "axis furniture colorized with -1");
+	assert.ok(seen.has(0) || seen.has(1), "series cells colorized with their index");
+});
+
+test("renderChart hides hidden series from the plot", () => {
+	const hourly = hourlyFrom([[TODAY + HOUR, "a", "m", "", cell({ cost: 5 })]]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: true,
+		hidden: new Set([TOTAL_SERIES_KEY, "a"]),
+		bounds: BOUNDS,
+	});
+	const lines = renderChart(model, CHART_OPTS);
+	const braille = lines.join("").match(/[\u2800-\u28ff]/g) ?? [];
+	assert.equal(braille.length, 0, "hidden series must not be drawn");
+});
+
+test("renderChart keeps the y-axis aligned when the mid label is the widest", () => {
+	// yMax 113 → labels "$113", "$61.6...", "$0" — the mid label used to overflow
+	// the axis column and shift its row by one character.
+	const hourly = hourlyFrom([[TODAY + HOUR, "a", "m", "", cell({ cost: 113 })]]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+	const lines = renderChart(model, {
+		...CHART_OPTS,
+		height: 12,
+		formatValue: (v) => (v === 0 ? "$0" : v < 100 ? `$${v.toFixed(1)}` : `$${Math.round(v)}`),
+	});
+	const axisCols = new Set(lines.slice(0, 12).map((l) => Math.max(l.indexOf("\u2524"), l.indexOf("\u2502"))));
+	assert.equal(axisCols.size, 1, `axis column must align: ${[...axisCols]}`);
+});
+
+test("renderChart handles an empty model without throwing", () => {
+	const model = buildGraphModel(new Map(), {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+	const lines = renderChart(model, CHART_OPTS);
+	assert.equal(lines.length, CHART_OPTS.height + 1);
+});

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.6.0] - 2026-07-17
+
+### Added
+- **Interactive graph explorer.** New third view mode (cycle with `v`): a braille line chart of usage over time for the active period, with a legend showing per-series totals and shares.
+  - Metrics (`m`): cost, tokens, messages, reasoning tokens.
+  - Grouping (`g`): by provider, by model, by thinking level, or total only — top 6 series plus an `other` rollup, with a bold Total line always drawn.
+  - Cumulative running totals or per-bucket rates (`c`), hourly buckets for day/week periods and daily buckets for Last 30 Days / All Time.
+  - Legend filtering: `↑`/`↓` moves the cursor, `Enter`/`Space` hides or shows a series, `a` shows all. The y-axis rescales to the visible series so small series can be inspected by hiding large ones.
+- **Thinking level and reasoning tokens.** Session parsing now replays `thinking_level_change` entries (compact and spaced JSON styles) to attribute a thinking level to each assistant message, and records `usage.reasoning` token counts. Messages before the first recorded change appear as `unknown`.
+
+### Changed
+- On-disk cache format bumped to v2 (per-message thinking level and reasoning tokens). The first open after upgrading does a one-off full rebuild; older caches are ignored safely.
+
 ## [0.5.0] - 2026-07-17
 
 ### Added

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -7,7 +7,7 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 ## Compatibility
 
 - **Pi version:** 0.42.4+
-- **Last updated:** 2026-07-17 (0.5.0)
+- **Last updated:** 2026-07-17 (0.6.0)
 
 ## Installation
 
@@ -57,14 +57,27 @@ In Pi, run:
 
 ### Views
 
-`/usage` has two view modes, toggled with `v`:
+`/usage` has three view modes, cycled with `v`:
 
 - **Table** (default) — per-provider / per-model stats with cost and token breakdown (screenshot at the top of this page).
 - **Insights** — narrative characteristics of your cost for the active time period, e.g. *"X% of your cost was at >150k context"*. Insights are **independent characteristics**, not a breakdown, so they overlap and can sum to more than 100%.
+- **Graphs** — an interactive braille line-chart explorer for usage over time (details below).
 
 ![Insights view of /usage](insights-screenshot.png)
 
 **Unit:** insights are always weighted by recorded API cost (USD). Periods with no recorded cost show an explicit empty state rather than silently switching to a different unit.
+
+### Graph explorer
+
+The **Graphs** view plots usage over time for the active period as a braille line chart, with a legend showing per-series totals and shares.
+
+- **Metric** (`m` to cycle): cost, tokens (input + output + cache write), messages, reasoning tokens.
+- **Grouping** (`g` to cycle): by provider, by model, by thinking level, or total only. The top 6 series are shown individually; the rest merge into an `other` series. A bold **Total** line is always drawn.
+- **Cumulative vs per-bucket** (`c` to toggle): running total across the period (default), or the raw per-bucket rate.
+- **Filtering**: move the legend cursor with `↑`/`↓` and toggle series visibility with `Enter`/`Space` (`a` shows all again). The y-axis rescales to the visible series — hide the big lines to zoom into the small ones.
+- **Buckets**: hourly for Today / This Week / Last Week, daily for Last 30 Days / All Time.
+
+Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Reasoning token counts come from `usage.reasoning` where providers report them.
 
 The insights currently shown:
 
@@ -114,9 +127,13 @@ On narrow terminals, `/usage` automatically switches to a compact table instead 
 | Key | Action |
 |-----|--------|
 | `Tab` / `←` `→` | Switch time period |
-| `↑` `↓` | Select provider *(table view)* |
-| `Enter` / `Space` | Expand/collapse provider to show models *(table view)* |
-| `v` | Toggle between Table and Insights view |
+| `↑` `↓` | Select provider *(table)* / move legend cursor *(graphs)* |
+| `Enter` / `Space` | Expand/collapse provider *(table)* / toggle series visibility *(graphs)* |
+| `v` | Cycle Table → Insights → Graphs view |
+| `m` | Cycle metric: cost / tokens / messages / reasoning *(graphs)* |
+| `g` | Cycle grouping: provider / model / thinking level / total *(graphs)* |
+| `c` | Toggle cumulative vs per-bucket *(graphs)* |
+| `a` | Show all series *(graphs)* |
 | `q` / `Esc` | Close |
 
 ## Performance & Caching
@@ -126,6 +143,7 @@ On narrow terminals, `/usage` automatically switches to a compact table instead 
 - **On-disk cache.** Per-file extraction results are cached in `<agentDir>/usage-extension-cache.json` (respects `PI_CODING_AGENT_DIR`), keyed by file size + mtime. Warm opens only re-parse session files that changed since the last run — on a 5.2 GB / 3,310-file corpus that takes the open from ~17 s to ~0.3 s.
 - **First open** after install (or after deleting the cache) does a one-off full build, showing the usual cancellable loader. Cancelling saves partial progress, so the next open resumes where it left off.
 - The cache is safe to delete at any time; it is rebuilt automatically. Corrupt or version-mismatched caches are ignored and rebuilt rather than trusted.
+- **0.6.0 bumps the cache format to v2** (adds thinking level and reasoning tokens per message). The first open after upgrading does a one-off full rebuild, then warm opens are fast again.
 
 ## Provider Notes
 

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -81,12 +81,51 @@ export interface TimeFilteredStats {
 	insights: PeriodInsights;
 }
 
+/**
+ * One (provider, model, thinkingLevel) cell inside an hourly bucket.
+ * Powers the graph explorer; built post-dedupe so it matches table totals.
+ */
+export interface HourlyCell {
+	messages: number;
+	cost: number;
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	reasoning: number;
+}
+
+/** Composite key: `${provider}\u0000${model}\u0000${thinkingLevel}` */
+export type HourlyKey = string;
+
+export const HOURLY_KEY_SEP = "\u0000";
+
+export function makeHourlyKey(provider: string, model: string, thinkingLevel: string): HourlyKey {
+	return provider + HOURLY_KEY_SEP + model + HOURLY_KEY_SEP + thinkingLevel;
+}
+
+export function splitHourlyKey(key: HourlyKey): { provider: string; model: string; thinkingLevel: string } {
+	const [provider = "", model = "", thinkingLevel = ""] = key.split(HOURLY_KEY_SEP);
+	return { provider, model, thinkingLevel };
+}
+
+export interface PeriodBounds {
+	todayMs: number;
+	weekStartMs: number;
+	lastWeekStartMs: number;
+	last30DaysStartMs: number;
+	nowMs: number;
+}
+
 export interface UsageData {
 	today: TimeFilteredStats;
 	thisWeek: TimeFilteredStats;
 	lastWeek: TimeFilteredStats;
 	last30Days: TimeFilteredStats;
 	allTime: TimeFilteredStats;
+	/** Deduped usage bucketed by hour start (ms) → series key → metrics. */
+	hourly: Map<number, Map<HourlyKey, HourlyCell>>;
+	bounds: PeriodBounds;
 }
 
 export type TabName = "today" | "thisWeek" | "lastWeek" | "last30Days" | "allTime";
@@ -96,11 +135,15 @@ export const TAB_ORDER: TabName[] = ["today", "thisWeek", "lastWeek", "last30Day
 export interface SessionMessage {
 	provider: string;
 	model: string;
+	/** Thinking level active when the message was produced; "" when unknown. */
+	thinkingLevel: string;
 	cost: number;
 	input: number;
 	output: number;
 	cacheRead: number;
 	cacheWrite: number;
+	/** Reasoning output tokens reported by the provider (0 when absent). */
+	reasoning: number;
 	timestamp: number;
 }
 
@@ -171,6 +214,8 @@ const PATTERN_ASSISTANT_COMPACT = Buffer.from('"role":"assistant"');
 const PATTERN_ASSISTANT_SPACED = Buffer.from('"role": "assistant"');
 const PATTERN_SESSION_COMPACT = Buffer.from('"type":"session"');
 const PATTERN_SESSION_SPACED = Buffer.from('"type": "session"');
+const PATTERN_THINKING_COMPACT = Buffer.from('"type":"thinking_level_change"');
+const PATTERN_THINKING_SPACED = Buffer.from('"type": "thinking_level_change"');
 
 const PARSE_YIELD_EVERY_LINES = 2000;
 
@@ -178,8 +223,10 @@ function lineMightBeRelevant(line: Buffer): boolean {
 	return (
 		line.includes(PATTERN_ASSISTANT_COMPACT) ||
 		line.includes(PATTERN_SESSION_COMPACT) ||
+		line.includes(PATTERN_THINKING_COMPACT) ||
 		line.includes(PATTERN_ASSISTANT_SPACED) ||
-		line.includes(PATTERN_SESSION_SPACED)
+		line.includes(PATTERN_SESSION_SPACED) ||
+		line.includes(PATTERN_THINKING_SPACED)
 	);
 }
 
@@ -191,6 +238,11 @@ function lineMightBeRelevant(line: Buffer): boolean {
 export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): Promise<ParsedSessionFile> {
 	const messages: SessionMessage[] = [];
 	let sessionId = "";
+	// Assistant messages don't carry the thinking level; pi records it as separate
+	// thinking_level_change entries, always written before the first assistant
+	// message of a session. Replaying them in append order attributes each message
+	// to the level active when it was produced.
+	let thinkingLevel = "";
 	let start = 0;
 	let lineNumber = 0;
 
@@ -210,6 +262,8 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 
 				if (entry.type === "session") {
 					sessionId = entry.id;
+				} else if (entry.type === "thinking_level_change") {
+					if (typeof entry.thinkingLevel === "string") thinkingLevel = entry.thinkingLevel;
 				} else if (entry.type === "message" && entry.message?.role === "assistant") {
 					const msg = entry.message;
 					if (msg.usage && msg.provider && msg.model) {
@@ -217,11 +271,13 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 						messages.push({
 							provider: msg.provider,
 							model: msg.model,
+							thinkingLevel,
 							cost: msg.usage.cost?.total || 0,
 							input: msg.usage.input || 0,
 							output: msg.usage.output || 0,
 							cacheRead: msg.usage.cacheRead || 0,
 							cacheWrite: msg.usage.cacheWrite || 0,
+							reasoning: msg.usage.reasoning || 0,
 							timestamp: msg.timestamp || (Number.isNaN(fallbackTs) ? 0 : fallbackTs),
 						});
 					}
@@ -241,7 +297,7 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 // On-disk cache
 // =============================================================================
 
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2;
 
 type CachedMessageTuple = [
 	providerIdx: number,
@@ -252,6 +308,8 @@ type CachedMessageTuple = [
 	cacheRead: number,
 	cacheWrite: number,
 	timestamp: number,
+	thinkingLevelIdx: number,
+	reasoning: number,
 ];
 
 interface CacheFileEntry {
@@ -293,25 +351,28 @@ export async function loadUsageCache(cachePath: string): Promise<Map<string, Cac
 		const messages: SessionMessage[] = [];
 		let valid = true;
 		for (const tuple of entry.messages) {
-			if (!Array.isArray(tuple) || tuple.length !== 8) {
+			if (!Array.isArray(tuple) || tuple.length !== 10) {
 				valid = false;
 				break;
 			}
 			const provider = names[tuple[0]];
 			const model = names[tuple[1]];
-			if (typeof provider !== "string" || typeof model !== "string") {
+			const thinkingLevel = names[tuple[8]];
+			if (typeof provider !== "string" || typeof model !== "string" || typeof thinkingLevel !== "string") {
 				valid = false;
 				break;
 			}
 			messages.push({
 				provider,
 				model,
+				thinkingLevel,
 				cost: Number(tuple[2]) || 0,
 				input: Number(tuple[3]) || 0,
 				output: Number(tuple[4]) || 0,
 				cacheRead: Number(tuple[5]) || 0,
 				cacheWrite: Number(tuple[6]) || 0,
 				timestamp: Number(tuple[7]) || 0,
+				reasoning: Number(tuple[9]) || 0,
 			});
 		}
 		if (!valid) continue;
@@ -352,6 +413,8 @@ export async function saveUsageCache(cachePath: string, states: Map<string, Cach
 				m.cacheRead,
 				m.cacheWrite,
 				m.timestamp,
+				intern(m.thinkingLevel),
+				m.reasoning,
 			]),
 		};
 	}
@@ -392,14 +455,41 @@ function emptyPeriodRawData(): PeriodRawData {
 	return { messages: [], sessionCosts: new Map() };
 }
 
-function emptyUsageData(): UsageData {
+function emptyUsageData(bounds: PeriodBounds): UsageData {
 	return {
 		today: emptyTimeFilteredStats(),
 		thisWeek: emptyTimeFilteredStats(),
 		lastWeek: emptyTimeFilteredStats(),
 		last30Days: emptyTimeFilteredStats(),
 		allTime: emptyTimeFilteredStats(),
+		hourly: new Map(),
+		bounds,
 	};
+}
+
+const HOUR_MS = 3_600_000;
+
+function addToHourlyBuckets(hourly: Map<number, Map<HourlyKey, HourlyCell>>, msg: SessionMessage): void {
+	if (msg.timestamp <= 0) return; // Unknown time can't be placed on a time axis.
+	const hour = Math.floor(msg.timestamp / HOUR_MS) * HOUR_MS;
+	let bucket = hourly.get(hour);
+	if (!bucket) {
+		bucket = new Map();
+		hourly.set(hour, bucket);
+	}
+	const key = makeHourlyKey(msg.provider, msg.model, msg.thinkingLevel);
+	let cell = bucket.get(key);
+	if (!cell) {
+		cell = { messages: 0, cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 };
+		bucket.set(key, cell);
+	}
+	cell.messages++;
+	cell.cost += msg.cost;
+	cell.input += msg.input;
+	cell.output += msg.output;
+	cell.cacheRead += msg.cacheRead;
+	cell.cacheWrite += msg.cacheWrite;
+	cell.reasoning += msg.reasoning;
 }
 
 // Helper to accumulate stats into a target
@@ -460,6 +550,8 @@ function addMessagesToUsageData(
 				if (msg.timestamp > span.endMs) span.endMs = msg.timestamp;
 			}
 		}
+
+		addToHourlyBuckets(data.hourly, msg);
 
 		const periods = getPeriodsForTimestamp(msg.timestamp, todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs);
 		const tokens = {
@@ -659,7 +751,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 	}
 
 	// 6. Aggregate in sorted path order with cross-file dedupe.
-	const data = emptyUsageData();
+	const data = emptyUsageData({ todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs, nowMs: now.getTime() });
 	const rawByPeriod: Record<TabName, PeriodRawData> = {
 		today: emptyPeriodRawData(),
 		thisWeek: emptyPeriodRawData(),

--- a/usage-extension/graph.ts
+++ b/usage-extension/graph.ts
@@ -1,0 +1,386 @@
+/**
+ * Graph explorer model + braille chart rendering for /usage.
+ *
+ * Everything here is pure and theme-free: series building works off the hourly
+ * buckets produced by data.ts, and the renderer emits plain text plus a
+ * colorize callback so the UI layer owns all styling. This keeps the module
+ * fully unit-testable.
+ */
+
+// Explicit .ts extension so plain `node --test` (type stripping) can resolve
+// this module too; pi's extension loader accepts it as well.
+import type { HourlyCell, HourlyKey, PeriodBounds, TabName } from "./data.ts";
+import { splitHourlyKey } from "./data.ts";
+
+// =============================================================================
+// Options and model types
+// =============================================================================
+
+export type GraphMetric = "cost" | "tokens" | "messages" | "reasoning";
+export type GraphGroupBy = "provider" | "model" | "thinking" | "total";
+
+export const METRIC_ORDER: GraphMetric[] = ["cost", "tokens", "messages", "reasoning"];
+export const GROUP_ORDER: GraphGroupBy[] = ["provider", "model", "thinking", "total"];
+
+export const METRIC_LABELS: Record<GraphMetric, string> = {
+	cost: "cost",
+	tokens: "tokens",
+	messages: "messages",
+	reasoning: "reasoning tokens",
+};
+
+export const GROUP_LABELS: Record<GraphGroupBy, string> = {
+	provider: "by provider",
+	model: "by model",
+	thinking: "by thinking level",
+	total: "total only",
+};
+
+/** Series beyond this cap are merged into a single "other" series. */
+export const MAX_GROUP_SERIES = 6;
+
+export const TOTAL_SERIES_KEY = "\u0000total";
+export const OTHER_SERIES_KEY = "\u0000other";
+
+export interface GraphOptions {
+	period: TabName;
+	metric: GraphMetric;
+	groupBy: GraphGroupBy;
+	cumulative: boolean;
+	/** Series keys hidden via the legend. */
+	hidden?: ReadonlySet<string>;
+	bounds: PeriodBounds;
+}
+
+export interface GraphSeries {
+	key: string;
+	label: string;
+	/** One value per bucket. Cumulative when options.cumulative. */
+	points: number[];
+	/** Period total for this series (not affected by cumulative). */
+	total: number;
+	hidden: boolean;
+}
+
+export interface GraphModel {
+	series: GraphSeries[];
+	/** Bucket start timestamps (ms), ascending. */
+	bucketStarts: number[];
+	bucketMs: number;
+	domainStartMs: number;
+	domainEndMs: number;
+	/** Max point value across visible series (y-axis scale). */
+	yMax: number;
+	/** Sum of totals across grouped (non-total) series, for legend percentages. */
+	groupedTotal: number;
+}
+
+// =============================================================================
+// Series building
+// =============================================================================
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+/** Periods spanning at most this many hours use hourly buckets; otherwise daily. */
+const MAX_HOURLY_BUCKETS = 8 * 24;
+
+function metricOf(cell: HourlyCell, metric: GraphMetric): number {
+	switch (metric) {
+		case "cost":
+			return cell.cost;
+		case "tokens":
+			// Matches the dashboard formula: fresh tokens = input + output + cacheWrite.
+			return cell.input + cell.output + cell.cacheWrite;
+		case "messages":
+			return cell.messages;
+		case "reasoning":
+			return cell.reasoning;
+	}
+}
+
+function groupKeyOf(key: HourlyKey, groupBy: GraphGroupBy): string {
+	if (groupBy === "total") return TOTAL_SERIES_KEY;
+	const { provider, model, thinkingLevel } = splitHourlyKey(key);
+	if (groupBy === "provider") return provider;
+	if (groupBy === "model") return model;
+	return thinkingLevel === "" ? "unknown" : thinkingLevel;
+}
+
+function domainFor(period: TabName, bounds: PeriodBounds, hourly: Map<number, Map<HourlyKey, HourlyCell>>): { startMs: number; endMs: number } {
+	switch (period) {
+		case "today":
+			return { startMs: bounds.todayMs, endMs: bounds.nowMs };
+		case "thisWeek":
+			return { startMs: bounds.weekStartMs, endMs: bounds.nowMs };
+		case "lastWeek":
+			return { startMs: bounds.lastWeekStartMs, endMs: bounds.weekStartMs };
+		case "last30Days":
+			return { startMs: bounds.last30DaysStartMs, endMs: bounds.nowMs };
+		case "allTime": {
+			let first = Number.POSITIVE_INFINITY;
+			for (const hour of hourly.keys()) if (hour < first) first = hour;
+			if (!Number.isFinite(first)) first = bounds.todayMs;
+			return { startMs: Math.min(first, bounds.nowMs), endMs: bounds.nowMs };
+		}
+	}
+}
+
+/**
+ * Build the graph model for one (period, metric, groupBy) view.
+ *
+ * Buckets are hourly for short periods and daily for long ones. Group series
+ * are capped at MAX_GROUP_SERIES by period total; the rest merge into "other".
+ * A Total series is always present (first). Hidden series keep their points
+ * but are excluded from the y-axis scale.
+ */
+export function buildGraphModel(
+	hourly: Map<number, Map<HourlyKey, HourlyCell>>,
+	options: GraphOptions
+): GraphModel {
+	const { startMs, endMs } = domainFor(options.period, options.bounds, hourly);
+	const spanMs = Math.max(endMs - startMs, 1);
+	const bucketMs = spanMs / HOUR_MS <= MAX_HOURLY_BUCKETS ? HOUR_MS : DAY_MS;
+
+	// Bucket starts aligned to the domain start so "day" buckets follow the
+	// local-midnight period boundaries computed by data.ts (DST shifts move a
+	// boundary by an hour, which is invisible at graph resolution).
+	const bucketCount = Math.max(1, Math.ceil(spanMs / bucketMs));
+	const bucketStarts: number[] = [];
+	for (let i = 0; i < bucketCount; i++) bucketStarts.push(startMs + i * bucketMs);
+
+	// Accumulate per-group bucket values.
+	const groupValues = new Map<string, number[]>();
+	const groupTotals = new Map<string, number>();
+	const totalPoints = new Array<number>(bucketCount).fill(0);
+	let totalSum = 0;
+
+	for (const [hour, bucket] of hourly) {
+		if (hour < startMs || hour >= endMs) continue;
+		const idx = Math.min(bucketCount - 1, Math.floor((hour - startMs) / bucketMs));
+		for (const [key, cell] of bucket) {
+			const value = metricOf(cell, options.metric);
+			if (value === 0) continue;
+			totalPoints[idx] += value;
+			totalSum += value;
+			if (options.groupBy !== "total") {
+				const groupKey = groupKeyOf(key, options.groupBy);
+				let points = groupValues.get(groupKey);
+				if (!points) {
+					points = new Array<number>(bucketCount).fill(0);
+					groupValues.set(groupKey, points);
+				}
+				points[idx] += value;
+				groupTotals.set(groupKey, (groupTotals.get(groupKey) ?? 0) + value);
+			}
+		}
+	}
+
+	// Rank groups and cap at MAX_GROUP_SERIES; merge the tail into "other".
+	const ranked = Array.from(groupTotals.entries()).sort((a, b) => b[1] - a[1]);
+	const kept = ranked.slice(0, MAX_GROUP_SERIES);
+	const merged = ranked.slice(MAX_GROUP_SERIES);
+
+	const hidden = options.hidden ?? new Set<string>();
+	const series: GraphSeries[] = [];
+
+	series.push({
+		key: TOTAL_SERIES_KEY,
+		label: "Total",
+		points: totalPoints.slice(),
+		total: totalSum,
+		hidden: hidden.has(TOTAL_SERIES_KEY),
+	});
+
+	for (const [groupKey, total] of kept) {
+		series.push({
+			key: groupKey,
+			label: groupKey,
+			points: groupValues.get(groupKey)!,
+			total,
+			hidden: hidden.has(groupKey),
+		});
+	}
+
+	if (merged.length > 0) {
+		const points = new Array<number>(bucketCount).fill(0);
+		let total = 0;
+		for (const [groupKey, groupTotal] of merged) {
+			const groupPoints = groupValues.get(groupKey)!;
+			for (let i = 0; i < bucketCount; i++) points[i] += groupPoints[i]!;
+			total += groupTotal;
+		}
+		series.push({
+			key: OTHER_SERIES_KEY,
+			label: `other (${merged.length})`,
+			points,
+			total,
+			hidden: hidden.has(OTHER_SERIES_KEY),
+		});
+	}
+
+	if (options.cumulative) {
+		for (const s of series) {
+			let running = 0;
+			s.points = s.points.map((v) => (running += v));
+		}
+	}
+
+	let yMax = 0;
+	for (const s of series) {
+		if (s.hidden) continue;
+		for (const v of s.points) if (v > yMax) yMax = v;
+	}
+
+	return {
+		series,
+		bucketStarts,
+		bucketMs,
+		domainStartMs: startMs,
+		domainEndMs: endMs,
+		yMax,
+		groupedTotal: totalSum,
+	};
+}
+
+// =============================================================================
+// Braille chart rendering
+// =============================================================================
+
+/**
+ * Style callback: seriesIndex is the index into model.series, or -1 for
+ * chart furniture (axes). Return the text styled for the terminal.
+ */
+export type ChartColorize = (seriesIndex: number, text: string) => string;
+
+export interface ChartRenderOptions {
+	width: number;
+	/** Text rows for the plot area (each row is 4 braille dots tall). */
+	height: number;
+	formatValue: (value: number) => string;
+	formatTime: (ms: number) => string;
+	colorize?: ChartColorize;
+}
+
+const BRAILLE_BASE = 0x2800;
+// Dot bit masks by (x: 0=left, 1=right) and (y: 0=top .. 3=bottom).
+const DOT_BITS = [
+	[0x01, 0x02, 0x04, 0x40],
+	[0x08, 0x10, 0x20, 0x80],
+] as const;
+
+/**
+ * Render the model as a braille line chart with a y-axis and an x-axis line.
+ * Returns exactly height + 1 lines (plot rows + x-axis labels).
+ */
+export function renderChart(model: GraphModel, options: ChartRenderOptions): string[] {
+	const colorize: ChartColorize = options.colorize ?? ((_i, text) => text);
+	const plotHeightForLabels = Math.max(options.height, 4);
+	const midRowForLabels = Math.floor((plotHeightForLabels - 1) / 2);
+	const midValue = (model.yMax * (plotHeightForLabels - 1 - midRowForLabels)) / (plotHeightForLabels - 1);
+	const yLabelWidth = Math.max(
+		options.formatValue(model.yMax).length,
+		options.formatValue(midValue).length,
+		options.formatValue(0).length
+	);
+	const axisWidth = yLabelWidth + 2; // label + " ┤" / " │"
+	const plotWidth = Math.max(options.width - axisWidth, 10);
+	const plotHeight = Math.max(options.height, 4);
+	const dotW = plotWidth * 2;
+	const dotH = plotHeight * 4;
+
+	// masks[row][col] per series index — draw order decides which color wins a cell.
+	const cellMasks: number[][] = Array.from({ length: plotHeight }, () => new Array<number>(plotWidth).fill(0));
+	const cellOwner: number[][] = Array.from({ length: plotHeight }, () => new Array<number>(plotWidth).fill(-1));
+
+	const yMax = model.yMax > 0 ? model.yMax : 1;
+	const bucketCount = model.bucketStarts.length;
+
+	const plot = (seriesIndex: number, points: number[]) => {
+		let prevX = -1;
+		let prevY = -1;
+		for (let i = 0; i < bucketCount; i++) {
+			const x = bucketCount === 1 ? dotW - 1 : Math.round((i / (bucketCount - 1)) * (dotW - 1));
+			const y = Math.round((1 - (points[i]! / yMax)) * (dotH - 1));
+			if (prevX >= 0) {
+				// Connect with a vertical-stepped segment for continuity.
+				const steps = Math.max(Math.abs(x - prevX), Math.abs(y - prevY), 1);
+				for (let s = 1; s <= steps; s++) {
+					const ix = Math.round(prevX + ((x - prevX) * s) / steps);
+					const iy = Math.round(prevY + ((y - prevY) * s) / steps);
+					setDot(ix, iy, seriesIndex);
+				}
+			} else {
+				setDot(x, y, seriesIndex);
+			}
+			prevX = x;
+			prevY = y;
+		}
+	};
+
+	const setDot = (x: number, y: number, seriesIndex: number) => {
+		if (x < 0 || y < 0 || x >= dotW || y >= dotH) return;
+		const col = Math.floor(x / 2);
+		const row = Math.floor(y / 4);
+		cellMasks[row]![col]! |= DOT_BITS[x % 2]![y % 4]!;
+		cellOwner[row]![col] = seriesIndex;
+	};
+
+	// Draw least-important first so important series own contested cells:
+	// other → smallest groups → largest group → total.
+	const drawOrder = model.series
+		.map((s, i) => ({ s, i }))
+		.filter(({ s }) => !s.hidden)
+		.sort((a, b) => {
+			const rank = (entry: { s: GraphSeries; i: number }) =>
+				entry.s.key === TOTAL_SERIES_KEY ? Number.POSITIVE_INFINITY : entry.s.key === OTHER_SERIES_KEY ? -1 : entry.s.total;
+			return rank(a) - rank(b);
+		});
+	for (const { s, i } of drawOrder) plot(i, s.points);
+
+	// Compose text rows.
+	const lines: string[] = [];
+	const midRow = Math.floor((plotHeight - 1) / 2);
+	for (let row = 0; row < plotHeight; row++) {
+		let label = "";
+		if (row === 0) label = options.formatValue(model.yMax);
+		else if (row === midRow && plotHeight > 2) label = options.formatValue(midValue);
+		else if (row === plotHeight - 1) label = options.formatValue(0);
+		const axisChar = label ? "┤" : "│";
+		let line = colorize(-1, label.padStart(yLabelWidth) + " " + axisChar);
+		// Batch consecutive cells with the same owning series into one colorize
+		// call to keep ANSI overhead proportional to color changes, not cells.
+		let runOwner = -2;
+		let runText = "";
+		const flush = () => {
+			if (!runText) return;
+			line += runOwner === -2 ? runText : colorize(runOwner, runText);
+			runText = "";
+		};
+		for (let col = 0; col < plotWidth; col++) {
+			const mask = cellMasks[row]![col]!;
+			const owner = mask === 0 ? -2 : cellOwner[row]![col]!;
+			if (owner !== runOwner) {
+				flush();
+				runOwner = owner;
+			}
+			runText += mask === 0 ? " " : String.fromCharCode(BRAILLE_BASE + mask);
+		}
+		flush();
+		lines.push(line);
+	}
+
+	// X-axis labels: start, optional middle, end.
+	const startLabel = options.formatTime(model.domainStartMs);
+	const endLabel = options.formatTime(model.domainEndMs);
+	const midLabel = plotWidth >= startLabel.length + endLabel.length + 14 ? options.formatTime(model.domainStartMs + (model.domainEndMs - model.domainStartMs) / 2) : "";
+	let axis = " ".repeat(yLabelWidth + 2) + startLabel;
+	if (midLabel) {
+		const midPos = yLabelWidth + 2 + Math.floor(plotWidth / 2 - midLabel.length / 2);
+		axis = axis.padEnd(midPos) + midLabel;
+	}
+	const endPos = yLabelWidth + 2 + plotWidth - endLabel.length;
+	axis = axis.padEnd(Math.max(endPos, axis.length + 1)) + endLabel;
+	lines.push(colorize(-1, axis));
+
+	return lines;
+}

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -15,8 +15,20 @@ import { CancellableLoader, Container, Spacer, matchesKey, visibleWidth, truncat
 
 import { collectUsageData, TAB_ORDER } from "./data";
 import type { BaseStats, TabName, UsageData } from "./data";
+import {
+	buildGraphModel,
+	renderChart,
+	GROUP_LABELS,
+	GROUP_ORDER,
+	METRIC_LABELS,
+	METRIC_ORDER,
+	TOTAL_SERIES_KEY,
+} from "./graph";
+import type { GraphGroupBy, GraphMetric, GraphModel } from "./graph";
 
-type ViewMode = "table" | "insights";
+type ViewMode = "table" | "insights" | "graph";
+
+const VIEW_CYCLE: ViewMode[] = ["table", "insights", "graph"];
 
 // =============================================================================
 // Column Configuration
@@ -137,6 +149,32 @@ function formatNumber(n: number): string {
 	return n.toLocaleString();
 }
 
+// Compact axis/legend formatters for the graph view.
+function formatAxisCost(v: number): string {
+	if (v === 0) return "$0";
+	if (v < 1) return `$${v.toFixed(2)}`;
+	if (v < 100) return `$${v.toFixed(1)}`;
+	if (v < 10_000) return `$${Math.round(v)}`;
+	if (v < 1_000_000) return `$${(v / 1000).toFixed(1)}k`;
+	return `$${(v / 1_000_000).toFixed(2)}M`;
+}
+
+function formatAxisCount(v: number): string {
+	if (v === 0) return "0";
+	if (v < 1000) return String(Math.round(v));
+	if (v < 1_000_000) return `${(v / 1000).toFixed(v < 10_000 ? 1 : 0)}k`;
+	if (v < 1_000_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+	return `${(v / 1_000_000_000).toFixed(1)}B`;
+}
+
+// Bright ANSI palette for graph series (Total uses index 0).
+const SERIES_COLORS = ["\x1b[97m", "\x1b[96m", "\x1b[95m", "\x1b[93m", "\x1b[92m", "\x1b[94m", "\x1b[91m", "\x1b[90m"];
+const COLOR_RESET = "\x1b[39m";
+
+function seriesColor(index: number): string {
+	return SERIES_COLORS[index % SERIES_COLORS.length]!;
+}
+
 function formatInsightPercent(p: number): string {
 	if (p >= 10) return `${Math.round(p)}%`;
 	return `${Math.round(p * 10) / 10}%`;
@@ -225,6 +263,13 @@ class UsageComponent {
 	private requestRender: () => void;
 	private done: () => void;
 
+	// Graph explorer state.
+	private graphMetric: GraphMetric = "cost";
+	private graphGroupBy: GraphGroupBy = "provider";
+	private graphCumulative = true;
+	private graphHidden = new Set<string>();
+	private graphLegendIndex = 0;
+
 	constructor(theme: Theme, data: UsageData, requestRender: () => void, done: () => void) {
 		this.theme = theme;
 		this.requestRender = requestRender;
@@ -248,8 +293,13 @@ class UsageComponent {
 		}
 
 		if (matchesKey(data, "v")) {
-			this.viewMode = this.viewMode === "table" ? "insights" : "table";
+			const idx = VIEW_CYCLE.indexOf(this.viewMode);
+			this.viewMode = VIEW_CYCLE[(idx + 1) % VIEW_CYCLE.length]!;
 			this.requestRender();
+			return;
+		}
+
+		if (this.viewMode === "graph" && this.handleGraphInput(data)) {
 			return;
 		}
 
@@ -263,6 +313,8 @@ class UsageComponent {
 			this.activeTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
 			this.requestRender();
+		} else if (this.viewMode === "graph") {
+			// Graph-specific keys were handled above; swallow table-only keys.
 		} else if (this.viewMode === "table" && matchesKey(data, "up")) {
 			if (this.selectedIndex > 0) {
 				this.selectedIndex--;
@@ -290,7 +342,57 @@ class UsageComponent {
 	// Render Methods
 	// -------------------------------------------------------------------------
 
+	private handleGraphInput(data: string): boolean {
+		if (matchesKey(data, "m")) {
+			const idx = METRIC_ORDER.indexOf(this.graphMetric);
+			this.graphMetric = METRIC_ORDER[(idx + 1) % METRIC_ORDER.length]!;
+		} else if (matchesKey(data, "g")) {
+			const idx = GROUP_ORDER.indexOf(this.graphGroupBy);
+			this.graphGroupBy = GROUP_ORDER[(idx + 1) % GROUP_ORDER.length]!;
+			this.graphHidden.clear();
+			this.graphLegendIndex = 0;
+		} else if (matchesKey(data, "c")) {
+			this.graphCumulative = !this.graphCumulative;
+		} else if (matchesKey(data, "a")) {
+			this.graphHidden.clear();
+		} else if (matchesKey(data, "up")) {
+			this.graphLegendIndex = Math.max(0, this.graphLegendIndex - 1);
+		} else if (matchesKey(data, "down")) {
+			const count = this.buildGraphModelForView().series.length;
+			this.graphLegendIndex = Math.min(Math.max(count - 1, 0), this.graphLegendIndex + 1);
+		} else if (matchesKey(data, "enter") || matchesKey(data, "space")) {
+			const model = this.buildGraphModelForView();
+			const target = model.series[this.graphLegendIndex];
+			if (target) {
+				if (this.graphHidden.has(target.key)) this.graphHidden.delete(target.key);
+				else this.graphHidden.add(target.key);
+			}
+		} else {
+			return false;
+		}
+		this.requestRender();
+		return true;
+	}
+
+	private buildGraphModelForView(): GraphModel {
+		return buildGraphModel(this.data.hourly, {
+			period: this.activeTab,
+			metric: this.graphMetric,
+			groupBy: this.graphGroupBy,
+			cumulative: this.graphCumulative,
+			hidden: this.graphHidden,
+			bounds: this.data.bounds,
+		});
+	}
+
 	render(width: number): string[] {
+		if (this.viewMode === "graph") {
+			return clampLines(
+				[...this.renderTitle(), ...this.renderTabs(width, getTableLayout(width)), ...this.renderGraph(width), ...this.renderHelp(width)],
+				width
+			);
+		}
+
 		if (this.viewMode === "insights") {
 			return clampLines(
 				[
@@ -320,8 +422,65 @@ class UsageComponent {
 
 	private renderTitle(): string[] {
 		const th = this.theme;
-		const label = this.viewMode === "insights" ? "Usage Insights" : "Usage Statistics";
+		const label =
+			this.viewMode === "insights" ? "Usage Insights" : this.viewMode === "graph" ? "Usage Graphs" : "Usage Statistics";
 		return [th.fg("accent", th.bold(label)), ""];
+	}
+
+	private renderGraph(width: number): string[] {
+		const th = this.theme;
+		const model = this.buildGraphModelForView();
+		const lines: string[] = [];
+
+		const modeLabel = `${this.graphCumulative ? "Cumulative" : "Per bucket"} ${METRIC_LABELS[this.graphMetric]} · ${GROUP_LABELS[this.graphGroupBy]}`;
+		lines.push(th.fg("muted", modeLabel));
+		lines.push("");
+
+		if (model.groupedTotal === 0 && model.series.every((s) => s.total === 0)) {
+			lines.push(th.fg("dim", "  No usage data for this period"));
+			lines.push("");
+			return lines;
+		}
+
+		const formatValue = this.graphMetric === "cost" ? formatAxisCost : formatAxisCount;
+		const spanMs = model.domainEndMs - model.domainStartMs;
+		const formatTime = (ms: number): string => {
+			const d = new Date(ms);
+			if (spanMs <= 26 * 3_600_000) {
+				return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+			}
+			return d.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+		};
+
+		const chartHeight = 12;
+		const chart = renderChart(model, {
+			width: Math.max(Math.min(width, 110), 30),
+			height: chartHeight,
+			formatValue,
+			formatTime,
+			colorize: (seriesIndex, text) => {
+				if (seriesIndex < 0) return th.fg("dim", text);
+				return seriesColor(seriesIndex) + text + COLOR_RESET;
+			},
+		});
+		lines.push(...chart);
+		lines.push("");
+
+		// Legend with selection cursor and hide/show state.
+		for (let i = 0; i < model.series.length; i++) {
+			const s = model.series[i]!;
+			const cursor = i === this.graphLegendIndex ? th.fg("accent", "▸ ") : "  ";
+			const marker = s.hidden ? th.fg("dim", "○") : seriesColor(i) + "●" + COLOR_RESET;
+			const value = this.graphMetric === "cost" ? formatAxisCost(s.total) : formatAxisCount(s.total);
+			const pct =
+				s.key !== TOTAL_SERIES_KEY && model.groupedTotal > 0
+					? ` ${th.fg("dim", `${Math.round((s.total / model.groupedTotal) * 100)}%`)}`
+					: "";
+			const label = s.hidden ? th.fg("dim", s.label) : s.key === TOTAL_SERIES_KEY ? th.bold(s.label) : s.label;
+			lines.push(`${cursor}${marker} ${padRight(label, 24)} ${padLeft(value, 8)}${pct}`);
+		}
+		lines.push("");
+		return lines;
 	}
 
 	private renderInsights(width: number): string[] {
@@ -494,11 +653,19 @@ class UsageComponent {
 
 	private renderHelp(width: number): string[] {
 		const variants =
-			this.viewMode === "insights"
+			this.viewMode === "graph"
 				? [
-						"[Tab/←→] period  [v] table view  [q] close",
-						"[Tab] period  [v] table  [q] close",
-						"[v] table  [q] close",
+						"[Tab/←→] period  [m] metric  [g] group  [c] cumulative  [↑↓/Enter] filter  [a] all  [v] view  [q] close",
+						"[Tab] period  [m] metric  [g] group  [c] cumul  [↑↓/Enter] filter  [v] view  [q] close",
+						"[m] metric  [g] group  [c] cumul  [↑↓] filter  [q] close",
+						"[m] [g] [c] [↑↓] [q]",
+						"[q] close",
+				  ]
+				: this.viewMode === "insights"
+				? [
+						"[Tab/←→] period  [v] graph view  [q] close",
+						"[Tab] period  [v] graphs  [q] close",
+						"[v] graphs  [q] close",
 						"[q] close",
 				  ]
 				: [

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
Adds a third `/usage` view mode — an interactive line-graph explorer.

## What
- **Graphs view** (cycle with `v`): braille line charts of usage over time for the active period.
- **Metrics** (`m`): cost · tokens · messages · reasoning tokens.
- **Grouping** (`g`): by provider · by model · by thinking level · total only. Top 6 series + `other` rollup; bold Total always drawn.
- **Cumulative or per-bucket** (`c`); hourly buckets for Today/This Week/Last Week, daily for Last 30 Days/All Time.
- **Legend filtering**: `↑↓` cursor, `Enter`/`Space` toggles a series, `a` shows all. Y-axis rescales to visible series (hide the big lines to zoom into small ones).

## Data layer
- Parses `thinking_level_change` entries (compact + spaced JSON) and replays them positionally to attribute a thinking level to each assistant message; messages before the first change are `unknown`. Captures `usage.reasoning`.
- Hourly pre-aggregation in `UsageData` keyed by `provider|model|thinkingLevel`.
- Cache format **v2** (10-element tuples); old caches are rejected safely with a one-off full rebuild.

## Testing
- New pure module `usage-extension/graph.ts`; 13 graph tests + updated data tests → **35/35 pass**, `tsc --strict` clean.
- Verified end-to-end in a real pi TUI session (tmux-driven) against the live 10 GB / 6.2k-file corpus: all three views, every grouping/metric, legend filtering with y-axis rescale, narrow widths.
- Real-data smoke: All Time cumulative cost by provider renders correctly ($34.5k total); last-30-days by thinking level shows 87% of cost at xhigh.