### PR TITLE
usage: consistent units — alarms lead with dollars (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.55] - 2026-07-17
+
+### Changed
+- `usage-extension` 0.8.1: all “Worth attention” alarms lead with dollars (share in the parenthetical); “Where it went” keeps percentages.
+
 ## [0.1.54] - 2026-07-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -560,10 +560,12 @@ test("insights fire upfront and concentration alarms when material", async (t) =
 	const upfront = findInsight(data, "today", /opening message of new sessions/);
 	assert.ok(upfront, "upfront alarm fires (every message is a session start here)");
 	assert.equal(upfront.kind, "alarm");
-	assert.equal(upfront.stat, "100%");
-	const conc = findInsight(data, "today", /came from just 5 sessions/);
+	assert.equal(upfront.stat, "$52.00");
+	assert.match(upfront.headline, /100% of this period/);
+	const conc = findInsight(data, "today", /came from just 5 of your 7 sessions/);
 	assert.ok(conc, "concentration alarm fires");
-	assert.equal(conc.stat, "96%"); // 50 of 52
+	assert.equal(conc.stat, "$50.00"); // top 5 of $52 total
+	assert.match(conc.headline, /96% of this period/);
 });
 
 test("insights include context tax, project mix, and reasoning share", async (t) => {

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.1] - 2026-07-17
+
+### Changed
+- **Consistent units.** Every alarm in “Worth attention” now leads with dollars (the act-or-ignore number), with the period share in the dimmed parenthetical; “Where it went” keeps percentages (shares of the pie). Session concentration and upfront tax previously led with %.
+
 ## [0.8.0] - 2026-07-17
 
 ### Changed

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -1093,8 +1093,8 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 		if (topPct >= CONCENTRATION_ALARM_PERCENT) {
 			insights.push({
 				kind: "alarm",
-				stat: fmtPercent(topPct),
-				headline: `of this period's cost came from just ${TOP_SESSION_COUNT} sessions (of ${raw.sessionCosts.size})`,
+				stat: fmtMoney(topWeight),
+				headline: `came from just ${TOP_SESSION_COUNT} of your ${raw.sessionCosts.size} sessions (${fmtPercent(topPct)} of this period)`,
 				advice: "A handful of sessions drove most of the spend. The graph view can show what they were doing.",
 			});
 		}
@@ -1104,8 +1104,8 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 	if (upfrontPct >= UPFRONT_ALARM_PERCENT) {
 		insights.push({
 			kind: "alarm",
-			stat: fmtPercent(upfrontPct),
-			headline: "of cost went on the opening message of new sessions",
+			stat: fmtMoney(raw.upfrontCost),
+			headline: `spent on the opening message of new sessions (${fmtPercent(upfrontPct)} of this period)`,
 			advice: "A session's first message sends everything from scratch. Fewer, longer sessions cut this overhead.",
 		});
 	}

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
The unit rule is now crisp:

- **Worth attention** (act-or-ignore decisions) → leads with **$**, period share in the dimmed parenthetical. Session concentration and upfront tax previously led with %, mixing units within the section. Cache leverage stays ×, a genuine ratio.
- **Where it went** (shares of the pie) → leads with **%**.

Before/after on real data:
- `76% of this period's cost came from just 5 sessions (of 47)` → `$277 came from just 5 of your 47 sessions (74% of this period)`
- `100% of cost went on the opening message of new sessions` → `$52.00 spent on the opening message of new sessions (100% of this period)`

Tests 46/46; tsc clean; verified headless against the live corpus.