### PR TITLE
usage: [e] export in every view (CSV/JSON)

### DIFF
--- a/tests/usage-export.test.mjs
+++ b/tests/usage-export.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTableCsv, buildGraphCsv, buildInsightsJson, exportFileName } from "../usage-extension/export.ts";
+
+function stats(cost, messages, tokens = {}) {
+	return {
+		cost,
+		messages,
+		tokens: { total: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, ...tokens },
+	};
+}
+
+test("buildTableCsv emits per-model rows sorted by cost plus a TOTAL row", () => {
+	const providers = new Map([
+		[
+			"anthropic",
+			{
+				...stats(10, 4, { total: 100, input: 60, output: 40 }),
+				sessions: new Set(["s1", "s2"]),
+				models: new Map([
+					["claude-fable-5", { ...stats(8, 3, { total: 80 }), sessions: new Set(["s1", "s2"]) }],
+					["claude-opus-4-8", { ...stats(2, 1, { total: 20 }), sessions: new Set(["s1"]) }],
+				]),
+			},
+		],
+		[
+			"openai-codex",
+			{
+				...stats(30, 5, { total: 300 }),
+				sessions: new Set(["s3"]),
+				models: new Map([["gpt-5.6-sol", { ...stats(30, 5, { total: 300 }), sessions: new Set(["s3"]) }]]),
+			},
+		],
+	]);
+	const totals = { ...stats(40, 9, { total: 400, cacheRead: 7 }), sessions: 3 };
+
+	const csv = buildTableCsv(providers, totals).trimEnd().split("\n");
+	assert.equal(csv[0], "provider,model,sessions,messages,cost_usd,fresh_tokens,input_tokens,output_tokens,cache_read_tokens,cache_write_tokens");
+	assert.equal(csv[1], "openai-codex,gpt-5.6-sol,1,5,30,300,0,0,0,0", "highest-cost provider first");
+	assert.equal(csv[2], "anthropic,claude-fable-5,2,3,8,80,0,0,0,0");
+	assert.equal(csv[3], "anthropic,claude-opus-4-8,1,1,2,20,0,0,0,0");
+	assert.equal(csv[4], "TOTAL,,3,9,40,400,0,0,7,0");
+});
+
+test("buildTableCsv quotes fields containing commas or quotes", () => {
+	const providers = new Map([
+		[
+			'we,"ird',
+			{
+				...stats(1, 1),
+				sessions: new Set(["s"]),
+				models: new Map([["m,1", { ...stats(1, 1), sessions: new Set(["s"]) }]]),
+			},
+		],
+	]);
+	const csv = buildTableCsv(providers, { ...stats(1, 1), sessions: 1 });
+	assert.match(csv, /^"we,""ird","m,1",/m);
+});
+
+test("buildGraphCsv exports visible series as plotted with ISO bucket starts", () => {
+	const t0 = Date.UTC(2026, 6, 17, 10);
+	const model = {
+		series: [
+			{ key: "a", label: "anthropic", points: [1, 2, 3], total: 6, hidden: false, firstIdx: 0, lastIdx: 2 },
+			{ key: "b", label: "hidden-one", points: [9, 9, 9], total: 27, hidden: true, firstIdx: 0, lastIdx: 2 },
+		],
+		bucketStarts: [t0, t0 + 3_600_000, t0 + 7_200_000],
+		bucketMs: 3_600_000,
+		domainStartMs: t0,
+		domainEndMs: t0 + 10_800_000,
+		yMax: 3,
+		groupedTotal: 6,
+	};
+	const csv = buildGraphCsv(model).trimEnd().split("\n");
+	assert.equal(csv[0], "bucket_start,anthropic", "hidden series excluded");
+	assert.equal(csv[1], "2026-07-17T10:00:00.000Z,1");
+	assert.equal(csv[3], "2026-07-17T12:00:00.000Z,3");
+});
+
+test("buildInsightsJson carries period, totals, and insights", () => {
+	const json = JSON.parse(
+		buildInsightsJson("allTime", { ...stats(42.5, 10), sessions: 4 }, [
+			{ kind: "alarm", stat: "$5.00", headline: "spent on x (12% of this period)", advice: "do less x" },
+		])
+	);
+	assert.equal(json.period, "allTime");
+	assert.deepEqual(json.totals, { costUsd: 42.5, messages: 10, sessions: 4 });
+	assert.equal(json.insights.length, 1);
+	assert.equal(json.insights[0].kind, "alarm");
+	assert.ok(json.generatedAt.endsWith("Z"));
+});
+
+test("exportFileName is stable and slice-aware", () => {
+	const now = new Date(2026, 6, 17, 15, 4, 9);
+	assert.equal(exportFileName("table", "allTime", null, "csv", now), "usage-table-allTime-20260717-150409.csv");
+	assert.equal(
+		exportFileName("graph", "today", "cumulative-cost-by-provider", "csv", now),
+		"usage-graph-today-cumulative-cost-by-provider-20260717-150409.csv"
+	);
+});

