### PR TITLE
feat(usage): clip graph lines to each series' active range (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.50] - 2026-07-17
+
+### Changed
+- `usage-extension` 0.6.1: graph lines are clipped to each series' active range, removing flat zero/flat tails for late-starting or retired providers/models/thinking levels.
+
 ## [0.1.49] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-graph.test.mjs
+++ b/tests/usage-graph.test.mjs
@@ -310,6 +310,78 @@ test("renderChart hides hidden series from the plot", () => {
 	assert.equal(braille.length, 0, "hidden series must not be drawn");
 });
 
+test("buildGraphModel exposes each series' active bucket range", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 2 * HOUR, "early", "m", "", cell({ cost: 5 })],
+		[TODAY + 4 * HOUR, "early", "m", "", cell({ cost: 1 })],
+		[TODAY + 8 * HOUR, "late", "m", "", cell({ cost: 3 })],
+	]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "provider",
+		cumulative: true, // ranges must come from raw values, not cumulative ones
+		bounds: BOUNDS,
+	});
+	const byKey = Object.fromEntries(model.series.map((s) => [s.key === TOTAL_SERIES_KEY ? "total" : s.key, s]));
+	assert.deepEqual([byKey.total.firstIdx, byKey.total.lastIdx], [2, 8]);
+	assert.deepEqual([byKey.early.firstIdx, byKey.early.lastIdx], [2, 4]);
+	assert.deepEqual([byKey.late.firstIdx, byKey.late.lastIdx], [8, 8]);
+});
+
+test("renderChart clips lines to each series' active range", () => {
+	// One series active only in the middle of the day: buckets 5..7 of 12.
+	const hourly = hourlyFrom([
+		[TODAY + 5 * HOUR, "a", "m", "", cell({ cost: 2 })],
+		[TODAY + 7 * HOUR, "a", "m", "", cell({ cost: 4 })],
+	]);
+
+	for (const cumulative of [false, true]) {
+		const model = buildGraphModel(hourly, {
+			period: "today",
+			metric: "cost",
+			groupBy: "total",
+			cumulative,
+			bounds: BOUNDS,
+		});
+		const lines = renderChart(model, CHART_OPTS);
+		const plotLines = lines.slice(0, CHART_OPTS.height);
+		const axisOffset = plotLines[0].indexOf("\u2524") + 1;
+		const plotWidth = Math.max(...plotLines.map((l) => l.length)) - axisOffset;
+
+		// Columns containing any braille dot, relative to the plot area.
+		const cols = new Set();
+		for (const line of plotLines) {
+			for (let i = axisOffset; i < line.length; i++) {
+				if (line[i] >= "\u2800" && line[i] <= "\u28ff") cols.add(i - axisOffset);
+			}
+		}
+		assert.ok(cols.size > 0);
+		const min = Math.min(...cols);
+		const max = Math.max(...cols);
+		// Active span is buckets 5..7 of 12 → roughly 45%..64% across the plot.
+		// Nothing may be drawn near the left or right edges (cumulative used to
+		// drag a flat tail all the way to the right edge).
+		assert.ok(min > plotWidth * 0.3, `cumulative=${cumulative}: line starts too early (col ${min}/${plotWidth})`);
+		assert.ok(max < plotWidth * 0.8, `cumulative=${cumulative}: line ends too late (col ${max}/${plotWidth})`);
+	}
+});
+
+test("renderChart draws a single dot for a series active in exactly one bucket", () => {
+	const hourly = hourlyFrom([[TODAY + 6 * HOUR, "a", "m", "", cell({ cost: 3 })]]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.deepEqual([model.series[0].firstIdx, model.series[0].lastIdx], [6, 6]);
+	const lines = renderChart(model, CHART_OPTS);
+	const braille = lines.join("").match(/[\u2800-\u28ff]/g) ?? [];
+	assert.equal(braille.length, 1, "exactly one braille cell for a single active bucket");
+});
+
 test("renderChart keeps the y-axis aligned when the mid label is the widest", () => {
 	// yMax 113 → labels "$113", "$61.6...", "$0" — the mid label used to overflow
 	// the axis column and shift its row by one character.

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.1] - 2026-07-17
+
+### Changed
+- Graph lines are clipped to each series' active range (first to last bucket with usage). Applies to every grouping — provider, model, thinking level, `other`, and Total — so a model that starts late (e.g. reasoning tokens, only recorded since pi 0.80.3) or gets retired no longer draws a flat zero/flat cumulative tail across the whole period.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -7,7 +7,7 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 ## Compatibility
 
 - **Pi version:** 0.42.4+
-- **Last updated:** 2026-07-17 (0.6.0)
+- **Last updated:** 2026-07-17 (0.6.1)
 
 ## Installation
 
@@ -76,6 +76,7 @@ The **Graphs** view plots usage over time for the active period as a braille lin
 - **Cumulative vs per-bucket** (`c` to toggle): running total across the period (default), or the raw per-bucket rate.
 - **Filtering**: move the legend cursor with `↑`/`↓` and toggle series visibility with `Enter`/`Space` (`a` shows all again). The y-axis rescales to the visible series — hide the big lines to zoom into the small ones.
 - **Buckets**: hourly for Today / This Week / Last Week, daily for Last 30 Days / All Time.
+- **Line clipping**: every series (provider, model, thinking level, `other`, Total) is drawn only between its first and last bucket with usage, so late-starting or retired series don't drag a flat zero/flat tail across the whole period.
 
 Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Reasoning token counts come from `usage.reasoning` where providers report them; pi only records this field since **pi 0.80.3 (30 June 2026)**, so earlier sessions show zero reasoning tokens even though thinking models were in use.
 

--- a/usage-extension/graph.ts
+++ b/usage-extension/graph.ts
@@ -60,6 +60,10 @@ export interface GraphSeries {
 	/** Period total for this series (not affected by cumulative). */
 	total: number;
 	hidden: boolean;
+	/** First bucket index with activity, or -1 when the series is empty. */
+	firstIdx: number;
+	/** Last bucket index with activity, or -1 when the series is empty. */
+	lastIdx: number;
 }
 
 export interface GraphModel {
@@ -183,21 +187,40 @@ export function buildGraphModel(
 	const hidden = options.hidden ?? new Set<string>();
 	const series: GraphSeries[] = [];
 
+	// Active range per series (computed on raw per-bucket values, before any
+	// cumulative transform): lines are later drawn only between the first and
+	// last bucket with usage, so late-starting or retired series do not drag a
+	// flat zero/flat tail across the whole period.
+	const activeRange = (points: number[]): { firstIdx: number; lastIdx: number } => {
+		let firstIdx = -1;
+		let lastIdx = -1;
+		for (let i = 0; i < points.length; i++) {
+			if (points[i] !== 0) {
+				if (firstIdx === -1) firstIdx = i;
+				lastIdx = i;
+			}
+		}
+		return { firstIdx, lastIdx };
+	};
+
 	series.push({
 		key: TOTAL_SERIES_KEY,
 		label: "Total",
 		points: totalPoints.slice(),
 		total: totalSum,
 		hidden: hidden.has(TOTAL_SERIES_KEY),
+		...activeRange(totalPoints),
 	});
 
 	for (const [groupKey, total] of kept) {
+		const points = groupValues.get(groupKey)!;
 		series.push({
 			key: groupKey,
 			label: groupKey,
-			points: groupValues.get(groupKey)!,
+			points,
 			total,
 			hidden: hidden.has(groupKey),
+			...activeRange(points),
 		});
 	}
 
@@ -215,6 +238,7 @@ export function buildGraphModel(
 			points,
 			total,
 			hidden: hidden.has(OTHER_SERIES_KEY),
+			...activeRange(points),
 		});
 	}
 
@@ -295,10 +319,11 @@ export function renderChart(model: GraphModel, options: ChartRenderOptions): str
 	const yMax = model.yMax > 0 ? model.yMax : 1;
 	const bucketCount = model.bucketStarts.length;
 
-	const plot = (seriesIndex: number, points: number[]) => {
+	const plot = (seriesIndex: number, points: number[], firstIdx: number, lastIdx: number) => {
+		if (firstIdx < 0) return;
 		let prevX = -1;
 		let prevY = -1;
-		for (let i = 0; i < bucketCount; i++) {
+		for (let i = firstIdx; i <= lastIdx; i++) {
 			const x = bucketCount === 1 ? dotW - 1 : Math.round((i / (bucketCount - 1)) * (dotW - 1));
 			const y = Math.round((1 - (points[i]! / yMax)) * (dotH - 1));
 			if (prevX >= 0) {
@@ -335,7 +360,7 @@ export function renderChart(model: GraphModel, options: ChartRenderOptions): str
 				entry.s.key === TOTAL_SERIES_KEY ? Number.POSITIVE_INFINITY : entry.s.key === OTHER_SERIES_KEY ? -1 : entry.s.total;
 			return rank(a) - rank(b);
 		});
-	for (const { s, i } of drawOrder) plot(i, s.points);
+	for (const { s, i } of drawOrder) plot(i, s.points, s.firstIdx, s.lastIdx);
 
 	// Compose text rows.
 	const lines: string[] = [];

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
Lines now start at a series' first bucket with usage and stop at its last — for every grouping (provider, model, thinking level, `other`, Total) and both cumulative and per-bucket modes.

Fixes the clutter where e.g. reasoning tokens (only recorded since pi 0.80.3) drew a flat zero line from February to June, and retired models dragged flat cumulative tails to the right edge.

- `GraphSeries` gains `firstIdx`/`lastIdx`, computed on raw per-bucket values before the cumulative transform
- Renderer plots only within that range; single-bucket series render as a single dot
- +3 tests (range exposure, render truncation in both modes, single-dot case) → 38/38, `tsc --strict` clean
- Verified against the real corpus: model-grouped all-time chart now shows staggered lifespans (gpt-5.5 → gpt-5.6-sol handoff, opus-4-6 → fable-5) with no zero tails