### PR TITLE
fix(session-recap): skip silently when active model's provider is unknown to pi-ai

### DIFF
--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Skip recap generation silently when the active model uses a custom API handler that is registered only in Pi's runtime and cannot be resolved by pi-ai's standalone compatibility layer. Users can still select a supported recap model with `--recap-model`.
+
+Thanks to @timvdhoorn for reporting and fixing the custom-provider failure ([#81](https://github.com/tmustier/pi-extensions/pull/81)).
+
 ## [0.2.1] - 2026-07-05
 
 ### Fixed

--- a/session-recap/README.md
+++ b/session-recap/README.md
@@ -33,13 +33,13 @@ If focus events cause any weirdness in your terminal, run with `--recap-disable-
 
 ## Model
 
-Defaults to the **currently active model** in your Pi session, but with recap-specific low-cost settings. This piggybacks on whatever auth you already have (including custom providers registered via `pi.registerProvider`), so there are no login surprises.
+Defaults to the **currently active model** in your Pi session, but with recap-specific low-cost settings. This piggybacks on the auth you already have configured, so there are no extra login prompts. Custom providers registered through `pi.registerProvider` work when they use one of pi-ai's built-in API types. Providers that register a custom API handler only inside Pi's runtime are skipped silently because pi-ai's standalone compatibility layer cannot route the recap call; use `--recap-model` to select a supported provider if you still want recaps in those sessions.
 
 - No tools or Agent Skills are loaded into the recap call — only a compact two-tier transcript is sent (recent activity in detail, plus your earlier prompts and any compaction summary for task framing), capped at ~12k chars.
 - Reasoning/thinking is disabled for the recap call.
 - Prompt cache writes/reads are disabled with `cacheRetention: "none"`.
 - Output is capped with `maxTokens: 256`.
-- No active model or failed auth resolution → the recap is skipped silently.
+- No active model, failed auth resolution, or an unsupported custom API handler → the recap is skipped silently.
 
 Override with `--recap-model "<provider>/<id>"` if you want a specific model regardless of the session's active one.
 

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -28,9 +28,10 @@
  * the user has lost is the task thread.
  *
  * Model: defaults to the user's currently active model with reasoning/thinking
- * disabled and cache writes disabled. This piggybacks on whatever auth the user
- * already has configured (including custom providers) so there are no login
- * surprises. Override explicitly with `--recap-model "<provider>/<id>"`.
+ * disabled and cache writes disabled. This piggybacks on the user's configured
+ * auth. Custom providers using a built-in pi-ai API work normally; providers
+ * with a custom API handler are skipped silently. Override explicitly with
+ * `--recap-model "<provider>/<id>"`.
  *
  * Flags:
  *   --recap-away-seconds <n>   Continuous blur before an away recap (default 90)
@@ -340,7 +341,7 @@ async function generateRecap(
 		// are unknown to pi-ai's compat provider registry, so completeSimple
 		// cannot route the call. Skip the recap silently, matching the documented
 		// "failed auth resolution → skipped silently" behavior.
-		if (err instanceof Error && err.message.includes("No API provider registered")) {
+		if (err instanceof Error && err.message.startsWith("No API provider registered for api:")) {
 			return undefined;
 		}
 		throw err;

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -307,32 +307,44 @@ async function generateRecap(
 		transcript.slice(0, TRANSCRIPT_CHAR_CAP) +
 		"\n</transcript>";
 
-	const response = await completeSimple(
-		model,
-		{
-			// Some providers (notably openai-codex-responses) require a non-empty
-			// top-level instruction string even for simple one-shot completions.
-			systemPrompt: "You write terse, concrete session recaps for a coding agent UI.",
-			messages: [
-				{
-					role: "user",
-					content: [{ type: "text", text: prompt }],
-					timestamp: Date.now(),
-				},
-			],
-		},
-		{
-			apiKey: auth.apiKey,
-			headers: auth.headers,
-			env: auth.env,
-			signal,
-			// Recaps are tiny, throwaway UI hints. Do not pay to create/read prompt
-			// cache entries, and do not spend reasoning tokens. Claude Code's away
-			// summary path likewise disables thinking for this job.
-			cacheRetention: "none",
-			maxTokens: 256,
-		},
-	);
+	let response;
+	try {
+		response = await completeSimple(
+			model,
+			{
+				// Some providers (notably openai-codex-responses) require a non-empty
+				// top-level instruction string even for simple one-shot completions.
+				systemPrompt: "You write terse, concrete session recaps for a coding agent UI.",
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: prompt }],
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: auth.apiKey,
+				headers: auth.headers,
+				env: auth.env,
+				signal,
+				// Recaps are tiny, throwaway UI hints. Do not pay to create/read prompt
+				// cache entries, and do not spend reasoning tokens. Claude Code's away
+				// summary path likewise disables thinking for this job.
+				cacheRetention: "none",
+				maxTokens: 256,
+			},
+		);
+	} catch (err) {
+		// Custom providers registered only with pi (e.g. via a bridge extension)
+		// are unknown to pi-ai's compat provider registry, so completeSimple
+		// cannot route the call. Skip the recap silently, matching the documented
+		// "failed auth resolution → skipped silently" behavior.
+		if (err instanceof Error && err.message.includes("No API provider registered")) {
+			return undefined;
+		}
+		throw err;
+	}
 
 	const text = response.content
 		.filter((c): c is { type: "text"; text: string } => c.type === "text")

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -27,5 +27,8 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.80.3",
     "@earendil-works/pi-coding-agent": "^0.80.3"
+  },
+  "scripts": {
+    "test": "node tests/unknown-api-provider.test.mjs"
   }
 }

--- a/session-recap/tests/unknown-api-provider.test.mjs
+++ b/session-recap/tests/unknown-api-provider.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import sessionRecap from "../index.ts";
+
+function makePi() {
+	const commands = new Map();
+	const flags = new Map();
+	return {
+		commands,
+		on() {},
+		registerCommand(name, command) {
+			commands.set(name, command);
+		},
+		registerFlag(name, options) {
+			flags.set(name, options.default);
+		},
+		getFlag(name) {
+			return flags.get(name);
+		},
+	};
+}
+
+const pi = makePi();
+sessionRecap(pi);
+
+const widgets = [];
+const ctx = {
+	hasUI: true,
+	model: {
+		id: "bridge-model",
+		name: "Bridge model",
+		api: "claude-bridge",
+		provider: "bridge",
+		baseUrl: "http://localhost.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	},
+	modelRegistry: {
+		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "unused" }),
+	},
+	sessionManager: {
+		getBranch: () => [
+			{ type: "message", message: { role: "user", content: "Please fix the bridge integration." } },
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "I inspected the integration and prepared the next concrete change." }],
+				},
+			},
+		],
+	},
+	ui: {
+		setStatus() {},
+		setWidget(...args) {
+			widgets.push(args);
+		},
+		theme: {
+			fg(_name, text) {
+				return text;
+			},
+			bold(text) {
+				return text;
+			},
+		},
+	},
+};
+
+const errors = [];
+const originalConsoleError = console.error;
+console.error = (...args) => errors.push(args);
+try {
+	await pi.commands.get("recap").handler("", ctx);
+} finally {
+	console.error = originalConsoleError;
+}
+
+assert.deepEqual(errors, [], "an unknown custom API provider should be skipped without logging an error");
+assert.deepEqual(widgets, [], "an unsupported provider should not render an empty recap widget");
+console.log("unknown API provider test passed");


### PR DESCRIPTION
## Problem

When the active Pi model runs through a custom provider registered only with pi itself (in my case a `claude-bridge` extension), `completeSimple` from `@earendil-works/pi-ai/compat` cannot resolve it and throws:

```
[session-recap] failed: Error: No API provider registered for api: claude-bridge
    at resolveApiProvider (.../pi-ai/dist/compat.js:165:15)
    at streamSimple (.../pi-ai/dist/compat.js:192:22)
    at completeSimple (.../pi-ai/dist/compat.js:196:15)
    at generateRecap (.../pi-session-recap/index.ts)
```

The error surfaces in the UI on every recap attempt, even though the README documents that failed model/auth resolution should result in the recap being skipped silently.

## Fix

Wrap the `completeSimple` call in a try/catch. When the error is the specific "No API provider registered" case, return `undefined` (recap skipped, no UI noise). Any other error is rethrown unchanged.

Users who still want recaps in such sessions can point `--recap-model` at a provider pi-ai knows.

Typecheck (`tsc --noEmit`) passes.