--- a/usage-extension/export.ts
+++ b/usage-extension/export.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure builders for /usage export ([e] key).
+ *
+ * Each view exports its current slice: the table as per-model CSV rows, the
+ * graph as one CSV column per visible series, and insights as structured JSON.
+ * Builders are pure string producers so they stay trivially testable; the
+ * component owns file naming and disk writes.
+ */
+
+import type { Insight, ProviderStats, TotalStats } from "./data.ts";
+import type { GraphModel } from "./graph.ts";
+
+/** Quote a CSV field only when it needs it (comma, quote, or newline). */
+function csvField(value: string | number): string {
+	const s = String(value);
+	return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function csvLine(fields: (string | number)[]): string {
+	return fields.map(csvField).join(",");
+}
+
+/** Per-model rows (provider repeated), then a TOTAL row. */
+export function buildTableCsv(providers: ReadonlyMap<string, ProviderStats>, totals: TotalStats): string {
+	const lines = [
+		csvLine([
+			"provider",
+			"model",
+			"sessions",
+			"messages",
+			"cost_usd",
+			"fresh_tokens",
+			"input_tokens",
+			"output_tokens",
+			"cache_read_tokens",
+			"cache_write_tokens",
+		]),
+	];
+	const sorted = Array.from(providers.entries()).sort((a, b) => b[1].cost - a[1].cost);
+	for (const [providerName, provider] of sorted) {
+		const models = Array.from(provider.models.entries()).sort((a, b) => b[1].cost - a[1].cost);
+		for (const [modelName, model] of models) {
+			lines.push(
+				csvLine([
+					providerName,
+					modelName,
+					model.sessions.size,
+					model.messages,
+					model.cost,
+					model.tokens.total,
+					model.tokens.input,
+					model.tokens.output,
+					model.tokens.cacheRead,
+					model.tokens.cacheWrite,
+				])
+			);
+		}
+	}
+	lines.push(
+		csvLine([
+			"TOTAL",
+			"",
+			totals.sessions,
+			totals.messages,
+			totals.cost,
+			totals.tokens.total,
+			totals.tokens.input,
+			totals.tokens.output,
+			totals.tokens.cacheRead,
+			totals.tokens.cacheWrite,
+		])
+	);
+	return lines.join("\n") + "\n";
+}
+
+/**
+ * One row per time bucket, one column per visible series, values exactly as
+ * plotted (per-bucket or cumulative, current metric).
+ */
+export function buildGraphCsv(model: GraphModel): string {
+	const visible = model.series.filter((s) => !s.hidden);
+	const lines = [csvLine(["bucket_start", ...visible.map((s) => s.label)])];
+	for (let i = 0; i < model.bucketStarts.length; i++) {
+		lines.push(csvLine([new Date(model.bucketStarts[i]!).toISOString(), ...visible.map((s) => s.points[i] ?? 0)]));
+	}
+	return lines.join("\n") + "\n";
+}
+
+/** Structured JSON of the period's insights plus headline totals. */
+export function buildInsightsJson(period: string, totals: TotalStats, insights: Insight[]): string {
+	return (
+		JSON.stringify(
+			{
+				period,
+				generatedAt: new Date().toISOString(),
+				totals: { costUsd: totals.cost, messages: totals.messages, sessions: totals.sessions },
+				insights: insights.map((i) => ({ kind: i.kind, stat: i.stat, headline: i.headline, advice: i.advice })),
+			},
+			null,
+			"\t"
+		) + "\n"
+	);
+}
+
+/** usage-<view>-<period>[-<slice>]-<stamp>.<ext> in the current directory. */
+export function exportFileName(view: string, period: string, slice: string | null, ext: string, now: Date): string {
+	const pad = (n: number) => String(n).padStart(2, "0");
+	const stamp =
+		`${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+		`-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+	return ["usage", view, period, ...(slice ? [slice] : []), stamp].join("-") + `.${ext}`;
+}

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -26,6 +26,9 @@ import {
 	TOTAL_SERIES_KEY,
 } from "./graph";
 import type { GraphGroupBy, GraphMetric, GraphModel } from "./graph";
+import { buildGraphCsv, buildInsightsJson, buildTableCsv, exportFileName } from "./export";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 type ViewMode = "table" | "insights" | "graph";
 
@@ -281,6 +284,7 @@ class UsageComponent {
 	private graphMetric: GraphMetric = "cost";
 	private graphGroupBy: GraphGroupBy = "provider";
 	private graphCumulative = true;
+	private exportNote: { text: string; ok: boolean } | null = null;
 	private graphHidden = new Set<string>();
 	private graphLegendIndex = 0;
 
@@ -309,6 +313,13 @@ class UsageComponent {
 		if (matchesKey(data, "v")) {
 			const idx = VIEW_CYCLE.indexOf(this.viewMode);
 			this.viewMode = VIEW_CYCLE[(idx + 1) % VIEW_CYCLE.length]!;
+			this.exportNote = null;
+			this.requestRender();
+			return;
+		}
+
+		if (matchesKey(data, "e")) {
+			this.exportCurrentView();
 			this.requestRender();
 			return;
 		}
@@ -321,11 +332,13 @@ class UsageComponent {
 			const idx = TAB_ORDER.indexOf(this.activeTab);
 			this.activeTab = TAB_ORDER[(idx + 1) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
+			this.exportNote = null;
 			this.requestRender();
 		} else if (matchesKey(data, "shift+tab") || matchesKey(data, "left")) {
 			const idx = TAB_ORDER.indexOf(this.activeTab);
 			this.activeTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
+			this.exportNote = null;
 			this.requestRender();
 		} else if (this.viewMode === "graph") {
 			// Graph-specific keys were handled above; swallow table-only keys.
@@ -386,6 +399,31 @@ class UsageComponent {
 		}
 		this.requestRender();
 		return true;
+	}
+
+	private exportCurrentView(): void {
+		const now = new Date();
+		let name: string;
+		let content: string;
+		const stats = this.data[this.activeTab];
+		if (this.viewMode === "graph") {
+			const slice = `${this.graphCumulative ? "cumulative" : "per-bucket"}-${this.graphMetric}-by-${this.graphGroupBy}`;
+			name = exportFileName("graph", this.activeTab, slice, "csv", now);
+			content = buildGraphCsv(this.buildGraphModelForView());
+		} else if (this.viewMode === "insights") {
+			name = exportFileName("insights", this.activeTab, null, "json", now);
+			content = buildInsightsJson(this.activeTab, stats.totals, stats.insights.insights);
+		} else {
+			name = exportFileName("table", this.activeTab, null, "csv", now);
+			content = buildTableCsv(stats.providers, stats.totals);
+		}
+		try {
+			const path = join(process.cwd(), name);
+			writeFileSync(path, content);
+			this.exportNote = { text: `Saved ${name}`, ok: true };
+		} catch (err) {
+			this.exportNote = { text: `Export failed: ${err instanceof Error ? err.message : String(err)}`, ok: false };
+		}
 	}
 
 	private buildGraphModelForView(): GraphModel {
@@ -708,32 +746,35 @@ class UsageComponent {
 	}
 
 	private renderHelp(width: number): string[] {
+		const noteLines = this.exportNote
+			? [this.theme.fg(this.exportNote.ok ? "success" : "error", `${this.exportNote.ok ? "✓" : "✗"} ${this.exportNote.text}`), ""]
+			: [];
 		const variants =
 			this.viewMode === "graph"
 				? [
-						"[Tab/←→] period  [m] metric  [g] group  [c] cumulative  [↑↓/Enter] filter  [a] all  [v] view  [q] close",
-						"[Tab] period  [m] metric  [g] group  [c] cumul  [↑↓/Enter] filter  [v] view  [q] close",
+						"[Tab/←→] period  [m] metric  [g] group  [c] cumulative  [↑↓/Enter] filter  [a] all  [e] export  [v] view  [q] close",
+						"[Tab] period  [m] metric  [g] group  [c] cumul  [↑↓/Enter] filter  [e] export  [v] view  [q] close",
 						"[m] metric  [g] group  [c] cumul  [↑↓] filter  [q] close",
 						"[m] [g] [c] [↑↓] [q]",
 						"[q] close",
 				  ]
 				: this.viewMode === "insights"
 				? [
-						"[Tab/←→] period  [v] view  [q] close",
-						"[Tab] period  [v] view  [q] close",
+						"[Tab/←→] period  [e] export  [v] view  [q] close",
+						"[Tab] period  [e] export  [v] view  [q] close",
 						"[v] view  [q] close",
 						"[q] close",
 				  ]
 				: [
-						"[Tab/←→] period  [↑↓] select  [Enter] expand  [v] view  [q] close",
-						"[Tab] period  [↑↓] select  [Enter] expand  [v] view  [q] close",
+						"[Tab/←→] period  [↑↓] select  [Enter] expand  [e] export  [v] view  [q] close",
+						"[Tab] period  [↑↓] select  [Enter] expand  [e] export  [v] view  [q] close",
 						"[↑↓] select  [Enter] expand  [v] view  [q] close",
 						"[↑↓] select  [v] view  [q] close",
 						"[↑↓] select  [q] close",
 						"[q] close",
 				  ];
 		const line = pickFittingText(width, variants);
-		return [this.theme.fg("dim", line)];
+		return [...noteLines, this.theme.fg("dim", line)];
 	}
 
 	invalidate(): void {}


### PR DESCRIPTION
Closes #67.

`[e]` exports the **current slice** from any view into the cwd:

- **Table** → `usage-table-<period>-<stamp>.csv` — per-model rows + TOTAL, full precision
- **Graph** → `usage-graph-<period>-<slice>-<stamp>.csv` — exactly what's plotted: visible series only, current metric/grouping/cumulative, ISO bucket starts
- **Insights** → `usage-insights-<period>-<stamp>.json` — period, totals, structured insights

Confirmation (`✓ Saved …` / `✗ Export failed: …`) renders above the help line and clears on view/period switches. Pure builders live in `export.ts` with CSV-escaping and filename tests.

Tests 51/51; tsc clean; live E2E: exported all three formats from a real store and verified contents.