### PR TITLE
Fix Pi 0.81 auxiliary usage accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.59] - 2026-07-21
+
+### Fixed
+- `usage-extension` 0.9.2: include Pi 0.81.0 tool, compaction, and branch-summary usage in cost/token totals under `Tools / summaries`, without inflating assistant-message counts or conversation cache insights. Cache format v4 performs a one-off rebuild.
+
 ## [0.1.58] - 2026-07-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -29,6 +29,10 @@ function sessionLine(id, ts, cwd = "/tmp") {
 	return JSON.stringify({ type: "session", version: 3, id, timestamp: new Date(ts).toISOString(), cwd });
 }
 
+function usage({ cost = 1, input = 100, output = 50, cacheRead = 0, cacheWrite = 0, reasoning = 0 } = {}) {
+	return { input, output, cacheRead, cacheWrite, reasoning, cost: { total: cost } };
+}
+
 function assistantLine({ ts, provider = "anthropic", model = "claude-fable-5", cost = 1, input = 100, output = 50, cacheRead = 0, cacheWrite = 0, reasoning = 0 }) {
 	return JSON.stringify({
 		type: "message",
@@ -40,9 +44,52 @@ function assistantLine({ ts, provider = "anthropic", model = "claude-fable-5", c
 			content: [{ type: "text", text: "hi" }],
 			provider,
 			model,
-			usage: { input, output, cacheRead, cacheWrite, reasoning, cost: { total: cost } },
+			usage: usage({ cost, input, output, cacheRead, cacheWrite, reasoning }),
 			timestamp: ts,
 		},
+	});
+}
+
+function toolResultLine({ id = "tool1", ts, ...usageValues }) {
+	return JSON.stringify({
+		type: "message",
+		id,
+		parentId: null,
+		timestamp: new Date(ts).toISOString(),
+		message: {
+			role: "toolResult",
+			toolCallId: `call-${id}`,
+			toolName: "nested_llm",
+			content: [{ type: "text", text: "done" }],
+			usage: usage(usageValues),
+			isError: false,
+			timestamp: ts,
+		},
+	});
+}
+
+function compactionLine({ id = "compact1", ts, ...usageValues }) {
+	return JSON.stringify({
+		type: "compaction",
+		id,
+		parentId: null,
+		timestamp: new Date(ts).toISOString(),
+		summary: "summary",
+		firstKeptEntryId: "kept",
+		tokensBefore: 1000,
+		usage: usage(usageValues),
+	});
+}
+
+function branchSummaryLine({ id = "branch1", ts, ...usageValues }) {
+	return JSON.stringify({
+		type: "branch_summary",
+		id,
+		parentId: null,
+		timestamp: new Date(ts).toISOString(),
+		fromId: "old-leaf",
+		summary: "branch summary",
+		usage: usage(usageValues),
 	});
 }
 
@@ -81,6 +128,8 @@ test("parseSessionBuffer extracts session id and assistant messages from compact
 		provider: "anthropic",
 		model: "claude-fable-5",
 		thinkingLevel: "",
+		source: "assistant",
+		sourceId: "",
 		cost: 2.5,
 		input: 10,
 		output: 20,
@@ -91,6 +140,32 @@ test("parseSessionBuffer extracts session id and assistant messages from compact
 		afterCompaction: false,
 	});
 	assert.equal(parsed.cwd, "/tmp");
+});
+
+test("parseSessionBuffer extracts Pi 0.81 tool and summary usage without consuming compaction state", async () => {
+	const content = [
+		sessionLine("s1", TS_TODAY),
+		assistantLine({ ts: TS_TODAY, cost: 1 }),
+		toolResultLine({ id: "tool-usage", ts: TS_TODAY + 1000, cost: 2, input: 20, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 1 }),
+		compactionLine({ id: "compact-usage", ts: TS_TODAY + 2000, cost: 3, input: 30, output: 3 }),
+		// Python-style spacing exercises the branch-summary pre-filter variant.
+		`{"type": "branch_summary", "id": "branch-usage", "timestamp": "${new Date(TS_TODAY + 3000).toISOString()}", "fromId": "old", "summary": "branch", "usage": ${JSON.stringify(usage({ cost: 4, input: 40, output: 4 }))}}`,
+		assistantLine({ ts: TS_TODAY + 4000, cost: 5 }),
+	].join("\n");
+
+	const parsed = await parseSessionBuffer(Buffer.from(content, "utf8"));
+	assert.equal(parsed.messages.length, 5);
+	assert.deepEqual(parsed.messages.map((m) => m.source), ["assistant", "auxiliary", "auxiliary", "auxiliary", "assistant"]);
+	assert.deepEqual(parsed.messages.map((m) => m.cost), [1, 2, 3, 4, 5]);
+	assert.deepEqual(parsed.messages.slice(1, 4).map((m) => [m.provider, m.model, m.thinkingLevel]), [
+		["Tools", "summaries", "Tools/summaries"],
+		["Tools", "summaries", "Tools/summaries"],
+		["Tools", "summaries", "Tools/summaries"],
+	]);
+	assert.deepEqual(parsed.messages.slice(1, 4).map((m) => m.sourceId), ["tool-usage", "compact-usage", "branch-usage"]);
+	assert.equal(parsed.messages[1].reasoning, 1);
+	assert.equal(parsed.messages[1].timestamp, TS_TODAY + 1000);
+	assert.equal(parsed.messages[4].afterCompaction, true, "auxiliary entries must not clear the pending compaction marker");
 });
 
 test("parseSessionBuffer flags the first assistant message after a compaction entry", async () => {
@@ -169,6 +244,9 @@ test("parseSessionBuffer ignores pre-filter false positives and messages without
 		userLine(TS_TODAY, 'observed "role":"assistant" and "type":"session" in a log'),
 		// Assistant message without usage data — excluded.
 		'{"type":"message","id":"n","message":{"role":"assistant","provider":"p","model":"m","content":[]}}',
+		// Tool result without usage, and an explicitly empty Usage object — excluded.
+		'{"type":"message","id":"t0","message":{"role":"toolResult","toolName":"x","content":[]}}',
+		'{"type":"message","id":"t1","message":{"role":"toolResult","toolName":"x","content":[],"usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"cost":{"total":0}}}}',
 	].join("\n");
 
 	const parsed = await parseSessionBuffer(Buffer.from(content, "utf8"));
@@ -261,6 +339,63 @@ test("collectUsageData aggregates periods, providers, and dedupes branched histo
 	assert.equal(anthropic.models.get("claude-fable-5").messages, 2);
 	assert.equal(openai.messages, 1);
 	assert.equal(openai.cost, 4);
+});
+
+test("collectUsageData includes tool and summary usage without inflating assistant message counts", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	writeFileSync(
+		join(sessionsDir, "auxiliary.jsonl"),
+		[
+			sessionLine("s1", TS_TODAY, "/projects/auxiliary"),
+			assistantLine({ ts: TS_TODAY, cost: 1, input: 10, output: 1, reasoning: 1 }),
+			toolResultLine({ id: "tool-a", ts: TS_TODAY + 1000, cost: 2, input: 20, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 2 }),
+			compactionLine({ id: "compact-a", ts: TS_TODAY + 2000, cost: 3, input: 30, output: 3 }),
+			branchSummaryLine({ id: "branch-a", ts: TS_TODAY + 3000, cost: 4, input: 40, output: 4 }),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.ok(data);
+	assert.equal(data.today.totals.cost, 10);
+	assert.equal(data.today.totals.messages, 1, "Msgs remains an assistant-message count");
+	assert.equal(data.today.totals.sessions, 1);
+	assert.equal(data.today.totals.tokens.total, 11 + 26 + 33 + 44);
+	assert.equal(data.today.totals.tokens.cacheRead, 3);
+
+	const auxiliary = data.today.providers.get("Tools");
+	assert.ok(auxiliary);
+	assert.equal(auxiliary.cost, 9);
+	assert.equal(auxiliary.messages, 0);
+	assert.equal(auxiliary.sessions.size, 1);
+	assert.equal(auxiliary.models.get("summaries").cost, 9);
+	assert.equal(auxiliary.models.get("summaries").messages, 0);
+
+	const hourMs = 3_600_000;
+	const bucket = data.hourly.get(Math.floor(TS_TODAY / hourMs) * hourMs);
+	const auxiliaryCell = bucket.get("Tools\u0000summaries\u0000Tools/summaries");
+	assert.equal(auxiliaryCell.cost, 9);
+	assert.equal(auxiliaryCell.messages, 0);
+	assert.equal(auxiliaryCell.reasoning, 2);
+
+	const overhead = findInsight(data, "today", /usage reported by tools and conversation summaries/);
+	assert.ok(overhead);
+	assert.equal(overhead.kind, "structure");
+	assert.equal(overhead.stat, "90%");
+});
+
+test("collectUsageData dedupes copied auxiliary entries by id without collapsing parallel peers", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const copied = toolResultLine({ id: "copied-tool", ts: TS_TODAY, cost: 2, input: 20, output: 2 });
+	const parallel = toolResultLine({ id: "parallel-tool", ts: TS_TODAY, cost: 2, input: 20, output: 2 });
+	writeFileSync(join(sessionsDir, "a.jsonl"), [sessionLine("s1", TS_TODAY), copied].join("\n") + "\n");
+	writeFileSync(join(sessionsDir, "b.jsonl"), [sessionLine("s2", TS_TODAY), copied, parallel].join("\n") + "\n");
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 4, "one copied entry plus one distinct parallel entry");
+	assert.equal(data.today.totals.messages, 0);
+	assert.equal(data.today.totals.sessions, 2);
+	assert.equal(data.today.providers.get("Tools").models.get("summaries").cost, 4);
+	assert.equal(findInsight(data, "today", /usage reported by tools and conversation summaries/).stat, "100%");
 });
 
 test("collectUsageData buckets the rolling 30-day window from midnight 29 days back", async (t) => {
@@ -382,7 +517,7 @@ test("collectUsageData survives a corrupt cache file", async (t) => {
 
 	// Cache was rebuilt.
 	const cacheJson = JSON.parse(readFileSync(cachePath, "utf8"));
-	assert.equal(cacheJson.version, 3);
+	assert.equal(cacheJson.version, 4);
 });
 
 test("collectUsageData works with the cache disabled", async (t) => {
@@ -413,8 +548,8 @@ test("saveUsageCache/loadUsageCache round-trips file states", async (t) => {
 					sessionId: "s1",
 					cwd: "/home/u/projects/x",
 					messages: [
-						{ provider: "anthropic", model: "claude-fable-5", thinkingLevel: "xhigh", cost: 1.5, input: 10, output: 20, cacheRead: 30, cacheWrite: 40, reasoning: 7, timestamp: TS_TODAY, afterCompaction: true },
-						{ provider: "openai", model: "gpt-5.6-sol", thinkingLevel: "", cost: 0.25, input: 1, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 0, timestamp: TS_OLD, afterCompaction: false },
+						{ provider: "anthropic", model: "claude-fable-5", thinkingLevel: "xhigh", source: "assistant", sourceId: "", cost: 1.5, input: 10, output: 20, cacheRead: 30, cacheWrite: 40, reasoning: 7, timestamp: TS_TODAY, afterCompaction: true },
+						{ provider: "Tools", model: "summaries", thinkingLevel: "Tools/summaries", source: "auxiliary", sourceId: "summary-a", cost: 0.25, input: 1, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 0, timestamp: TS_OLD, afterCompaction: false },
 					],
 				},
 			},
@@ -464,17 +599,30 @@ test("loadUsageCache rejects wrong versions and malformed entries", async (t) =>
 	);
 	assert.equal((await loadUsageCache(cachePath)).size, 0);
 
+	// v3 caches predate tool/summary usage and must be rebuilt too.
 	writeFileSync(
 		cachePath,
 		JSON.stringify({
 			version: 3,
 			names: ["p", "m", "high"],
+			files: { "/v3.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 5, 1]] } },
+		})
+	);
+	assert.equal((await loadUsageCache(cachePath)).size, 0);
+
+	writeFileSync(
+		cachePath,
+		JSON.stringify({
+			version: 4,
+			names: ["p", "m", "high", "entry-a"],
 			files: {
-				"/ok.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 5, 1]] },
+				"/ok.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 5, 1, 1, 3]] },
 				"/bad-tuple.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1]] },
-				"/bad-name-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[7, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0]] },
-				"/bad-level-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 9, 0, 0]] },
-				"/no-cwd.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0]] },
+				"/bad-name-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[7, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 3]] },
+				"/bad-level-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 9, 0, 0, 0, 3]] },
+				"/bad-source.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 7, 3]] },
+				"/bad-source-id.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 9]] },
+				"/no-cwd.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 3]] },
 				"/bad-shape.jsonl": { size: "x", mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [] },
 			},
 		})
@@ -484,6 +632,8 @@ test("loadUsageCache rejects wrong versions and malformed entries", async (t) =>
 	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].thinkingLevel, "high");
 	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].reasoning, 5);
 	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].afterCompaction, true);
+	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].source, "auxiliary");
+	assert.equal(loaded.get("/ok.jsonl").parsed.messages[0].sourceId, "entry-a");
 	assert.equal(loaded.get("/ok.jsonl").parsed.cwd, "/w");
 });
 
