### PR TITLE
docs(usage): reasoning tokens recorded since pi 0.80.3

### DIFF
--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -77,7 +77,7 @@ The **Graphs** view plots usage over time for the active period as a braille lin
 - **Filtering**: move the legend cursor with `↑`/`↓` and toggle series visibility with `Enter`/`Space` (`a` shows all again). The y-axis rescales to the visible series — hide the big lines to zoom into the small ones.
 - **Buckets**: hourly for Today / This Week / Last Week, daily for Last 30 Days / All Time.
 
-Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Reasoning token counts come from `usage.reasoning` where providers report them.
+Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Reasoning token counts come from `usage.reasoning` where providers report them; pi only records this field since **pi 0.80.3 (30 June 2026)**, so earlier sessions show zero reasoning tokens even though thinking models were in use.
 
 The insights currently shown:
 


### PR DESCRIPTION
The graph explorer's reasoning-tokens metric shows a flat zero before 30 June 2026 — that's when pi 0.80.3 added `Usage.reasoning` to session JSONL, not a usage change. Verified against the real corpus: first `reasoning > 0` message is 2026-06-30T21:11Z (openai-codex), matching the release date.