### PR TITLE
usage: three-way miss taxonomy, facts-first sections, exclude test providers (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.54] - 2026-07-17
+
+### Changed
+- `usage-extension` 0.8.0: cache-miss taxonomy split (resume after break / model switch / prefix change), facts-first section order, and pi test providers (`faux-provider`, `fake-provider`) excluded from all stats.
+
 ## [0.1.53] - 2026-07-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -493,7 +493,7 @@ test("loadUsageCache rejects wrong versions and malformed entries", async (t) =>
 
 const findInsight = (data, period, re) => data[period].insights.insights.find((i) => re.test(i.headline));
 
-test("insights classify TTL vs prefix cache misses and exclude compaction", async (t) => {
+test("insights classify resume vs model-switch vs prefix misses and exclude compaction", async (t) => {
 	const { sessionsDir, cachePath } = fixture(t);
 	const SIX_MIN = 6 * 60_000;
 	writeFileSync(
@@ -502,24 +502,48 @@ test("insights classify TTL vs prefix cache misses and exclude compaction", asyn
 			sessionLine("s1", TS_TODAY),
 			// Establishes a large previous context.
 			assistantLine({ ts: TS_TODAY, cost: 1, input: 1000, cacheRead: 100000 }),
-			// >5min idle, cacheRead ~0 → TTL-shaped miss.
+			// >5min idle, cacheRead ~0 → resume-after-break (TTL) miss.
 			assistantLine({ ts: TS_TODAY + SIX_MIN, cost: 10, input: 100000, cacheRead: 0 }),
-			// Short gap, cacheRead ~0 → prefix-shaped miss.
+			// Short gap, cacheRead ~0 → true prefix-change miss.
 			assistantLine({ ts: TS_TODAY + SIX_MIN + 10_000, cost: 5, input: 100000, cacheRead: 0 }),
 			// Compaction between messages → excluded from prefix accounting.
 			'{"type":"compaction","id":"c1"}',
 			assistantLine({ ts: TS_TODAY + SIX_MIN + 20_000, cost: 7, input: 100000, cacheRead: 0 }),
+			// Short gap but a different model → model-switch miss, not prefix.
+			assistantLine({ ts: TS_TODAY + SIX_MIN + 30_000, cost: 60, input: 100000, cacheRead: 0, model: "gpt-5.6-sol" }),
 		].join("\n") + "\n"
 	);
 
 	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
-	const ttl = findInsight(data, "today", /re-sending conversations after a break/);
-	assert.ok(ttl, "TTL alarm fires");
+	const ttl = findInsight(data, "today", /resuming conversations after a break/);
+	assert.ok(ttl, "resume alarm fires");
 	assert.equal(ttl.kind, "alarm");
 	assert.equal(ttl.stat, "$10.00");
 	const prefix = findInsight(data, "today", /re-sending conversations mid-session/);
 	assert.ok(prefix, "prefix alarm fires");
-	assert.equal(prefix.stat, "$5.00", "compaction-adjacent miss is excluded from prefix cost");
+	assert.equal(prefix.stat, "$5.00", "compaction- and switch-adjacent misses are excluded from prefix cost");
+	const sw = findInsight(data, "today", /switching models mid-conversation/);
+	assert.ok(sw, "model-switch alarm fires");
+	assert.equal(sw.stat, "$60.00");
+});
+
+test("pi test providers are excluded from all stats", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	writeFileSync(
+		join(sessionsDir, "a.jsonl"),
+		[
+			sessionLine("s1", TS_TODAY),
+			assistantLine({ ts: TS_TODAY, cost: 2 }),
+			assistantLine({ ts: TS_TODAY + 1000, cost: 99, provider: "faux-provider", model: "faux" }),
+			assistantLine({ ts: TS_TODAY + 2000, cost: 99, provider: "fake-provider", model: "fake" }),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 2, "test-provider cost is excluded");
+	assert.equal(data.today.totals.messages, 1, "test-provider messages are excluded");
+	assert.ok(!data.today.providers.has("faux-provider"));
+	assert.ok(!data.today.providers.has("fake-provider"));
 });
 
 test("insights fire upfront and concentration alarms when material", async (t) => {

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.0] - 2026-07-17
+
+### Changed
+- **Cache-miss taxonomy split into three behaviours**, each with its own alarm: resuming a conversation after a break (cache expired), switching models mid-conversation (the previous model's cache doesn't transfer), and true mid-session prefix changes (no break, compaction, or model switch to explain them). Validated against a second public corpus (badlogicgames/pi-mono, 628 sessions).
+- **Insights sections reordered facts-first**: “Where it went” (structure) now comes before “Worth attention” (alarms).
+- **pi's built-in test providers excluded**: `faux-provider` and `fake-provider` never call a real API and no longer appear in tables, graphs, totals, or insights.
+
 ## [0.7.2] - 2026-07-17
 
 ### Changed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -67,17 +67,7 @@ In Pi, run:
 
 ### Insights
 
-The **Insights** view has two sections:
-
-**Worth attention** — alarms that only appear when a wasteful pattern is material for the period. When nothing is flagged, the section shows an explicit all-clear.
-
-| Alarm | Fires when |
-|---|---|
-| Re-sends after a break (cache TTL) | ≥ 2% of the period's cost (and ≥ $1) went to messages that re-sent a large conversation from scratch after a > 5 min idle gap — provider caches expire after a few minutes idle |
-| Mid-session re-sends (prefix change) | ≥ 2% of cost (and ≥ $1) went to large-context cache misses with **no** idle gap — the request prefix changed mid-session. Messages right after a pi compaction are excluded, since compaction legitimately rewrites the prefix |
-| Session concentration | the top 5 sessions account for ≥ 35% of the period's cost |
-| Upfront tax | ≥ 8% of cost was the first message of a session (session starts pay for their whole prompt uncached) |
-| Cache leverage floor | fewer than 5 cached tokens served per fresh token paid (shown only above $5 / 1M fresh tokens, to avoid noise) |
+The **Insights** view has two sections, facts first:
 
 **Where it went** — always-on structural lenses:
 
@@ -85,8 +75,21 @@ The **Insights** view has two sections:
 |---|---|
 | Context tax | share of cost spent at ≥ 150k context, with the average per-message cost vs messages under 100k |
 | Project mix | top 3 project directories by cost, derived from each session's working directory (worktrees collapse into their repository; hidden when one project is ≥ 90% — you already know) |
-| Reasoning share | share of output tokens that were invisible reasoning (recorded by pi 0.80.3+ only; hidden below 5%) |
+| Reasoning share | share of output tokens that were hidden reasoning (recorded by pi 0.80.3+ only; hidden below 5%) |
 | Burn trend | your last 7 days of spend vs your prior 4-week weekly pace (same on every tab) |
+
+**Worth attention** — alarms that only appear when a wasteful pattern is material for the period. When nothing is flagged, the section shows an explicit all-clear. Large-context cache misses are split into three distinct behaviours:
+
+| Alarm | Fires when |
+|---|---|
+| Resuming after a break | ≥ 2% of the period's cost (and ≥ $1) went to messages that re-sent a large conversation from scratch after a > 5 min idle gap — provider caches expire after a few minutes idle |
+| Switching models mid-conversation | ≥ 2% of cost (and ≥ $1) went to large-context misses right after the provider/model changed mid-session — the previous model's cache doesn't transfer |
+| Mid-session re-sends (prefix change) | ≥ 2% of cost (and ≥ $1) went to large-context misses with **no** idle gap, compaction, or model switch to explain them — something rewrote the request prefix |
+| Session concentration | the top 5 sessions account for ≥ 35% of the period's cost |
+| Upfront tax | ≥ 8% of cost was the first message of a session (session starts pay for their whole prompt uncached) |
+| Cache leverage floor | fewer than 5 cached tokens served per fresh token paid (shown only above $5 / 1M fresh tokens, to avoid noise) |
+
+pi's built-in test providers (`faux-provider`, `fake-provider`) never call a real API and are excluded from all statistics, graphs, and insights.
 
 **Unit:** insights are weighted by recorded API cost (USD). Periods with no recorded cost show an explicit empty state rather than silently switching to a different unit.
 

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -76,9 +76,11 @@ interface PeriodRawData {
 	sessionCosts: Map<string, number>;
 	/** Cost of each session's first-ever message falling in this period. */
 	upfrontCost: number;
-	/** Cache misses after >TTL_GAP_MS idle — expired-cache re-warms. */
+	/** Cache misses after >TTL_GAP_MS idle — resuming after the cache expired. */
 	ttlMissCost: number;
-	/** Cache misses without an idle gap (compaction excluded) — prefix changes. */
+	/** Cache misses right after a mid-session model switch (no idle gap). */
+	modelSwitchMissCost: number;
+	/** Cache misses with no idle gap, compaction, or model switch — true prefix changes. */
 	prefixMissCost: number;
 	reasoningTokens: number;
 	outputTokens: number;
@@ -92,6 +94,8 @@ interface MessageMeta {
 	gapMs: number;
 	/** Context size of the previous assistant message in the same file; 0 when first. */
 	prevCtx: number;
+	/** True when the provider/model differs from the previous assistant message. */
+	modelSwitched: boolean;
 	/** True for the first deduped message of a session across all its files. */
 	isSessionStart: boolean;
 }
@@ -514,6 +518,7 @@ function emptyPeriodRawData(): PeriodRawData {
 		sessionCosts: new Map(),
 		upfrontCost: 0,
 		ttlMissCost: 0,
+		modelSwitchMissCost: 0,
 		prefixMissCost: 0,
 		reasoningTokens: 0,
 		outputTokens: 0,
@@ -640,6 +645,9 @@ function addMessagesToUsageData(
 		const msg = messages[mi]!;
 		const mm = meta[mi]!;
 
+		// pi's built-in test providers never call a real API — keep them out of stats.
+		if (EXCLUDED_PROVIDERS.has(msg.provider)) continue;
+
 		// Day-indexed cost totals power the burn-trend insight.
 		if (msg.timestamp > 0) {
 			const dayIdx = Math.floor((msg.timestamp - todayMs) / DAY_MS);
@@ -704,6 +712,7 @@ function addMessagesToUsageData(
 				msg.cacheRead < Math.min(MISS_MAX_CACHE_READ, 0.3 * mm.prevCtx)
 			) {
 				if (mm.gapMs > TTL_GAP_MS) raw.ttlMissCost += msg.cost;
+				else if (mm.gapMs >= 0 && mm.modelSwitched) raw.modelSwitchMissCost += msg.cost;
 				else if (mm.gapMs >= 0) raw.prefixMissCost += msg.cost;
 			}
 			raw.reasoningTokens += msg.reasoning;
@@ -943,6 +952,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 			meta.push({
 				gapMs: prev && prev.timestamp > 0 && m.timestamp > 0 ? m.timestamp - prev.timestamp : -1,
 				prevCtx: prev ? prev.input + prev.cacheRead + prev.cacheWrite : 0,
+				modelSwitched: prev !== null && (prev.provider !== m.provider || prev.model !== m.model),
 				isSessionStart: false,
 			});
 		}
@@ -1002,6 +1012,9 @@ const TREND_LOW_RATIO = 0.6;
 const TTL_GAP_MS = 5 * 60_000;
 const MISS_MIN_PREV_CONTEXT = 20_000;
 const MISS_MAX_CACHE_READ = 5_000;
+/** pi's built-in test providers never send anything to a real API. */
+const EXCLUDED_PROVIDERS = new Set(["faux-provider", "fake-provider"]);
+
 const CACHE_MISS_ALARM_PERCENT = 2;
 const CACHE_MISS_ALARM_MIN_COST = 1;
 // Concentration / upfront alarms
@@ -1045,9 +1058,20 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 		insights.push({
 			kind: "alarm",
 			stat: fmtMoney(raw.ttlMissCost),
-			headline: `spent re-sending conversations after a break (${fmtPercent(ttlPct)} of this period)`,
+			headline: `spent resuming conversations after a break (${fmtPercent(ttlPct)} of this period)`,
 			advice:
 				"Sent context is only reusable for a few minutes. After a longer pause, the next message pays to send the whole conversation again. Replying while a session is fresh avoids this.",
+		});
+	}
+
+	const switchPct = (raw.modelSwitchMissCost / total) * 100;
+	if (switchPct >= CACHE_MISS_ALARM_PERCENT && raw.modelSwitchMissCost >= CACHE_MISS_ALARM_MIN_COST) {
+		insights.push({
+			kind: "alarm",
+			stat: fmtMoney(raw.modelSwitchMissCost),
+			headline: `spent switching models mid-conversation (${fmtPercent(switchPct)} of this period)`,
+			advice:
+				"Changing model re-sends the whole conversation at full price — the previous model's saved context doesn't transfer. Switching between tasks instead of mid-conversation avoids this.",
 		});
 	}
 
@@ -1058,7 +1082,7 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 			stat: fmtMoney(raw.prefixMissCost),
 			headline: `spent re-sending conversations mid-session (${fmtPercent(prefixPct)} of this period)`,
 			advice:
-				"These messages paid full price for context that had already been sent, without a pause to explain it. Usually a tool or workflow is restarting or rewriting conversations. Worth a look if it stays high.",
+				"These messages paid full price for context that had already been sent — with no break, compaction, or model switch to explain it. Usually a tool or workflow is restarting or rewriting conversations. Worth a look if it stays high.",
 		});
 	}
 

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -553,16 +553,17 @@ class UsageComponent {
 
 		const alarms = insights.filter((i) => i.kind === "alarm");
 		const structure = insights.filter((i) => i.kind === "structure");
+		// Facts first, flagged waste second.
+		if (structure.length > 0) {
+			lines.push(sectionHeader("Where it went", "accent"));
+			for (const insight of structure) renderOne(insight);
+		}
 		lines.push(sectionHeader("Worth attention", "warning"));
 		if (alarms.length > 0) {
 			for (const insight of alarms) renderOne(insight);
 		} else {
 			lines.push(`  ${th.fg("success", padLeft("✓", 6))} ${th.fg("dim", "no waste patterns flagged for this period")}`);
 			lines.push("");
-		}
-		if (structure.length > 0) {
-			lines.push(sectionHeader("Where it went", "accent"));
-			for (const insight of structure) renderOne(insight);
 		}
 
 		return lines;

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
Closes #73.

**Three miss behaviours**, each its own conditional alarm (2% / $1 gates unchanged):
- *Resuming after a break* — >5 min idle, cache expired
- *Switching models mid-conversation* — provider/model differs from the previous message; the old model's cache doesn't transfer
- *Mid-session re-sends (prefix change)* — no break, compaction, or model switch left to explain it

**Facts first**: 'Where it went' section now renders above 'Worth attention'.

**Test providers excluded**: `faux-provider` / `fake-provider` are pi test doubles that never hit a real API — now filtered from all stats, graphs, and insights (aggregation-time, so no cache rebuild).

Validated on both corpora: our store ($34.6k — switch slice immaterial, no false alarm) and badlogicgames/pi-mono ($642 — honest finding: Mario's 208 mid-session switches only account for ~$4.82 of large-context misses; his 11% prefix share is workflow-driven, which the advice text now correctly describes).

Tests 46/46 (new: three-way classification, test-provider exclusion); tsc clean; live TUI verified.