### PR TITLE
release: Ralph 0.2.3 and session recap 0.2.2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,11 @@
 .build/
 .research/
 
+# Dependency/install artifacts
+node_modules/
+**/node_modules/
+package-lock.json
+
 # Unrelated extensions for npm root package
 control/
 review/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.58] - 2026-07-21
+
+### Changed
+- Bundle `@tmustier/pi-ralph-wiggum` 0.2.3, which binds loops to their owning Pi session and documents how iterations share a session and use normal compaction. Thanks to @juicetin for the fix and regression test ([#50](https://github.com/tmustier/pi-extensions/issues/50), [#52](https://github.com/tmustier/pi-extensions/pull/52)), and to @rhossack and @RichardScottOZ for prompting the documentation clarification ([#46](https://github.com/tmustier/pi-extensions/issues/46)).
+- Bundle `@tmustier/pi-session-recap` 0.2.2, which silently skips unsupported runtime-only custom API handlers instead of logging a recap failure. Thanks to @timvdhoorn for reporting and fixing the custom-provider failure ([#81](https://github.com/tmustier/pi-extensions/pull/81)).
+- Exclude nested development `node_modules` trees from the root npm package and document pre-publish tarball inspection.
 
 ### Removed
 - Remove the retired Tessl `skill-review-and-optimize` workflows. They had no configured Tessl token, reported authentication failures as successful checks, and could no longer provide useful skill review or optimization feedback.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,18 @@ Use `extension-name/vX.Y.Z` (example: `usage-extension/v0.1.2`).
 1. Update the extension's `CHANGELOG.md`.
 2. Optionally refresh compatibility notes in the extension README.
 3. Bump the extension version in its `package.json` and bump the repo version in the root `package.json` (ensure it is not marked `private` when publishing).
-4. Publish to npm (both packages):
+4. Run the extension tests and inspect the exact npm package contents before publishing:
+
+```bash
+npm test --prefix <extension-dir>
+mkdir -p /tmp/pi-release-pack
+npm pack --json --pack-destination /tmp/pi-release-pack ./<extension-dir>
+npm pack --json --pack-destination /tmp/pi-release-pack .
+```
+
+Check the JSON file lists and package sizes. The root tarball must not contain any nested `node_modules` directories from package-local development installs.
+
+5. Publish to npm (both packages):
 
 ```bash
 # Extension-specific package
@@ -23,12 +34,12 @@ cd <repo-root>
 npm publish --access public
 ```
 
-5. Tag and push the release:
+6. Tag and push the release:
 
 ```bash
 git tag -a usage-extension/v0.1.2 -m "usage-extension v0.1.2"
 git push origin usage-extension/v0.1.2
 ```
 
-4. Create a GitHub release from the tag and paste the notes from the changelog.
+7. Create a GitHub release from the tag and paste the notes from the changelog.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/pi-ralph-wiggum/CHANGELOG.md
+++ b/pi-ralph-wiggum/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.3] - 2026-07-21
 
 ### Fixed
 - Bind active Ralph loops to their owning Pi session. Reloads and compaction restore only that session's loop; unrelated sessions sharing the same working directory no longer receive Ralph prompt injection or mutate the loop. `/ralph resume <name>` explicitly transfers ownership.

--- a/pi-ralph-wiggum/package.json
+++ b/pi-ralph-wiggum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-ralph-wiggum",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Long-running agent loops for iterative development in Pi.",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.2] - 2026-07-21
 
 ### Fixed
 - Skip recap generation silently when the active model uses a custom API handler that is registered only in Pi's runtime and cannot be resolved by pi-ai's standalone compatibility layer. Users can still select a supported recap model with `--recap-model`.
+- Publish the metadata-only branch deduplication fix listed under 0.2.1. Version 0.2.2 is the first npm release since 0.2.0.
 
 Thanks to @timvdhoorn for reporting and fixing the custom-provider failure ([#81](https://github.com/tmustier/pi-extensions/pull/81)).
 

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Releases
- `@tmustier/pi-ralph-wiggum` 0.2.3
- `@tmustier/pi-session-recap` 0.2.2
- bundled `pi-extensions` 0.1.58

The release notes retain contributor credit for @juicetin, @timvdhoorn, @rhossack, @RichardScottOZ and @popey. Session Recap 0.2.2 also notes that it is the first npm publication since 0.2.0 and therefore includes the previously committed 0.2.1 deduplication fix.

## Packaging hardening
Pre-publish inspection found that a package-local dev install could make the root tarball absorb 19,639 nested `node_modules` files. This adds an explicit npm ignore boundary and a pack-inspection step to the release runbook. The clean root artifact contains 0 nested dependency files and is 9.2 MB unpacked.

## Validation
- Ralph session-boundary test
- Session Recap unknown-provider test
- 53 repository tests
- TypeScript checks for both extensions
- `git diff --check`
- `npm publish --dry-run --access public` for all 3 packages
- tarball inspection: Ralph 50.6 KB unpacked; Session Recap 394 KB; root 9.2 MB with no nested `node_modules`
- target versions confirmed absent from npm and release tags