### PR TITLE
usage: exports default to /tmp, configurable exportDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.57] - 2026-07-17
+
+### Changed
+- `usage-extension` 0.9.1: exports save to `/tmp` by default (full path shown in the confirmation note), with a configurable `exportDir` under the `usage-extension` key in settings.json.
+
 ## [0.1.56] - 2026-07-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-export.test.mjs
+++ b/tests/usage-export.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildTableCsv, buildGraphCsv, buildInsightsJson, exportFileName } from "../usage-extension/export.ts";
+import {
+	buildTableCsv,
+	buildGraphCsv,
+	buildInsightsJson,
+	exportFileName,
+	parseExportDirSetting,
+	resolveExportDir,
+} from "../usage-extension/export.ts";
 
 function stats(cost, messages, tokens = {}) {
 	return {
@@ -98,4 +105,21 @@ test("exportFileName is stable and slice-aware", () => {
 		exportFileName("graph", "today", "cumulative-cost-by-provider", "csv", now),
 		"usage-graph-today-cumulative-cost-by-provider-20260717-150409.csv"
 	);
+});
+
+test("parseExportDirSetting reads the usage-extension key and tolerates junk", () => {
+	assert.equal(parseExportDirSetting('{"usage-extension":{"exportDir":"~/Downloads"}}'), "~/Downloads");
+	assert.equal(parseExportDirSetting('{"usage-extension":{"exportDir":"  /data/exports "}}'), "/data/exports");
+	assert.equal(parseExportDirSetting('{"usage-extension":{"exportDir":""}}'), null);
+	assert.equal(parseExportDirSetting('{"usage-extension":{"exportDir":42}}'), null);
+	assert.equal(parseExportDirSetting('{"defaultProvider":"openai-codex"}'), null);
+	assert.equal(parseExportDirSetting("not json at all"), null);
+});
+
+test("resolveExportDir prefers config, expands ~, defaults to /tmp", () => {
+	assert.equal(resolveExportDir("/data/exports", "/Users/t", true, "/var/tmp-x"), "/data/exports");
+	assert.equal(resolveExportDir("~/Downloads", "/Users/t", true, "/var/tmp-x"), "/Users/t/Downloads");
+	assert.equal(resolveExportDir("~", "/Users/t", true, "/var/tmp-x"), "/Users/t");
+	assert.equal(resolveExportDir(null, "/Users/t", true, "/var/tmp-x"), "/tmp");
+	assert.equal(resolveExportDir(null, "/Users/t", false, "/var/tmp-x"), "/var/tmp-x");
 });

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.1] - 2026-07-17
+
+### Changed
+- Exports now save to `/tmp` (or the OS temp dir where `/tmp` doesn't exist) instead of the pi session's cwd, so they never litter a repo or home directory. The `✓ Saved` note shows the full path.
+- The export directory is configurable: `{ "usage-extension": { "exportDir": "~/Downloads" } }` in `~/.pi/agent/settings.json` (`~` expands; the directory is created if missing).
+
 ## [0.9.0] - 2026-07-17
 
 ### Added

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -7,7 +7,7 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 ## Compatibility
 
 - **Pi version:** 0.42.4+
-- **Last updated:** 2026-07-17 (0.9.0)
+- **Last updated:** 2026-07-17 (0.9.1)
 
 ## Installation
 
@@ -107,7 +107,7 @@ A note on reading them: cache-miss and context numbers are **observed cost, not 
 
 ### Export
 
-Press `e` in any view to write the **current slice** to the current working directory:
+Press `e` in any view to write the **current slice** to `/tmp` (or the OS temp dir where `/tmp` doesn't exist) — exports never litter your repo or home directory, and the `✓ Saved` note shows the full path so you can grab the file if you want to keep it:
 
 | View | File | Contents |
 |---|---|---|
@@ -116,6 +116,14 @@ Press `e` in any view to write the **current slice** to the current working dire
 | Insights | `usage-insights-<period>-<stamp>.json` | period, totals, and the structured insight list |
 
 A `✓ Saved …` note confirms the write (or reports the error) above the help line.
+
+To export somewhere permanent instead, set an export directory in `~/.pi/agent/settings.json` (created if missing, `~` expands):
+
+```json
+{
+	"usage-extension": { "exportDir": "~/Downloads" }
+}
+```
 
 ### Graph explorer
 

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -198,7 +198,7 @@ export interface ParsedSessionFile {
 // Paths
 // =============================================================================
 
-function getAgentDir(): string {
+export function getAgentDir(): string {
 	// Replicate Pi's logic: respect PI_CODING_AGENT_DIR env var
 	return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 }

--- a/usage-extension/export.ts
+++ b/usage-extension/export.ts
@@ -7,8 +7,42 @@
  * component owns file naming and disk writes.
  */
 
+import { join } from "node:path";
 import type { Insight, ProviderStats, TotalStats } from "./data.ts";
 import type { GraphModel } from "./graph.ts";
+
+/**
+ * Read the configured export directory from settings.json content, if any.
+ * Config shape: `{ "usage-extension": { "exportDir": "~/Downloads" } }`.
+ */
+export function parseExportDirSetting(settingsJson: string): string | null {
+	try {
+		const parsed = JSON.parse(settingsJson) as { "usage-extension"?: { exportDir?: unknown } };
+		const dir = parsed["usage-extension"]?.exportDir;
+		return typeof dir === "string" && dir.trim() !== "" ? dir.trim() : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Pick the export directory. A configured dir wins (with `~` expanded);
+ * otherwise exports go to /tmp so they never litter a repo or home
+ * directory, falling back to the OS temp dir where /tmp doesn't exist.
+ */
+export function resolveExportDir(
+	configured: string | null,
+	home: string,
+	slashTmpExists: boolean,
+	fallbackTmp: string,
+): string {
+	if (configured !== null) {
+		if (configured === "~") return home;
+		if (configured.startsWith("~/")) return join(home, configured.slice(2));
+		return configured;
+	}
+	return slashTmpExists ? "/tmp" : fallbackTmp;
+}
 
 /** Quote a CSV field only when it needs it (comma, quote, or newline). */
 function csvField(value: string | number): string {

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -13,7 +13,7 @@ import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-wor
 import { DynamicBorder } from "@earendil-works/pi-coding-agent";
 import { CancellableLoader, Container, Spacer, matchesKey, visibleWidth, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 
-import { collectUsageData, TAB_ORDER } from "./data";
+import { collectUsageData, getAgentDir, TAB_ORDER } from "./data";
 import type { CollectProgress } from "./data";
 import type { BaseStats, ProviderStats, TabName, TotalStats, UsageData } from "./data";
 import {
@@ -26,8 +26,16 @@ import {
 	TOTAL_SERIES_KEY,
 } from "./graph";
 import type { GraphGroupBy, GraphMetric, GraphModel } from "./graph";
-import { buildGraphCsv, buildInsightsJson, buildTableCsv, exportFileName } from "./export";
-import { writeFileSync } from "node:fs";
+import {
+	buildGraphCsv,
+	buildInsightsJson,
+	buildTableCsv,
+	exportFileName,
+	parseExportDirSetting,
+	resolveExportDir,
+} from "./export";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 type ViewMode = "table" | "insights" | "graph";
@@ -524,9 +532,19 @@ class UsageComponent {
 			content = buildTableCsv(visible.providers, visible.totals);
 		}
 		try {
-			const path = join(process.cwd(), name);
+			let configured: string | null = null;
+			try {
+				configured = parseExportDirSetting(readFileSync(join(getAgentDir(), "settings.json"), "utf8"));
+			} catch {
+				// No settings file or unreadable: fall through to the default dir.
+			}
+			const home = homedir();
+			const dir = resolveExportDir(configured, home, existsSync("/tmp"), tmpdir());
+			mkdirSync(dir, { recursive: true });
+			const path = join(dir, name);
 			writeFileSync(path, content);
-			this.exportNote = { text: `Saved ${name}`, ok: true };
+			const shown = path.startsWith(home + "/") ? "~" + path.slice(home.length) : path;
+			this.exportNote = { text: `Saved ${shown}`, ok: true };
 		} catch (err) {
 			this.exportNote = { text: `Export failed: ${err instanceof Error ? err.message : String(err)}`, ok: false };
 		}

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
Follow-up to #77: saving exports to the session cwd littered repos (untracked junk in `git status`, committable by accident). Now:

- Default: `/tmp` (or `os.tmpdir()` where /tmp doesn't exist) — retrieve-if-you-want-it, OS cleans up otherwise
- Configurable: `{ "usage-extension": { "exportDir": "~/Downloads" } }` in `~/.pi/agent/settings.json`, read at export time (no restart), `~` expanded, dir created if missing
- The ✓ Saved note now shows the **full path** (home shortened to `~`)

Safety check: pi's settings-manager `persistScopedSettings` spreads the on-disk file and only overwrites modified fields, so a foreign `usage-extension` key survives pi's own settings rewrites.

Tests 53/53 (new: config parse + dir resolution), tsc clean. Live-verified both paths in a tmux pi session: default → `/tmp`, then flipped settings.json mid-session → next export landed in the configured dir (created on demand), cwd stayed empty throughout.