@@ -502,6 +652,9 @@ test("insights classify resume vs model-switch vs prefix misses and exclude comp
 			sessionLine("s1", TS_TODAY),
 			// Establishes a large previous context.
 			assistantLine({ ts: TS_TODAY, cost: 1, input: 1000, cacheRead: 100000 }),
+			// Interleaved auxiliary usage must not replace the previous assistant or
+			// dilute the percentages for assistant-turn/cache insights.
+			toolResultLine({ id: "nested-between-turns", ts: TS_TODAY + 1000, cost: 100, input: 1, output: 1 }),
 			// >5min idle, cacheRead ~0 → resume-after-break (TTL) miss.
 			assistantLine({ ts: TS_TODAY + SIX_MIN, cost: 10, input: 100000, cacheRead: 0 }),
 			// Short gap, cacheRead ~0 → true prefix-change miss.
@@ -519,12 +672,15 @@ test("insights classify resume vs model-switch vs prefix misses and exclude comp
 	assert.ok(ttl, "resume alarm fires");
 	assert.equal(ttl.kind, "alarm");
 	assert.equal(ttl.stat, "$10.00");
+	assert.match(ttl.headline, /12% of assistant-message cost/);
 	const prefix = findInsight(data, "today", /re-sending conversations mid-session/);
 	assert.ok(prefix, "prefix alarm fires");
 	assert.equal(prefix.stat, "$5.00", "compaction- and switch-adjacent misses are excluded from prefix cost");
+	assert.match(prefix.headline, /6\.0% of assistant-message cost/);
 	const sw = findInsight(data, "today", /switching models mid-conversation/);
 	assert.ok(sw, "model-switch alarm fires");
 	assert.equal(sw.stat, "$60.00");
+	assert.match(sw.headline, /72% of assistant-message cost/);
 });
 
 test("pi test providers are excluded from all stats", async (t) => {
@@ -578,6 +734,9 @@ test("insights include context tax, project mix, and reasoning share", async (t)
 			sessionLine("sa", TS_TODAY, alpha),
 			assistantLine({ ts: TS_TODAY, cost: 6, input: 200000, output: 50 }),
 			assistantLine({ ts: TS_TODAY + 1000, cost: 6, input: 200000, output: 50 }),
+			// A large auxiliary call contributes to project/total cost but not the
+			// assistant-message denominator of the context insight.
+			toolResultLine({ id: "alpha-tool", ts: TS_TODAY + 1500, cost: 16, input: 10, output: 1 }),
 		].join("\n") + "\n"
 	);
 	writeFileSync(
@@ -593,12 +752,13 @@ test("insights include context tax, project mix, and reasoning share", async (t)
 	const ctx = findInsight(data, "today", /≥150k tokens loaded/);
 	assert.ok(ctx, "context tax shows");
 	assert.equal(ctx.kind, "structure");
-	assert.equal(ctx.stat, "75%"); // 12 of 16
+	assert.equal(ctx.stat, "75%"); // 12 of 16 assistant-message dollars
+	assert.match(ctx.headline, /assistant-message cost/);
 	assert.match(ctx.headline, /\$6\.00\/msg vs \$2\.00 under 100k/);
 	const proj = findInsight(data, "today", /~\/projects\/alpha/);
 	assert.ok(proj, "project mix shows");
-	assert.equal(proj.stat, "75%");
-	assert.match(proj.headline, /~\/projects\/beta 25%/, "worktree collapses to its repository");
+	assert.equal(proj.stat, "88%");
+	assert.match(proj.headline, /~\/projects\/beta 13%/, "auxiliary cost is included and the worktree collapses");
 	const reas = findInsight(data, "today", /hidden reasoning/);
 	assert.ok(reas, "reasoning share shows");
 	assert.equal(reas.stat, "33%"); // 100 of 300 output tokens

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.9.2] - 2026-07-21
+
+### Fixed
+- Include usage persisted by Pi 0.81.0 on tool results, compactions, and branch summaries. Auxiliary cost and token fields now participate in `/usage` accounting under the same synthetic `Tools / summaries` bucket as Pi's footer and `/session`, while `Msgs` remains an assistant-message count.
+- Keep auxiliary usage out of conversation context/cache-miss classification, attribute it separately in Insights, and deduplicate copied auxiliary entries by stable session entry id.
+
+### Internal
+- Cache format bumped to **v4**. The first `/usage` open after upgrading performs a one-off rebuild so previously ignored auxiliary entries are ingested.
+
 ## [0.9.1] - 2026-07-17
 
 ### Changed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -7,7 +7,9 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 ## Compatibility
 
 - **Pi version:** 0.42.4+
-- **Last updated:** 2026-07-17 (0.9.1)
+- **Last updated:** 2026-07-21 (0.9.2)
+
+Pi 0.81.0+ persists nested tool, compaction, and branch-summary usage. `/usage` includes that auxiliary usage in totals under `Tools / summaries`; older Pi versions remain supported but do not record these entries.
 
 ## Installation
 
@@ -83,6 +85,7 @@ The **Insights** view has two sections, facts first:
 
 | Insight | Detail |
 |---|---|
+| Tool and summary usage | share of cost reported by nested tool calls, compaction, and branch summarization (Pi 0.81.0+) |
 | Context tax | share of cost spent at ≥ 150k context, with the average per-message cost vs messages under 100k |
 | Project mix | top 3 project directories by cost, derived from each session's working directory (worktrees collapse into their repository; hidden when one project is ≥ 90% — you already know) |
 | Reasoning share | share of output tokens that were hidden reasoning (recorded by pi 0.80.3+ only; hidden below 5%) |
@@ -136,7 +139,7 @@ The **Graphs** view plots usage over time for the active period as a braille lin
 - **Buckets**: hourly for Today / This Week / Last Week, daily for Last 30 Days / All Time.
 - **Line clipping**: every series (provider, model, thinking level, `other`, Total) is drawn only between its first and last bucket with usage, so late-starting or retired series don't drag a flat zero/flat tail across the whole period.
 
-Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Reasoning token counts come from `usage.reasoning` where providers report them; pi only records this field since **pi 0.80.3 (30 June 2026)**, so earlier sessions show zero reasoning tokens even though thinking models were in use.
+Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Auxiliary usage has no reliable thinking-level attribution and appears as `Tools/summaries` in that grouping. Reasoning token counts come from `usage.reasoning` where providers report them; pi only records this field since **pi 0.80.3 (30 June 2026)**, so earlier sessions show zero reasoning tokens even though thinking models were in use.
 
 ### Time Periods
 
@@ -160,8 +163,8 @@ Time periods are calculated in the local timezone where Pi runs. If you want to 
 |--------|-------------|
 | **Provider / Model** | Provider name, expandable to show models |
 | **Sessions** | Number of unique sessions |
-| **Msgs** | Number of assistant messages |
-| **Cost** | Total cost in USD (from API response) |
+| **Msgs** | Number of assistant messages; auxiliary `Tools / summaries` usage does not inflate this count |
+| **Cost** | Total cost in USD (from API response), including usage reported by tools and summaries |
 | **Tokens** | Fresh tokens for the turn: input + output + cache write |
 | **↑In** | Fresh input tokens: input + cache write *(dimmed)* |
 | **↓Out** | Output tokens *(dimmed)* |
@@ -195,13 +198,13 @@ On narrow terminals, `/usage` automatically switches to a compact table instead 
 - **On-disk cache.** Per-file extraction results are cached in `<agentDir>/usage-extension-cache.json` (respects `PI_CODING_AGENT_DIR`), keyed by file size + mtime. Warm opens only re-parse session files that changed since the last run — on a 5.2 GB / 3,310-file corpus that takes the open from ~17 s to ~0.3 s.
 - **First open** after install (or after deleting the cache) does a one-off full build, showing the usual cancellable loader. Cancelling saves partial progress, so the next open resumes where it left off.
 - The cache is safe to delete at any time; it is rebuilt automatically. Corrupt or version-mismatched caches are ignored and rebuilt rather than trusted.
-- **0.7.0 bumps the cache format to v3** (adds session working directory and compaction markers; 0.6.0's v2 added thinking level and reasoning tokens). The first open after upgrading does a one-off full rebuild (with a progress message and live file counter), then warm opens are fast again.
+- **0.9.2 bumps the cache format to v4** to include Pi 0.81.0 tool and summary usage (v3 added session working directory and compaction markers; v2 added thinking level and reasoning tokens). The first open after upgrading does a one-off full rebuild (with a progress message and live file counter), then warm opens are fast again.
 
 ## Provider Notes
 
 ### Cost Tracking
 
-Cost data comes directly from the API response (`usage.cost.total`). Accuracy depends on the provider reporting costs.
+Cost data comes directly from persisted `usage.cost.total` values. For assistant messages it is grouped by provider/model. Pi 0.81.0+ also persists usage reported by nested tools, compaction, and branch summarization; because those entries do not carry reliable provider/model attribution, `/usage` groups them under `Tools / summaries`, matching Pi's `/session` breakdown. Accuracy depends on the provider or tool reporting costs.
 
 ### Cache Tokens
 
@@ -219,9 +222,9 @@ The "Cache" column combines both read and write tokens.
 
 ## Data Source
 
-Statistics are parsed recursively from session files in `~/.pi/agent/sessions/`, including nested subagent runs such as `run-0/` directories. Each session is a JSONL file containing message entries with usage data.
+Statistics are parsed recursively from session files in `~/.pi/agent/sessions/`, including nested subagent runs such as `run-0/` directories. Each session is a JSONL file containing assistant messages and, on Pi 0.81.0+, optional usage on tool-result, compaction, and branch-summary entries.
 
-Assistant messages duplicated across branched session files are deduplicated by timestamp + total tokens, matching the extension's previous behavior while still including recursive subagent sessions.
+Assistant messages duplicated across branched session files are deduplicated by timestamp + total tokens. Auxiliary usage is deduplicated by its stable session entry id, which avoids collapsing parallel tools that happen to report identical usage. Tool and summary usage contributes cost and tokens to totals, graphs, project/session mix, and burn trend, but does not count as an assistant message or distort conversation context/cache insights.
 
 Respects the `PI_CODING_AGENT_DIR` environment variable if set.
 

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -66,8 +66,12 @@ interface CostCount {
 }
 
 interface PeriodRawData {
+	/** All recorded cost, including usage reported by tools and summaries. */
 	totalCost: number;
-	totalMessages: number;
+	/** Cost attached to assistant messages, used as the turn-insight denominator. */
+	assistantCost: number;
+	/** Usage reported by tool results, compactions, and branch summaries. */
+	auxiliaryCost: number;
 	/** Messages at ≥ CTX_TAX_THRESHOLD context. */
 	ctxHigh: CostCount;
 	/** Messages below CTX_LOW_THRESHOLD context (comparison group). */
@@ -164,11 +168,22 @@ export type TabName = "today" | "thisWeek" | "lastWeek" | "last30Days" | "allTim
 
 export const TAB_ORDER: TabName[] = ["today", "thisWeek", "lastWeek", "last30Days", "allTime"];
 
+export type UsageSource = "assistant" | "auxiliary";
+
+/** Pi's own label for usage that cannot be attributed to a provider/model. */
+export const AUXILIARY_PROVIDER = "Tools";
+export const AUXILIARY_MODEL = "summaries";
+export const AUXILIARY_THINKING_LEVEL = "Tools/summaries";
+
 export interface SessionMessage {
 	provider: string;
 	model: string;
 	/** Thinking level active when the message was produced; "" when unknown. */
 	thinkingLevel: string;
+	/** Assistant response, or usage reported by a tool/summary entry. */
+	source: UsageSource;
+	/** Session entry id used to dedupe copied auxiliary entries; empty for assistant messages. */
+	sourceId: string;
 	cost: number;
 	input: number;
 	output: number;
@@ -190,7 +205,7 @@ export interface ParsedSessionFile {
 	sessionId: string;
 	/** Working directory from the session header; "" when absent. */
 	cwd: string;
-	/** Extracted assistant messages, pre-dedupe. Dedupe happens at aggregation. */
+	/** Extracted assistant and auxiliary usage records, pre-dedupe. */
 	messages: SessionMessage[];
 }
 
@@ -252,30 +267,50 @@ const NEWLINE = 0x0a;
 // only cost a wasted JSON.parse — the parsed entry is still shape-checked.
 const PATTERN_ASSISTANT_COMPACT = Buffer.from('"role":"assistant"');
 const PATTERN_ASSISTANT_SPACED = Buffer.from('"role": "assistant"');
+const PATTERN_TOOL_RESULT_COMPACT = Buffer.from('"role":"toolResult"');
+const PATTERN_TOOL_RESULT_SPACED = Buffer.from('"role": "toolResult"');
+const PATTERN_USAGE_COMPACT = Buffer.from('"usage":{');
+const PATTERN_USAGE_SPACED = Buffer.from('"usage": {');
 const PATTERN_SESSION_COMPACT = Buffer.from('"type":"session"');
 const PATTERN_SESSION_SPACED = Buffer.from('"type": "session"');
 const PATTERN_THINKING_COMPACT = Buffer.from('"type":"thinking_level_change"');
 const PATTERN_THINKING_SPACED = Buffer.from('"type": "thinking_level_change"');
 const PATTERN_COMPACTION_COMPACT = Buffer.from('"type":"compaction"');
 const PATTERN_COMPACTION_SPACED = Buffer.from('"type": "compaction"');
+const PATTERN_BRANCH_SUMMARY_COMPACT = Buffer.from('"type":"branch_summary"');
+const PATTERN_BRANCH_SUMMARY_SPACED = Buffer.from('"type": "branch_summary"');
 
 const PARSE_YIELD_EVERY_LINES = 2000;
 
 function lineMightBeRelevant(line: Buffer): boolean {
+	// Entry type/role fields are at the front of Pi's JSONL objects. Restrict
+	// those checks to a small prefix so multi-megabyte tool output is not scanned
+	// repeatedly for every possible entry shape.
+	const head = line.length > 1024 ? line.subarray(0, 1024) : line;
+	if (head.includes(PATTERN_ASSISTANT_COMPACT) || head.includes(PATTERN_ASSISTANT_SPACED)) return true;
+
+	if (head.includes(PATTERN_TOOL_RESULT_COMPACT) || head.includes(PATTERN_TOOL_RESULT_SPACED)) {
+		// Pi serializes optional tool usage after content/details and immediately
+		// before the small isError/timestamp suffix. Checking the tail preserves
+		// the fast path for ordinary tool results, which dominate session bytes.
+		const tail = line.length > 4096 ? line.subarray(line.length - 4096) : line;
+		return tail.includes(PATTERN_USAGE_COMPACT) || tail.includes(PATTERN_USAGE_SPACED);
+	}
+
 	return (
-		line.includes(PATTERN_ASSISTANT_COMPACT) ||
-		line.includes(PATTERN_SESSION_COMPACT) ||
-		line.includes(PATTERN_THINKING_COMPACT) ||
-		line.includes(PATTERN_COMPACTION_COMPACT) ||
-		line.includes(PATTERN_ASSISTANT_SPACED) ||
-		line.includes(PATTERN_SESSION_SPACED) ||
-		line.includes(PATTERN_THINKING_SPACED) ||
-		line.includes(PATTERN_COMPACTION_SPACED)
+		head.includes(PATTERN_SESSION_COMPACT) ||
+		head.includes(PATTERN_THINKING_COMPACT) ||
+		head.includes(PATTERN_COMPACTION_COMPACT) ||
+		head.includes(PATTERN_BRANCH_SUMMARY_COMPACT) ||
+		head.includes(PATTERN_SESSION_SPACED) ||
+		head.includes(PATTERN_THINKING_SPACED) ||
+		head.includes(PATTERN_COMPACTION_SPACED) ||
+		head.includes(PATTERN_BRANCH_SUMMARY_SPACED)
 	);
 }
 
 /**
- * Extract the session id and assistant messages from a session JSONL buffer.
+ * Extract the session id plus assistant/tool/summary usage from a JSONL buffer.
  * Returns partial results when aborted — callers must check `signal.aborted`
  * before caching or using the result.
  */
@@ -289,6 +324,44 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 	// to the level active when it was produced.
 	let thinkingLevel = "";
 	let compactionPending = false;
+
+	const appendAuxiliaryUsage = (usage: unknown, timestamp: unknown, sourceId: unknown): void => {
+		if (!usage || typeof usage !== "object") return;
+		const persisted = usage as Record<string, unknown>;
+		const finiteNumber = (value: unknown): number =>
+			typeof value === "number" && Number.isFinite(value) ? value : 0;
+		const costObject = persisted.cost;
+		const cost =
+			costObject && typeof costObject === "object"
+				? finiteNumber((costObject as Record<string, unknown>).total)
+				: 0;
+		const input = finiteNumber(persisted.input);
+		const output = finiteNumber(persisted.output);
+		const cacheRead = finiteNumber(persisted.cacheRead);
+		const cacheWrite = finiteNumber(persisted.cacheWrite);
+		const reasoning = finiteNumber(persisted.reasoning);
+		// Match Pi's own breakdown: omit auxiliary buckets with neither billed
+		// cost nor token usage, even if a tool persisted an empty Usage object.
+		if (cost === 0 && input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) return;
+
+		const parsedTimestamp = typeof timestamp === "number" ? timestamp : new Date(String(timestamp ?? "")).getTime();
+		messages.push({
+			provider: AUXILIARY_PROVIDER,
+			model: AUXILIARY_MODEL,
+			thinkingLevel: AUXILIARY_THINKING_LEVEL,
+			source: "auxiliary",
+			sourceId: typeof sourceId === "string" ? sourceId : "",
+			cost,
+			input,
+			output,
+			cacheRead,
+			cacheWrite,
+			reasoning,
+			timestamp: Number.isFinite(parsedTimestamp) ? parsedTimestamp : 0,
+			afterCompaction: false,
+		});
+	};
+
 	let start = 0;
 	let lineNumber = 0;
 
@@ -312,7 +385,10 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 				} else if (entry.type === "thinking_level_change") {
 					if (typeof entry.thinkingLevel === "string") thinkingLevel = entry.thinkingLevel;
 				} else if (entry.type === "compaction") {
+					appendAuxiliaryUsage(entry.usage, entry.timestamp, entry.id);
 					compactionPending = true;
+				} else if (entry.type === "branch_summary") {
+					appendAuxiliaryUsage(entry.usage, entry.timestamp, entry.id);
 				} else if (entry.type === "message" && entry.message?.role === "assistant") {
 					const msg = entry.message;
 					if (msg.usage && msg.provider && msg.model) {
@@ -321,6 +397,8 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 							provider: msg.provider,
 							model: msg.model,
 							thinkingLevel,
+							source: "assistant",
+							sourceId: "",
 							cost: msg.usage.cost?.total || 0,
 							input: msg.usage.input || 0,
 							output: msg.usage.output || 0,
@@ -332,6 +410,9 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 						});
 						compactionPending = false;
 					}
+				} else if (entry.type === "message" && entry.message?.role === "toolResult") {
+					const msg = entry.message;
+					appendAuxiliaryUsage(msg.usage, msg.timestamp ?? entry.timestamp, entry.id);
 				}
 			} catch {
 				// Skip malformed lines
@@ -348,7 +429,7 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 // On-disk cache
 // =============================================================================
 
-const CACHE_VERSION = 3;
+const CACHE_VERSION = 4;
 
 type CachedMessageTuple = [
 	providerIdx: number,
@@ -362,6 +443,8 @@ type CachedMessageTuple = [
 	thinkingLevelIdx: number,
 	reasoning: number,
 	afterCompaction: 0 | 1,
+	auxiliary: 0 | 1,
+	sourceIdIdx: number,
 ];
 
 interface CacheFileEntry {
@@ -405,14 +488,21 @@ export async function loadUsageCache(cachePath: string): Promise<Map<string, Cac
 		const messages: SessionMessage[] = [];
 		let valid = true;
 		for (const tuple of entry.messages) {
-			if (!Array.isArray(tuple) || tuple.length !== 11) {
+			if (!Array.isArray(tuple) || tuple.length !== 13) {
 				valid = false;
 				break;
 			}
 			const provider = names[tuple[0]];
 			const model = names[tuple[1]];
 			const thinkingLevel = names[tuple[8]];
-			if (typeof provider !== "string" || typeof model !== "string" || typeof thinkingLevel !== "string") {
+			const sourceId = names[tuple[12]];
+			if (
+				typeof provider !== "string" ||
+				typeof model !== "string" ||
+				typeof thinkingLevel !== "string" ||
+				typeof sourceId !== "string" ||
+				(tuple[11] !== 0 && tuple[11] !== 1)
+			) {
 				valid = false;
 				break;
 			}
@@ -420,6 +510,8 @@ export async function loadUsageCache(cachePath: string): Promise<Map<string, Cac
 				provider,
 				model,
 				thinkingLevel,
+				source: tuple[11] === 1 ? "auxiliary" : "assistant",
+				sourceId,
 				cost: Number(tuple[2]) || 0,
 				input: Number(tuple[3]) || 0,
 				output: Number(tuple[4]) || 0,
@@ -472,6 +564,8 @@ export async function saveUsageCache(cachePath: string, states: Map<string, Cach
 				intern(m.thinkingLevel),
 				m.reasoning,
 				m.afterCompaction ? 1 : 0,
+				m.source === "auxiliary" ? 1 : 0,
+				intern(m.source === "auxiliary" ? m.sourceId : ""),
 			]),
 		};
 	}
@@ -511,7 +605,8 @@ function emptyTimeFilteredStats(): TimeFilteredStats {
 function emptyPeriodRawData(): PeriodRawData {
 	return {
 		totalCost: 0,
-		totalMessages: 0,
+		assistantCost: 0,
+		auxiliaryCost: 0,
 		ctxHigh: { cost: 0, messages: 0 },
 		ctxLow: { cost: 0, messages: 0 },
 		projectCosts: new Map(),
@@ -581,7 +676,7 @@ function addToHourlyBuckets(hourly: Map<number, Map<HourlyKey, HourlyCell>>, msg
 		cell = { messages: 0, cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 };
 		bucket.set(key, cell);
 	}
-	cell.messages++;
+	if (msg.source === "assistant") cell.messages++;
 	cell.cost += msg.cost;
 	cell.input += msg.input;
 	cell.output += msg.output;
@@ -594,9 +689,10 @@ function addToHourlyBuckets(hourly: Map<number, Map<HourlyKey, HourlyCell>>, msg
 function accumulateStats(
 	target: BaseStats,
 	cost: number,
-	tokens: { total: number; input: number; output: number; cacheRead: number; cacheWrite: number }
+	tokens: { total: number; input: number; output: number; cacheRead: number; cacheWrite: number },
+	countMessage: boolean
 ): void {
-	target.messages++;
+	if (countMessage) target.messages++;
 	target.cost += cost;
 	target.tokens.total += tokens.total;
 	target.tokens.input += tokens.input;
@@ -683,18 +779,30 @@ function addMessagesToUsageData(
 				providerStats.models.set(msg.model, modelStats);
 			}
 
+			const isAssistant = msg.source === "assistant";
 			modelStats.sessions.add(sessionId);
-			accumulateStats(modelStats, msg.cost, tokens);
+			accumulateStats(modelStats, msg.cost, tokens, isAssistant);
 
 			providerStats.sessions.add(sessionId);
-			accumulateStats(providerStats, msg.cost, tokens);
+			accumulateStats(providerStats, msg.cost, tokens, isAssistant);
 
-			accumulateStats(stats.totals, msg.cost, tokens);
+			accumulateStats(stats.totals, msg.cost, tokens, isAssistant);
 			sessionContributed[period] = true;
 
 			const raw = rawByPeriod[period];
 			raw.totalCost += msg.cost;
-			raw.totalMessages++;
+			raw.projectCosts.set(project, (raw.projectCosts.get(project) ?? 0) + msg.cost);
+			raw.sessionCosts.set(sessionId, (raw.sessionCosts.get(sessionId) ?? 0) + msg.cost);
+
+			// Auxiliary calls belong in accounting totals, project/session mix, and
+			// burn trend. They are not assistant turns, so do not let their synthetic
+			// model identity or nested context distort turn/cache insights.
+			if (!isAssistant) {
+				raw.auxiliaryCost += msg.cost;
+				continue;
+			}
+			raw.assistantCost += msg.cost;
+
 			const ctx = msg.input + msg.cacheRead + msg.cacheWrite;
 			if (ctx >= CTX_TAX_THRESHOLD) {
 				raw.ctxHigh.cost += msg.cost;
@@ -703,8 +811,6 @@ function addMessagesToUsageData(
 				raw.ctxLow.cost += msg.cost;
 				raw.ctxLow.messages++;
 			}
-			raw.projectCosts.set(project, (raw.projectCosts.get(project) ?? 0) + msg.cost);
-			raw.sessionCosts.set(sessionId, (raw.sessionCosts.get(sessionId) ?? 0) + msg.cost);
 			if (mm.isSessionStart) raw.upfrontCost += msg.cost;
 			if (
 				!msg.afterCompaction &&
@@ -942,12 +1048,22 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 		const rawMsgs = state.parsed.messages;
 		const deduped: SessionMessage[] = [];
 		const meta: MessageMeta[] = [];
-		for (let i = 0; i < rawMsgs.length; i++) {
-			const m = rawMsgs[i]!;
-			const hash = `${m.timestamp}:${m.input + m.output + m.cacheRead + m.cacheWrite}`;
+		let previousAssistant: SessionMessage | null = null;
+		for (const m of rawMsgs) {
+			// Auxiliary usage is interleaved with conversation entries, but it must
+			// not become the "previous message" for cache-miss classification.
+			const prev = m.source === "assistant" ? previousAssistant : null;
+			if (m.source === "assistant") previousAssistant = m;
+
+			// Pi entry ids survive copied branch history and distinguish parallel
+			// tool results that happen to report identical usage in the same ms.
+			const tokenFingerprint = m.input + m.output + m.cacheRead + m.cacheWrite;
+			const hash =
+				m.source === "auxiliary" && m.sourceId
+					? `auxiliary:${m.sourceId}:${m.timestamp}:${tokenFingerprint}`
+					: `${m.source}:${m.timestamp}:${tokenFingerprint}`;
 			if (seenHashes.has(hash)) continue;
 			seenHashes.add(hash);
-			const prev = i > 0 ? rawMsgs[i - 1]! : null;
 			deduped.push(m);
 			meta.push({
 				gapMs: prev && prev.timestamp > 0 && m.timestamp > 0 ? m.timestamp - prev.timestamp : -1,
@@ -957,9 +1073,10 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 			});
 		}
 		if (deduped.length === 0) continue;
-		if (!seenSessions.has(state.parsed.sessionId)) {
+		const firstAssistantIndex = deduped.findIndex((m) => m.source === "assistant");
+		if (firstAssistantIndex !== -1 && !seenSessions.has(state.parsed.sessionId)) {
 			seenSessions.add(state.parsed.sessionId);
-			meta[0]!.isSessionStart = true;
+			meta[firstAssistantIndex]!.isSessionStart = true;
 		}
 
 		addMessagesToUsageData(
@@ -1045,42 +1162,44 @@ function fmtPercent(p: number): string {
  * distinct empty-state for that case.
  */
 function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodInsights {
-	if (raw.totalMessages === 0 || raw.totalCost <= 0) {
+	if (raw.totalCost <= 0) {
 		return { insights: [] };
 	}
 	const total = raw.totalCost;
+	const assistantTotal = raw.assistantCost;
+	const assistantPctLabel = raw.auxiliaryCost > 0 ? "assistant-message cost" : "this period";
 	const insights: Insight[] = [];
 
 	// --- Alarms (listed first) ---
 
-	const ttlPct = (raw.ttlMissCost / total) * 100;
+	const ttlPct = assistantTotal > 0 ? (raw.ttlMissCost / assistantTotal) * 100 : 0;
 	if (ttlPct >= CACHE_MISS_ALARM_PERCENT && raw.ttlMissCost >= CACHE_MISS_ALARM_MIN_COST) {
 		insights.push({
 			kind: "alarm",
 			stat: fmtMoney(raw.ttlMissCost),
-			headline: `spent resuming conversations after a break (${fmtPercent(ttlPct)} of this period)`,
+			headline: `spent resuming conversations after a break (${fmtPercent(ttlPct)} of ${assistantPctLabel})`,
 			advice:
 				"Sent context is only reusable for a few minutes. After a longer pause, the next message pays to send the whole conversation again. Replying while a session is fresh avoids this.",
 		});
 	}
 
-	const switchPct = (raw.modelSwitchMissCost / total) * 100;
+	const switchPct = assistantTotal > 0 ? (raw.modelSwitchMissCost / assistantTotal) * 100 : 0;
 	if (switchPct >= CACHE_MISS_ALARM_PERCENT && raw.modelSwitchMissCost >= CACHE_MISS_ALARM_MIN_COST) {
 		insights.push({
 			kind: "alarm",
 			stat: fmtMoney(raw.modelSwitchMissCost),
-			headline: `spent switching models mid-conversation (${fmtPercent(switchPct)} of this period)`,
+			headline: `spent switching models mid-conversation (${fmtPercent(switchPct)} of ${assistantPctLabel})`,
 			advice:
 				"Changing model re-sends the whole conversation at full price — the previous model's saved context doesn't transfer. Switching between tasks instead of mid-conversation avoids this.",
 		});
 	}
 
-	const prefixPct = (raw.prefixMissCost / total) * 100;
+	const prefixPct = assistantTotal > 0 ? (raw.prefixMissCost / assistantTotal) * 100 : 0;
 	if (prefixPct >= CACHE_MISS_ALARM_PERCENT && raw.prefixMissCost >= CACHE_MISS_ALARM_MIN_COST) {
 		insights.push({
 			kind: "alarm",
 			stat: fmtMoney(raw.prefixMissCost),
-			headline: `spent re-sending conversations mid-session (${fmtPercent(prefixPct)} of this period)`,
+			headline: `spent re-sending conversations mid-session (${fmtPercent(prefixPct)} of ${assistantPctLabel})`,
 			advice:
 				"These messages paid full price for context that had already been sent — with no break, compaction, or model switch to explain it. Usually a tool or workflow is restarting or rewriting conversations. Worth a look if it stays high.",
 		});
@@ -1100,17 +1219,17 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 		}
 	}
 
-	const upfrontPct = (raw.upfrontCost / total) * 100;
+	const upfrontPct = assistantTotal > 0 ? (raw.upfrontCost / assistantTotal) * 100 : 0;
 	if (upfrontPct >= UPFRONT_ALARM_PERCENT) {
 		insights.push({
 			kind: "alarm",
 			stat: fmtMoney(raw.upfrontCost),
-			headline: `spent on the opening message of new sessions (${fmtPercent(upfrontPct)} of this period)`,
+			headline: `spent on the opening message of new sessions (${fmtPercent(upfrontPct)} of ${assistantPctLabel})`,
 			advice: "A session's first message sends everything from scratch. Fewer, longer sessions cut this overhead.",
 		});
 	}
 
-	if (total >= LEVERAGE_MIN_COST && raw.freshTokens >= LEVERAGE_MIN_FRESH_TOKENS) {
+	if (assistantTotal >= LEVERAGE_MIN_COST && raw.freshTokens >= LEVERAGE_MIN_FRESH_TOKENS) {
 		const leverage = raw.cacheReadTokens / raw.freshTokens;
 		if (leverage < LEVERAGE_FLOOR) {
 			insights.push({
@@ -1125,8 +1244,20 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 
 	// --- Structure (always-on) ---
 
-	if (raw.ctxHigh.messages > 0) {
-		const pct = (raw.ctxHigh.cost / total) * 100;
+	if (raw.auxiliaryCost > 0) {
+		const pct = (raw.auxiliaryCost / total) * 100;
+		if (pct >= 1) {
+			insights.push({
+				kind: "structure",
+				stat: fmtPercent(pct),
+				headline: "of your cost came from usage reported by tools and conversation summaries",
+				advice: "Pi records this separately because it cannot be attributed reliably to a specific provider and model.",
+			});
+		}
+	}
+
+	if (raw.ctxHigh.messages > 0 && assistantTotal > 0) {
+		const pct = (raw.ctxHigh.cost / assistantTotal) * 100;
 		if (pct >= 1) {
 			const avgHigh = raw.ctxHigh.cost / raw.ctxHigh.messages;
 			const avgLow = raw.ctxLow.messages > 0 ? raw.ctxLow.cost / raw.ctxLow.messages : 0;
@@ -1137,7 +1268,7 @@ function computeInsights(raw: PeriodRawData, trend: TrendInfo | null): PeriodIns
 			insights.push({
 				kind: "structure",
 				stat: fmtPercent(pct),
-				headline: `of your cost came from messages with ≥${formatThresholdTokens(CTX_TAX_THRESHOLD)} tokens loaded${cmp}`,
+				headline: `of your ${raw.auxiliaryCost > 0 ? "assistant-message cost" : "cost"} came from messages with ≥${formatThresholdTokens(CTX_TAX_THRESHOLD)} tokens loaded${cmp}`,
 				advice: "Long conversations cost more per message. /compact mid-task and /clear between tasks keep them lean.",
 			});
 		}

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -673,7 +673,11 @@ class UsageComponent {
 		const th = this.theme;
 		const stats = this.data[this.activeTab];
 		const { insights } = stats.insights;
-		const hasMessages = stats.totals.messages > 0;
+		const hasUsage =
+			stats.totals.messages > 0 ||
+			stats.totals.cost > 0 ||
+			stats.totals.tokens.total > 0 ||
+			stats.totals.tokens.cacheRead > 0;
 		const hasCost = stats.totals.cost > 0;
 		const lines: string[] = [];
 
@@ -687,7 +691,7 @@ class UsageComponent {
 		}
 		lines.push("");
 
-		if (!hasMessages) {
+		if (!hasUsage) {
 			lines.push(th.fg("dim", "  No usage recorded for this period."));
 			lines.push("");
 			return lines;

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Summary

- include Pi 0.81 tool-result, compaction, and branch-summary usage under `Tools / summaries`
- keep `Msgs` and conversation context/cache insights scoped to assistant responses
- deduplicate copied auxiliary entries by stable entry metadata and rebuild the v4 cache once
- preserve the fast scanner by checking tool usage in the JSONL tail
- bump the extension to 0.9.2 and the bundle to 0.1.59

## Validation

- `node --test tests/*.test.mjs` (56/56)
- focused TypeScript compile
- `git diff --check`
- package dry-runs for both npm packages
- live Pi 0.81.1 TUI fixture: graph, table, Insights, and auxiliary-only state
- cold scan of 10 GB / 6,316 session files: 7.7 seconds, with no auxiliary entries in the current local corpus
