### PR TITLE
Fix nested child usage reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.60] - 2026-07-22
+
+### Fixed
+- `usage-extension` 0.9.3: reconcile nested-agent tool reports with recursively scanned child sessions using exact token-and-cost vectors, count only unmatched aggregate residuals, and backfill legacy child reports only when no scanned child span represents them. Cache format v5 performs a one-off rebuild.
+
 ## [0.1.59] - 2026-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -68,6 +68,41 @@ function toolResultLine({ id = "tool1", ts, ...usageValues }) {
 	});
 }
 
+function childUsage(values = {}) {
+	const persisted = usage(values);
+	return { ...persisted, cost: persisted.cost.total, turns: 1 };
+}
+
+function nestedToolResultLine({ id = "nested1", ts, runId = "run-a", reported = null, children = [], content = "done" }) {
+	return JSON.stringify({
+		type: "message",
+		id,
+		parentId: null,
+		timestamp: new Date(ts).toISOString(),
+		message: {
+			role: "toolResult",
+			toolCallId: `call-${id}`,
+			toolName: "subagent",
+			content: [{ type: "text", text: content }],
+			details: {
+				mode: children.length > 1 ? "parallel" : "single",
+				runId,
+				results: children.map((child, index) => ({
+					agent: `agent-${index}`,
+					task: "test",
+					exitCode: 0,
+					...(child.messages ? { messages: child.messages } : {}),
+					usage: childUsage(child),
+					...(child.sessionFile ? { sessionFile: child.sessionFile } : {}),
+				})),
+			},
+			...(reported ? { usage: usage(reported) } : {}),
+			isError: false,
+			timestamp: ts,
+		},
+	});
+}
+
 function compactionLine({ id = "compact1", ts, ...usageValues }) {
 	return JSON.stringify({
 		type: "compaction",
@@ -154,18 +189,20 @@ test("parseSessionBuffer extracts Pi 0.81 tool and summary usage without consumi
 	].join("\n");
 
 	const parsed = await parseSessionBuffer(Buffer.from(content, "utf8"));
-	assert.equal(parsed.messages.length, 5);
-	assert.deepEqual(parsed.messages.map((m) => m.source), ["assistant", "auxiliary", "auxiliary", "auxiliary", "assistant"]);
-	assert.deepEqual(parsed.messages.map((m) => m.cost), [1, 2, 3, 4, 5]);
-	assert.deepEqual(parsed.messages.slice(1, 4).map((m) => [m.provider, m.model, m.thinkingLevel]), [
-		["Tools", "summaries", "Tools/summaries"],
+	assert.equal(parsed.messages.length, 4);
+	assert.deepEqual(parsed.messages.map((m) => m.source), ["assistant", "auxiliary", "auxiliary", "assistant"]);
+	assert.deepEqual(parsed.messages.map((m) => m.cost), [1, 3, 4, 5]);
+	assert.deepEqual(parsed.messages.slice(1, 3).map((m) => [m.provider, m.model, m.thinkingLevel]), [
 		["Tools", "summaries", "Tools/summaries"],
 		["Tools", "summaries", "Tools/summaries"],
 	]);
-	assert.deepEqual(parsed.messages.slice(1, 4).map((m) => m.sourceId), ["tool-usage", "compact-usage", "branch-usage"]);
-	assert.equal(parsed.messages[1].reasoning, 1);
-	assert.equal(parsed.messages[1].timestamp, TS_TODAY + 1000);
-	assert.equal(parsed.messages[4].afterCompaction, true, "auxiliary entries must not clear the pending compaction marker");
+	assert.deepEqual(parsed.messages.slice(1, 3).map((m) => m.sourceId), ["compact-usage", "branch-usage"]);
+	assert.equal(parsed.toolUsages.length, 1);
+	assert.equal(parsed.toolUsages[0].sourceId, "tool-usage");
+	assert.equal(parsed.toolUsages[0].reportedUsage.cost, 2);
+	assert.equal(parsed.toolUsages[0].reportedUsage.reasoning, 1);
+	assert.equal(parsed.toolUsages[0].timestamp, TS_TODAY + 1000);
+	assert.equal(parsed.messages[3].afterCompaction, true, "auxiliary entries must not clear the pending compaction marker");
 });
 
 test("parseSessionBuffer flags the first assistant message after a compaction entry", async () => {
@@ -383,6 +420,196 @@ test("collectUsageData includes tool and summary usage without inflating assista
 	assert.equal(overhead.stat, "90%");
 });
 
+test("collectUsageData suppresses canonical tool usage already present in a linked child session", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const parentPath = join(sessionsDir, "parent.jsonl");
+	const childPath = join(sessionsDir, "parent", "run-a", "run-0", "session.jsonl");
+	mkdirSync(join(childPath, ".."), { recursive: true });
+	writeFileSync(
+		childPath,
+		[sessionLine("child", TS_TODAY), assistantLine({ ts: TS_TODAY + 1000, cost: 3, input: 30, output: 3, cacheRead: 4 })].join("\n") + "\n"
+	);
+	writeFileSync(
+		parentPath,
+		[
+			sessionLine("parent", TS_TODAY),
+			nestedToolResultLine({
+				id: "reported-child",
+				ts: TS_TODAY + 2000,
+				reported: { cost: 3, input: 30, output: 3, cacheRead: 4 },
+				children: [{
+					cost: 3,
+					input: 30,
+					output: 3,
+					cacheRead: 4,
+					sessionFile: childPath,
+					// Old pi-subagents records retained messages before direct child usage.
+					// The large-line parser must skip this nested usage rather than select it.
+					messages: [{ role: "assistant", usage: usage({ cost: 99, input: 99, output: 99 }) }],
+				}],
+				content: "x".repeat(70 * 1024), // exercise the allocation-safe large-line parser
+			}),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 3);
+	assert.equal(data.today.totals.messages, 1);
+	assert.equal(data.today.totals.sessions, 1, "the empty parent must not become a second contributing session");
+	assert.equal(data.today.providers.has("Tools"), false);
+});
+
+test("collectUsageData counts only the unmatched residual of mixed child usage", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const parentPath = join(sessionsDir, "mixed.jsonl");
+	const childPath = join(sessionsDir, "mixed", "run-a", "run-0", "session.jsonl");
+	mkdirSync(join(childPath, ".."), { recursive: true });
+	writeFileSync(
+		childPath,
+		[sessionLine("child", TS_TODAY), assistantLine({ ts: TS_TODAY + 1000, cost: 2, input: 20, output: 2, reasoning: 2 })].join("\n") + "\n"
+	);
+	writeFileSync(
+		parentPath,
+		[
+			sessionLine("parent", TS_TODAY),
+			nestedToolResultLine({
+				id: "mixed-children",
+				ts: TS_TODAY + 2000,
+				reported: { cost: 5, input: 50, output: 5, reasoning: 5 },
+				children: [
+					{ cost: 2, input: 20, output: 2, reasoning: 2 }, // resolved through the standard derived path
+					{ cost: 3, input: 30, output: 3, reasoning: 3, sessionFile: join(sessionsDir, "missing.jsonl") },
+				],
+			}),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 5, "the $2 child plus the $3 residual, not the $5 report again");
+	assert.equal(data.today.totals.messages, 1);
+	assert.equal(data.today.providers.get("anthropic").cost, 2);
+	assert.equal(data.today.providers.get("Tools").cost, 3);
+	const toolsReasoning = [...data.hourly.values()].reduce(
+		(total, cells) => total + [...cells.entries()].reduce((sum, [key, cell]) => sum + (key.startsWith("Tools\0") ? cell.reasoning : 0), 0),
+		0
+	);
+	assert.equal(toolsReasoning, 3);
+	assert.equal(data.today.providers.get("Tools").models.get("summaries").cost, 3);
+});
+
+test("collectUsageData backfills legacy nested usage only when no scanned child span represents it", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const parentPath = join(sessionsDir, "legacy.jsonl");
+	const childPath = join(sessionsDir, "legacy", "run-a", "run-0", "session.jsonl");
+	mkdirSync(join(childPath, ".."), { recursive: true });
+	writeFileSync(
+		childPath,
+		[
+			sessionLine("child", TS_TODAY),
+			assistantLine({ ts: TS_TODAY + 1000, cost: 7, input: 70, output: 7 }),
+			assistantLine({ ts: TS_TODAY + 2000, cost: 2, input: 20, output: 2 }),
+			assistantLine({ ts: TS_TODAY + 3000, cost: 8, input: 80, output: 8 }),
+		].join("\n") + "\n"
+	);
+	writeFileSync(
+		parentPath,
+		[
+			sessionLine("parent", TS_TODAY),
+			nestedToolResultLine({
+				id: "legacy-children",
+				ts: TS_TODAY + 4000,
+				children: [
+					{ cost: 2, input: 20, output: 2 }, // exact middle span in the derived child session
+					{ cost: 3, input: 30, output: 3, sessionFile: join(sessionsDir, "gone.jsonl") },
+				],
+			}),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 20, "$17 in the child session plus only the missing $3 legacy result");
+	assert.equal(data.today.totals.messages, 3);
+	assert.equal(data.today.providers.get("Tools").cost, 3);
+});
+
+test("collectUsageData requires an exact cost vector before suppressing linked child usage", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const childPath = join(sessionsDir, "exact-child.jsonl");
+	writeFileSync(
+		childPath,
+		[sessionLine("child", TS_TODAY), assistantLine({ ts: TS_TODAY + 1000, cost: 2, input: 20, output: 2 })].join("\n") + "\n"
+	);
+	writeFileSync(
+		join(sessionsDir, "parent.jsonl"),
+		[
+			sessionLine("parent", TS_TODAY),
+			nestedToolResultLine({
+				id: "near-not-exact",
+				ts: TS_TODAY + 2000,
+				children: [{ cost: 2.000001, input: 20, output: 2, sessionFile: childPath }],
+			}),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 4.000001);
+	assert.equal(data.today.providers.get("Tools").cost, 2.000001);
+});
+
+test("collectUsageData dedupes copied legacy child reports by parent entry id", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const copied = nestedToolResultLine({
+		id: "copied-legacy",
+		ts: TS_TODAY,
+		children: [{ cost: 3, input: 30, output: 3, sessionFile: join(sessionsDir, "missing.jsonl") }],
+	});
+	writeFileSync(join(sessionsDir, "a.jsonl"), [sessionLine("s1", TS_TODAY), copied].join("\n") + "\n");
+	writeFileSync(join(sessionsDir, "b.jsonl"), [sessionLine("s2", TS_TODAY), copied].join("\n") + "\n");
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 3);
+	assert.equal(data.today.totals.messages, 0);
+	assert.equal(data.today.providers.get("Tools").cost, 3);
+});
+
+test("collectUsageData reconciles copied tool reports globally rather than trusting the first parent copy", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	const childPath = join(sessionsDir, "child.jsonl");
+	writeFileSync(
+		childPath,
+		[sessionLine("child", TS_TODAY), assistantLine({ ts: TS_TODAY + 1000, cost: 3, input: 30, output: 3 })].join("\n") + "\n"
+	);
+	writeFileSync(
+		join(sessionsDir, "a.jsonl"),
+		[
+			sessionLine("a", TS_TODAY),
+			nestedToolResultLine({
+				id: "copied-linked",
+				ts: TS_TODAY + 2000,
+				reported: { cost: 3, input: 30, output: 3 },
+				children: [{ cost: 3, input: 30, output: 3, sessionFile: join(sessionsDir, "missing.jsonl") }],
+			}),
+		].join("\n") + "\n"
+	);
+	writeFileSync(
+		join(sessionsDir, "b.jsonl"),
+		[
+			sessionLine("b", TS_TODAY),
+			nestedToolResultLine({
+				id: "copied-linked",
+				ts: TS_TODAY + 2000,
+				reported: { cost: 3, input: 30, output: 3 },
+				children: [{ cost: 3, input: 30, output: 3, sessionFile: childPath }],
+			}),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.today.totals.cost, 3);
+	assert.equal(data.today.totals.messages, 1);
+	assert.equal(data.today.providers.has("Tools"), false);
+});
+
 test("collectUsageData dedupes copied auxiliary entries by id without collapsing parallel peers", async (t) => {
 	const { sessionsDir, cachePath } = fixture(t);
 	const copied = toolResultLine({ id: "copied-tool", ts: TS_TODAY, cost: 2, input: 20, output: 2 });
@@ -517,7 +744,7 @@ test("collectUsageData survives a corrupt cache file", async (t) => {
 
 	// Cache was rebuilt.
 	const cacheJson = JSON.parse(readFileSync(cachePath, "utf8"));
-	assert.equal(cacheJson.version, 4);
+	assert.equal(cacheJson.version, 5);
 });
 
 test("collectUsageData works with the cache disabled", async (t) => {
@@ -551,10 +778,21 @@ test("saveUsageCache/loadUsageCache round-trips file states", async (t) => {
 						{ provider: "anthropic", model: "claude-fable-5", thinkingLevel: "xhigh", source: "assistant", sourceId: "", cost: 1.5, input: 10, output: 20, cacheRead: 30, cacheWrite: 40, reasoning: 7, timestamp: TS_TODAY, afterCompaction: true },
 						{ provider: "Tools", model: "summaries", thinkingLevel: "Tools/summaries", source: "auxiliary", sourceId: "summary-a", cost: 0.25, input: 1, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 0, timestamp: TS_OLD, afterCompaction: false },
 					],
+					toolUsages: [
+						{
+							sourceId: "tool-a",
+							timestamp: TS_TODAY,
+							reportedUsage: { cost: 2, input: 20, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 1 },
+							runId: "run-a",
+							children: [
+								{ resultIndex: 0, sessionFile: "/tmp/child.jsonl", usage: { cost: 2, input: 20, output: 2, cacheRead: 3, cacheWrite: 4, reasoning: 0 } },
+							],
+						},
+					],
 				},
 			},
 		],
-		["/tmp/empty.jsonl", { size: 1, mtimeMs: 2, parsed: { sessionId: "", cwd: "", messages: [] } }],
+		["/tmp/empty.jsonl", { size: 1, mtimeMs: 2, parsed: { sessionId: "", cwd: "", messages: [], toolUsages: [] } }],
 	]);
 
 	await saveUsageCache(cachePath, states);
@@ -567,6 +805,7 @@ test("saveUsageCache/loadUsageCache round-trips file states", async (t) => {
 	assert.equal(a.parsed.sessionId, "s1");
 	assert.equal(a.parsed.cwd, "/home/u/projects/x");
 	assert.deepEqual(a.parsed.messages, states.get("/tmp/a.jsonl").parsed.messages);
+	assert.deepEqual(a.parsed.toolUsages, states.get("/tmp/a.jsonl").parsed.toolUsages);
 	assert.equal(loaded.get("/tmp/empty.jsonl").parsed.sessionId, "");
 });
 
@@ -610,20 +849,26 @@ test("loadUsageCache rejects wrong versions and malformed entries", async (t) =>
 	);
 	assert.equal((await loadUsageCache(cachePath)).size, 0);
 
+	// v4 caches have canonical tool usage but not the child-linkage metadata
+	// needed to reconcile recursively scanned sessions.
+	writeFileSync(cachePath, JSON.stringify({ version: 4, names: [], files: {} }));
+	assert.equal((await loadUsageCache(cachePath)).size, 0);
+
 	writeFileSync(
 		cachePath,
 		JSON.stringify({
-			version: 4,
+			version: 5,
 			names: ["p", "m", "high", "entry-a"],
 			files: {
-				"/ok.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 5, 1, 1, 3]] },
-				"/bad-tuple.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1]] },
-				"/bad-name-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[7, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 3]] },
-				"/bad-level-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 9, 0, 0, 0, 3]] },
-				"/bad-source.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 7, 3]] },
-				"/bad-source-id.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 9]] },
-				"/no-cwd.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 3]] },
-				"/bad-shape.jsonl": { size: "x", mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [] },
+				"/ok.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 5, 1, 1, 3]], toolUsages: [] },
+				"/bad-tuple.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1]], toolUsages: [] },
+				"/bad-name-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[7, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 3]], toolUsages: [] },
+				"/bad-level-idx.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 9, 0, 0, 0, 3]], toolUsages: [] },
+				"/bad-source.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 7, 3]], toolUsages: [] },
+				"/bad-source-id.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 9]], toolUsages: [] },
+				"/bad-tool.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [], toolUsages: [[3, TS_TODAY, [1, 2], 3, []]] },
+				"/no-cwd.jsonl": { size: 1, mtimeMs: 2, sessionId: "s", messages: [[0, 1, 1, 1, 1, 0, 0, TS_TODAY, 2, 0, 0, 0, 3]], toolUsages: [] },
+				"/bad-shape.jsonl": { size: "x", mtimeMs: 2, sessionId: "s", cwd: "/w", messages: [], toolUsages: [] },
 			},
 		})
 	);

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.9.3] - 2026-07-22
+
+### Fixed
+- Reconcile nested-agent tool usage against recursively scanned child sessions using exact contiguous token-and-cost vectors. Canonical tool aggregates now exclude child usage already counted from session files, and mixed aggregates add only the unmatched residual under `Tools / summaries`.
+- Reconcile globally across copied parent history, so a stale copy with a missing child path cannot win deduplication and reintroduce usage represented by another copy's linked child session.
+- Backfill recognised legacy `subagent` and `subagent_wait` child usage only when no scanned child-session span represents it.
+
+### Performance
+- Extract accounting metadata from large tool results without decoding or JSON-parsing multi-megabyte output bodies.
+
+### Internal
+- Cache format bumped to **v5** to retain tool reports and child-session linkage. The first `/usage` open after upgrading performs a one-off rebuild.
+- Document the irrecoverable historical boundary: compaction and branch-summary entries written without usage metadata remain unmetered. The compatibility audit found 2,753 such compactions and 20 branch summaries.
+
 ## [0.9.2] - 2026-07-21
 
 ### Fixed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -7,9 +7,9 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 ## Compatibility
 
 - **Pi version:** 0.42.4+
-- **Last updated:** 2026-07-21 (0.9.2)
+- **Last updated:** 2026-07-22 (0.9.3)
 
-Pi 0.81.0+ persists nested tool, compaction, and branch-summary usage. `/usage` includes that auxiliary usage in totals under `Tools / summaries`; older Pi versions remain supported but do not record these entries.
+Pi 0.81.0+ can persist tool-result, compaction, and branch-summary usage. `/usage` includes that auxiliary usage in totals under `Tools / summaries`. Nested-agent reports are reconciled against recursively scanned child sessions, so a child call is counted once; when only part of an aggregate is already present, only the unmatched residual is added. Older Pi versions remain supported.
 
 ## Installation
 
@@ -198,13 +198,16 @@ On narrow terminals, `/usage` automatically switches to a compact table instead 
 - **On-disk cache.** Per-file extraction results are cached in `<agentDir>/usage-extension-cache.json` (respects `PI_CODING_AGENT_DIR`), keyed by file size + mtime. Warm opens only re-parse session files that changed since the last run — on a 5.2 GB / 3,310-file corpus that takes the open from ~17 s to ~0.3 s.
 - **First open** after install (or after deleting the cache) does a one-off full build, showing the usual cancellable loader. Cancelling saves partial progress, so the next open resumes where it left off.
 - The cache is safe to delete at any time; it is rebuilt automatically. Corrupt or version-mismatched caches are ignored and rebuilt rather than trusted.
-- **0.9.2 bumps the cache format to v4** to include Pi 0.81.0 tool and summary usage (v3 added session working directory and compaction markers; v2 added thinking level and reasoning tokens). The first open after upgrading does a one-off full rebuild (with a progress message and live file counter), then warm opens are fast again.
+- **0.9.3 bumps the cache format to v5** to retain child-session linkage for tool-usage reconciliation (v4 added Pi 0.81.0 tool and summary usage; v3 added session working directory and compaction markers; v2 added thinking level and reasoning tokens). The first open after upgrading does a one-off full rebuild (with a progress message and live file counter), then warm opens are fast again.
+- Large nested-agent tool results use an allocation-safe metadata parser: multi-megabyte output bodies are scanned as bytes rather than decoded and JSON-parsed in full.
 
 ## Provider Notes
 
 ### Cost Tracking
 
-Cost data comes directly from persisted `usage.cost.total` values. For assistant messages it is grouped by provider/model. Pi 0.81.0+ also persists usage reported by nested tools, compaction, and branch summarization; because those entries do not carry reliable provider/model attribution, `/usage` groups them under `Tools / summaries`, matching Pi's `/session` breakdown. Accuracy depends on the provider or tool reporting costs.
+Cost data comes directly from persisted usage values. For assistant messages it is grouped by provider/model. Pi 0.81.0+ can also persist usage reported by tools, compaction, and branch summarization; because those entries do not carry reliable provider/model attribution, `/usage` groups them under `Tools / summaries`, matching Pi's `/session` breakdown. Recognised legacy `subagent` and `subagent_wait` details are used as a fallback when their child session is no longer available. Accuracy depends on the provider or tool reporting costs.
+
+Only persisted usage can be counted. Pi did not add usage metadata retroactively, so historical compaction or branch-summary entries written without `usage` remain unmetered: their exact token and cost vectors cannot be reconstructed. The compatibility audit corpus contained 2,753 such compactions and 20 branch summaries.
 
 ### Cache Tokens
 
@@ -224,7 +227,7 @@ The "Cache" column combines both read and write tokens.
 
 Statistics are parsed recursively from session files in `~/.pi/agent/sessions/`, including nested subagent runs such as `run-0/` directories. Each session is a JSONL file containing assistant messages and, on Pi 0.81.0+, optional usage on tool-result, compaction, and branch-summary entries.
 
-Assistant messages duplicated across branched session files are deduplicated by timestamp + total tokens. Auxiliary usage is deduplicated by its stable session entry id, which avoids collapsing parallel tools that happen to report identical usage. Tool and summary usage contributes cost and tokens to totals, graphs, project/session mix, and burn trend, but does not count as an assistant message or distort conversation context/cache insights.
+Assistant messages duplicated across branched session files are deduplicated by timestamp + total tokens. Auxiliary usage is deduplicated by its stable session entry id, which avoids collapsing parallel tools that happen to report identical usage. Tool reports are reconciled globally across copied parent history: an exact contiguous child-session token-and-cost vector suppresses the matching portion of the parent aggregate, while missing children and unmatched residuals stay under `Tools / summaries`. Tool and summary usage contributes cost and tokens to totals, graphs, project/session mix, and burn trend, but does not count as an assistant message or distort conversation context/cache insights.
 
 Respects the `PI_CODING_AGENT_DIR` environment variable if set.
 

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -2,10 +2,10 @@
  * Data collection, caching, and insights for the /usage dashboard.
  *
  * Performance model (see CHANGELOG 0.4.0):
- * - Session JSONL files are scanned at the buffer level. Only lines that can
- *   possibly be a session header or an assistant message are UTF-8 decoded and
- *   JSON.parsed — the multi-megabyte tool-result lines that dominate session
- *   files are skipped with a cheap byte search.
+ * - Session JSONL files are scanned at the buffer level. Only lines relevant
+ *   to assistant or auxiliary accounting are decoded and JSON.parsed. Ordinary
+ *   multi-megabyte tool results are skipped; accounting-bearing large results
+ *   use an allocation-safe byte parser for their small metadata fields.
  * - Per-file extraction results are persisted to an on-disk cache keyed by
  *   (size, mtimeMs). Session files are append-only, so a warm load only
  *   re-parses files that changed since the last run.
@@ -13,7 +13,7 @@
 
 import { readdir, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
 // =============================================================================
 // Types
@@ -175,7 +175,16 @@ export const AUXILIARY_PROVIDER = "Tools";
 export const AUXILIARY_MODEL = "summaries";
 export const AUXILIARY_THINKING_LEVEL = "Tools/summaries";
 
-export interface SessionMessage {
+export interface UsageAmount {
+	cost: number;
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	reasoning: number;
+}
+
+export interface SessionMessage extends UsageAmount {
 	provider: string;
 	model: string;
 	/** Thinking level active when the message was produced; "" when unknown. */
@@ -184,13 +193,6 @@ export interface SessionMessage {
 	source: UsageSource;
 	/** Session entry id used to dedupe copied auxiliary entries; empty for assistant messages. */
 	sourceId: string;
-	cost: number;
-	input: number;
-	output: number;
-	cacheRead: number;
-	cacheWrite: number;
-	/** Reasoning output tokens reported by the provider (0 when absent). */
-	reasoning: number;
 	timestamp: number;
 	/**
 	 * True when a compaction entry occurred between the previous assistant
@@ -200,13 +202,34 @@ export interface SessionMessage {
 	afterCompaction: boolean;
 }
 
+export interface ChildToolUsage {
+	resultIndex: number;
+	/** Persisted child session path when the tool supplied one; empty otherwise. */
+	sessionFile: string;
+	usage: UsageAmount;
+}
+
+export interface ToolUsageRecord {
+	/** Parent tool-result entry id, stable across copied branch history. */
+	sourceId: string;
+	timestamp: number;
+	/** Canonical Pi 0.81+ tool usage; null for legacy nested-agent results. */
+	reportedUsage: UsageAmount | null;
+	/** Run id used to derive the standard nested-session path when needed. */
+	runId: string;
+	/** Recognised per-child usage from nested-agent tool details. */
+	children: ChildToolUsage[];
+}
+
 export interface ParsedSessionFile {
 	/** Empty string when the file has no session header — such files are ignored. */
 	sessionId: string;
 	/** Working directory from the session header; "" when absent. */
 	cwd: string;
-	/** Extracted assistant and auxiliary usage records, pre-dedupe. */
+	/** Extracted assistant and summary usage records, pre-dedupe. */
 	messages: SessionMessage[];
+	/** Tool usage is reconciled against recursively scanned child sessions later. */
+	toolUsages: ToolUsageRecord[];
 }
 
 // =============================================================================
@@ -279,8 +302,318 @@ const PATTERN_COMPACTION_COMPACT = Buffer.from('"type":"compaction"');
 const PATTERN_COMPACTION_SPACED = Buffer.from('"type": "compaction"');
 const PATTERN_BRANCH_SUMMARY_COMPACT = Buffer.from('"type":"branch_summary"');
 const PATTERN_BRANCH_SUMMARY_SPACED = Buffer.from('"type": "branch_summary"');
+// pi-subagents versions predating Pi 0.81 persisted child usage in details but
+// could not put it on the canonical tool-result usage field. Their tool names
+// are near the start of the line, so we can recover those records without
+// scanning every multi-megabyte tool result.
+const PATTERN_SUBAGENT_TOOL_COMPACT = Buffer.from('"toolName":"subagent"');
+const PATTERN_SUBAGENT_TOOL_SPACED = Buffer.from('"toolName": "subagent"');
+const PATTERN_SUBAGENT_WAIT_TOOL_COMPACT = Buffer.from('"toolName":"subagent_wait"');
+const PATTERN_SUBAGENT_WAIT_TOOL_SPACED = Buffer.from('"toolName": "subagent_wait"');
 
 const PARSE_YIELD_EVERY_LINES = 2000;
+
+function finiteNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function parseUsageAmount(value: unknown): UsageAmount | null {
+	if (!value || typeof value !== "object") return null;
+	const persisted = value as Record<string, unknown>;
+	const costValue = persisted.cost;
+	const cost =
+		typeof costValue === "number"
+			? finiteNumber(costValue)
+			: costValue && typeof costValue === "object"
+				? finiteNumber((costValue as Record<string, unknown>).total)
+				: 0;
+	const usage = {
+		cost,
+		input: finiteNumber(persisted.input),
+		output: finiteNumber(persisted.output),
+		cacheRead: finiteNumber(persisted.cacheRead),
+		cacheWrite: finiteNumber(persisted.cacheWrite),
+		reasoning: finiteNumber(persisted.reasoning),
+	};
+	return usage.cost === 0 && usage.input === 0 && usage.output === 0 && usage.cacheRead === 0 && usage.cacheWrite === 0
+		? null
+		: usage;
+}
+
+function parsedTimestamp(messageTimestamp: unknown, entryTimestamp: unknown): number {
+	const parsed =
+		typeof messageTimestamp === "number"
+			? messageTimestamp
+			: new Date(String(messageTimestamp ?? entryTimestamp ?? "")).getTime();
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function auxiliaryMessage(usage: UsageAmount, timestamp: number, sourceId: string): SessionMessage {
+	return {
+		provider: AUXILIARY_PROVIDER,
+		model: AUXILIARY_MODEL,
+		thinkingLevel: AUXILIARY_THINKING_LEVEL,
+		source: "auxiliary",
+		sourceId,
+		...usage,
+		timestamp,
+		afterCompaction: false,
+	};
+}
+
+function buildToolUsageRecord(
+	toolName: unknown,
+	detailsValue: unknown,
+	reportedValue: unknown,
+	sourceIdValue: unknown,
+	messageTimestamp: unknown,
+	entryTimestamp: unknown
+): ToolUsageRecord | null {
+	const reportedUsage = parseUsageAmount(reportedValue);
+	const details = detailsValue && typeof detailsValue === "object" ? (detailsValue as Record<string, unknown>) : null;
+	const totalChildUsage = parseUsageAmount(details?.totalChildUsage);
+	const knownNestedTool = toolName === "subagent" || toolName === "subagent_wait";
+	const children: ChildToolUsage[] = [];
+	if (details && Array.isArray(details.results)) {
+		for (let resultIndex = 0; resultIndex < details.results.length; resultIndex++) {
+			const result = details.results[resultIndex];
+			if (!result || typeof result !== "object") continue;
+			const child = result as Record<string, unknown>;
+			const usage = parseUsageAmount(child.usage);
+			const sessionFile = typeof child.sessionFile === "string" ? child.sessionFile : "";
+			// Legacy fallback is deliberately restricted to recognised nested-agent
+			// records. Generic Pi 0.81 tools remain canonical through reportedUsage.
+			if (usage && (knownNestedTool || totalChildUsage || (reportedUsage && sessionFile))) {
+				children.push({ resultIndex, sessionFile, usage });
+			}
+		}
+	}
+	if (!reportedUsage && children.length === 0) return null;
+	return {
+		sourceId: typeof sourceIdValue === "string" ? sourceIdValue : "",
+		timestamp: parsedTimestamp(messageTimestamp, entryTimestamp),
+		reportedUsage,
+		runId: details && typeof details.runId === "string" ? details.runId : "",
+		children,
+	};
+}
+
+const LARGE_TOOL_RESULT_BYTES = 64 * 1024;
+const PROPERTY_ID = Buffer.from('"id":');
+const PROPERTY_TIMESTAMP = Buffer.from('"timestamp":');
+const PROPERTY_MESSAGE = Buffer.from('"message":');
+const PROPERTY_TOOL_NAME = Buffer.from('"toolName":');
+const PROPERTY_DETAILS = Buffer.from('"details":');
+const PROPERTY_USAGE = Buffer.from('"usage":');
+const DIRECT_CHILD_PROPERTIES = new Set(["usage", "sessionFile"]);
+
+function skipJsonWhitespace(buffer: Buffer, offset: number, limit: number): number {
+	while (offset < limit && (buffer[offset] === 0x20 || buffer[offset] === 0x09 || buffer[offset] === 0x0a || buffer[offset] === 0x0d)) offset++;
+	return offset;
+}
+
+/** Find one JSON value's end without decoding large strings or container bodies. */
+function jsonValueEnd(buffer: Buffer, offset: number, limit: number): number {
+	offset = skipJsonWhitespace(buffer, offset, limit);
+	if (offset >= limit) return offset;
+	const first = buffer[offset];
+	if (first === 0x22) {
+		let escaped = false;
+		for (let i = offset + 1; i < limit; i++) {
+			const byte = buffer[i];
+			if (escaped) escaped = false;
+			else if (byte === 0x5c) escaped = true;
+			else if (byte === 0x22) return i + 1;
+		}
+		return limit;
+	}
+	if (first === 0x7b || first === 0x5b) {
+		let depth = 0;
+		let inString = false;
+		let escaped = false;
+		for (let i = offset; i < limit; i++) {
+			const byte = buffer[i];
+			if (inString) {
+				if (escaped) escaped = false;
+				else if (byte === 0x5c) escaped = true;
+				else if (byte === 0x22) inString = false;
+				continue;
+			}
+			if (byte === 0x22) inString = true;
+			else if (byte === 0x7b || byte === 0x5b) depth++;
+			else if (byte === 0x7d || byte === 0x5d) {
+				depth--;
+				if (depth === 0) return i + 1;
+			}
+		}
+		return limit;
+	}
+	let end = offset;
+	while (end < limit && buffer[end] !== 0x2c && buffer[end] !== 0x5d && buffer[end] !== 0x7d) end++;
+	return end;
+}
+
+function parseJsonValueAt(buffer: Buffer, offset: number, limit: number): unknown {
+	const start = skipJsonWhitespace(buffer, offset, limit);
+	const end = jsonValueEnd(buffer, start, limit);
+	if (end <= start) return undefined;
+	try {
+		return JSON.parse(buffer.toString("utf8", start, end));
+	} catch {
+		return undefined;
+	}
+}
+
+function parsePropertyValue(buffer: Buffer, property: Buffer, from: number, to: number): unknown {
+	const propertyOffset = buffer.indexOf(property, from);
+	if (propertyOffset < 0 || propertyOffset >= to) return undefined;
+	return parseJsonValueAt(buffer, propertyOffset + property.length, to);
+}
+
+function parseLastPropertyValue(buffer: Buffer, property: Buffer, from: number, to: number): unknown {
+	const propertyOffset = buffer.lastIndexOf(property, to - 1);
+	if (propertyOffset < from) return undefined;
+	return parseJsonValueAt(buffer, propertyOffset + property.length, to);
+}
+
+interface DirectObjectScan {
+	end: number;
+	values: Map<string, [start: number, end: number]>;
+}
+
+/** Scan direct object properties while skipping nested values allocation-free. */
+function scanDirectObjectProperties(buffer: Buffer, objectStart: number, limit: number, wanted: Set<string>): DirectObjectScan {
+	const values = new Map<string, [number, number]>();
+	let cursor = objectStart + 1;
+	while (cursor < limit) {
+		cursor = skipJsonWhitespace(buffer, cursor, limit);
+		if (buffer[cursor] === 0x7d) return { end: cursor + 1, values };
+		if (buffer[cursor] === 0x2c) {
+			cursor++;
+			continue;
+		}
+		if (buffer[cursor] !== 0x22) return { end: jsonValueEnd(buffer, objectStart, limit), values };
+		const keyEnd = jsonValueEnd(buffer, cursor, limit);
+		let colon = skipJsonWhitespace(buffer, keyEnd, limit);
+		if (buffer[colon] !== 0x3a) return { end: jsonValueEnd(buffer, objectStart, limit), values };
+		const valueStart = skipJsonWhitespace(buffer, colon + 1, limit);
+		const valueEnd = jsonValueEnd(buffer, valueStart, limit);
+		const key = buffer.toString("utf8", cursor + 1, keyEnd - 1);
+		if (wanted.has(key)) values.set(key, [valueStart, valueEnd]);
+		if (valueEnd <= valueStart) return { end: limit, values };
+		cursor = valueEnd;
+	}
+	return { end: limit, values };
+}
+
+function parseJsonRange(buffer: Buffer, range: [number, number] | undefined): unknown {
+	if (!range) return undefined;
+	try {
+		return JSON.parse(buffer.toString("utf8", range[0], range[1]));
+	} catch {
+		return undefined;
+	}
+}
+
+interface ChildResultsScan {
+	end: number;
+	results: Array<Record<string, unknown>>;
+}
+
+function scanChildResults(buffer: Buffer, arrayStart: number, limit: number): ChildResultsScan {
+	const results: Array<Record<string, unknown>> = [];
+	let cursor = arrayStart + 1;
+	while (cursor < limit) {
+		cursor = skipJsonWhitespace(buffer, cursor, limit);
+		if (buffer[cursor] === 0x5d) return { end: cursor + 1, results };
+		if (buffer[cursor] === 0x2c) {
+			cursor++;
+			continue;
+		}
+		if (buffer[cursor] === 0x7b) {
+			const scanned = scanDirectObjectProperties(buffer, cursor, limit, DIRECT_CHILD_PROPERTIES);
+			results.push({
+				usage: parseJsonRange(buffer, scanned.values.get("usage")),
+				sessionFile: parseJsonRange(buffer, scanned.values.get("sessionFile")),
+			});
+			if (scanned.end <= cursor) return { end: limit, results };
+			cursor = scanned.end;
+			continue;
+		}
+		const valueEnd = jsonValueEnd(buffer, cursor, limit);
+		if (valueEnd <= cursor) return { end: limit, results };
+		cursor = valueEnd;
+	}
+	return { end: limit, results };
+}
+
+interface LargeDetailsScan {
+	end: number;
+	details: Record<string, unknown>;
+}
+
+/** Scan nested-agent details and its result metadata in a single byte pass. */
+function scanLargeDetails(buffer: Buffer, objectStart: number, limit: number): LargeDetailsScan {
+	const details: Record<string, unknown> = { results: [] };
+	let cursor = objectStart + 1;
+	while (cursor < limit) {
+		cursor = skipJsonWhitespace(buffer, cursor, limit);
+		if (buffer[cursor] === 0x7d) return { end: cursor + 1, details };
+		if (buffer[cursor] === 0x2c) {
+			cursor++;
+			continue;
+		}
+		if (buffer[cursor] !== 0x22) return { end: jsonValueEnd(buffer, objectStart, limit), details };
+		const keyEnd = jsonValueEnd(buffer, cursor, limit);
+		let colon = skipJsonWhitespace(buffer, keyEnd, limit);
+		if (buffer[colon] !== 0x3a) return { end: jsonValueEnd(buffer, objectStart, limit), details };
+		const valueStart = skipJsonWhitespace(buffer, colon + 1, limit);
+		const key = buffer.toString("utf8", cursor + 1, keyEnd - 1);
+		let valueEnd: number;
+		if (key === "results" && buffer[valueStart] === 0x5b) {
+			const scanned = scanChildResults(buffer, valueStart, limit);
+			details.results = scanned.results;
+			valueEnd = scanned.end;
+		} else {
+			valueEnd = jsonValueEnd(buffer, valueStart, limit);
+			if (key === "runId" || key === "totalChildUsage") {
+				details[key] = parseJsonRange(buffer, [valueStart, valueEnd]);
+			}
+		}
+		if (valueEnd <= valueStart) return { end: limit, details };
+		cursor = valueEnd;
+	}
+	return { end: limit, details };
+}
+
+/**
+ * Parse only the small accounting fields from a large tool-result line. This
+ * avoids UTF-8 decoding and JSON.parse allocation for multi-megabyte content.
+ */
+function parseLargeToolResultLine(line: Buffer): ToolUsageRecord | null {
+	const messageOffset = line.indexOf(PROPERTY_MESSAGE);
+	if (messageOffset < 0) return null;
+	const detailsOffset = line.indexOf(PROPERTY_DETAILS, messageOffset);
+	let detailsEnd = -1;
+	let details: Record<string, unknown> | null = null;
+	if (detailsOffset >= 0) {
+		const detailsStart = skipJsonWhitespace(line, detailsOffset + PROPERTY_DETAILS.length, line.length);
+		if (line[detailsStart] === 0x7b) {
+			const scanned = scanLargeDetails(line, detailsStart, line.length);
+			detailsEnd = scanned.end;
+			details = scanned.details;
+		}
+	}
+
+	const reportedUsage = detailsEnd >= 0
+		? parsePropertyValue(line, PROPERTY_USAGE, detailsEnd, line.length)
+		: parseLastPropertyValue(line, PROPERTY_USAGE, messageOffset, line.length);
+	const sourceId = parsePropertyValue(line, PROPERTY_ID, 0, messageOffset);
+	const entryTimestamp = parsePropertyValue(line, PROPERTY_TIMESTAMP, 0, messageOffset);
+	const messageTimestamp = parseLastPropertyValue(line, PROPERTY_TIMESTAMP, messageOffset, line.length);
+	const toolName = parsePropertyValue(line, PROPERTY_TOOL_NAME, messageOffset, detailsOffset >= 0 ? detailsOffset : line.length);
+	return buildToolUsageRecord(toolName, details, reportedUsage, sourceId, messageTimestamp, entryTimestamp);
+}
 
 function lineMightBeRelevant(line: Buffer): boolean {
 	// Entry type/role fields are at the front of Pi's JSONL objects. Restrict
@@ -290,6 +623,14 @@ function lineMightBeRelevant(line: Buffer): boolean {
 	if (head.includes(PATTERN_ASSISTANT_COMPACT) || head.includes(PATTERN_ASSISTANT_SPACED)) return true;
 
 	if (head.includes(PATTERN_TOOL_RESULT_COMPACT) || head.includes(PATTERN_TOOL_RESULT_SPACED)) {
+		if (
+			head.includes(PATTERN_SUBAGENT_TOOL_COMPACT) ||
+			head.includes(PATTERN_SUBAGENT_TOOL_SPACED) ||
+			head.includes(PATTERN_SUBAGENT_WAIT_TOOL_COMPACT) ||
+			head.includes(PATTERN_SUBAGENT_WAIT_TOOL_SPACED)
+		) {
+			return true;
+		}
 		// Pi serializes optional tool usage after content/details and immediately
 		// before the small isError/timestamp suffix. Checking the tail preserves
 		// the fast path for ordinary tool results, which dominate session bytes.
@@ -316,6 +657,7 @@ function lineMightBeRelevant(line: Buffer): boolean {
  */
 export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): Promise<ParsedSessionFile> {
 	const messages: SessionMessage[] = [];
+	const toolUsages: ToolUsageRecord[] = [];
 	let sessionId = "";
 	let cwd = "";
 	// Assistant messages don't carry the thinking level; pi records it as separate
@@ -324,43 +666,6 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 	// to the level active when it was produced.
 	let thinkingLevel = "";
 	let compactionPending = false;
-
-	const appendAuxiliaryUsage = (usage: unknown, timestamp: unknown, sourceId: unknown): void => {
-		if (!usage || typeof usage !== "object") return;
-		const persisted = usage as Record<string, unknown>;
-		const finiteNumber = (value: unknown): number =>
-			typeof value === "number" && Number.isFinite(value) ? value : 0;
-		const costObject = persisted.cost;
-		const cost =
-			costObject && typeof costObject === "object"
-				? finiteNumber((costObject as Record<string, unknown>).total)
-				: 0;
-		const input = finiteNumber(persisted.input);
-		const output = finiteNumber(persisted.output);
-		const cacheRead = finiteNumber(persisted.cacheRead);
-		const cacheWrite = finiteNumber(persisted.cacheWrite);
-		const reasoning = finiteNumber(persisted.reasoning);
-		// Match Pi's own breakdown: omit auxiliary buckets with neither billed
-		// cost nor token usage, even if a tool persisted an empty Usage object.
-		if (cost === 0 && input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) return;
-
-		const parsedTimestamp = typeof timestamp === "number" ? timestamp : new Date(String(timestamp ?? "")).getTime();
-		messages.push({
-			provider: AUXILIARY_PROVIDER,
-			model: AUXILIARY_MODEL,
-			thinkingLevel: AUXILIARY_THINKING_LEVEL,
-			source: "auxiliary",
-			sourceId: typeof sourceId === "string" ? sourceId : "",
-			cost,
-			input,
-			output,
-			cacheRead,
-			cacheWrite,
-			reasoning,
-			timestamp: Number.isFinite(parsedTimestamp) ? parsedTimestamp : 0,
-			afterCompaction: false,
-		});
-	};
 
 	let start = 0;
 	let lineNumber = 0;
@@ -372,10 +677,18 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 		lineNumber++;
 		if (lineNumber % PARSE_YIELD_EVERY_LINES === 0) {
 			await new Promise<void>((resolve) => setImmediate(resolve));
-			if (signal?.aborted) return { sessionId, cwd, messages };
+			if (signal?.aborted) return { sessionId, cwd, messages, toolUsages };
 		}
 
-		if (end > start && lineMightBeRelevant(buffer.subarray(start, end))) {
+		const lineBuffer = buffer.subarray(start, end);
+		if (end > start && lineMightBeRelevant(lineBuffer)) {
+			const head = lineBuffer.subarray(0, Math.min(1024, lineBuffer.length));
+			if (lineBuffer.length > LARGE_TOOL_RESULT_BYTES && head.includes(PATTERN_TOOL_RESULT_COMPACT)) {
+				const toolUsage = parseLargeToolResultLine(lineBuffer);
+				if (toolUsage) toolUsages.push(toolUsage);
+				start = end + 1;
+				continue;
+			}
 			try {
 				const entry = JSON.parse(buffer.toString("utf8", start, end));
 
@@ -385,10 +698,12 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 				} else if (entry.type === "thinking_level_change") {
 					if (typeof entry.thinkingLevel === "string") thinkingLevel = entry.thinkingLevel;
 				} else if (entry.type === "compaction") {
-					appendAuxiliaryUsage(entry.usage, entry.timestamp, entry.id);
+					const usage = parseUsageAmount(entry.usage);
+					if (usage) messages.push(auxiliaryMessage(usage, parsedTimestamp(undefined, entry.timestamp), typeof entry.id === "string" ? entry.id : ""));
 					compactionPending = true;
 				} else if (entry.type === "branch_summary") {
-					appendAuxiliaryUsage(entry.usage, entry.timestamp, entry.id);
+					const usage = parseUsageAmount(entry.usage);
+					if (usage) messages.push(auxiliaryMessage(usage, parsedTimestamp(undefined, entry.timestamp), typeof entry.id === "string" ? entry.id : ""));
 				} else if (entry.type === "message" && entry.message?.role === "assistant") {
 					const msg = entry.message;
 					if (msg.usage && msg.provider && msg.model) {
@@ -412,7 +727,8 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 					}
 				} else if (entry.type === "message" && entry.message?.role === "toolResult") {
 					const msg = entry.message;
-					appendAuxiliaryUsage(msg.usage, msg.timestamp ?? entry.timestamp, entry.id);
+					const toolUsage = buildToolUsageRecord(msg.toolName, msg.details, msg.usage, entry.id, msg.timestamp, entry.timestamp);
+					if (toolUsage) toolUsages.push(toolUsage);
 				}
 			} catch {
 				// Skip malformed lines
@@ -422,14 +738,14 @@ export async function parseSessionBuffer(buffer: Buffer, signal?: AbortSignal): 
 		start = end + 1;
 	}
 
-	return { sessionId, cwd, messages };
+	return { sessionId, cwd, messages, toolUsages };
 }
 
 // =============================================================================
 // On-disk cache
 // =============================================================================
 
-const CACHE_VERSION = 4;
+const CACHE_VERSION = 5;
 
 type CachedMessageTuple = [
 	providerIdx: number,
@@ -447,12 +763,36 @@ type CachedMessageTuple = [
 	sourceIdIdx: number,
 ];
 
+type CachedUsageTuple = [
+	cost: number,
+	input: number,
+	output: number,
+	cacheRead: number,
+	cacheWrite: number,
+	reasoning: number,
+];
+
+type CachedChildToolUsageTuple = [
+	resultIndex: number,
+	sessionFileIdx: number,
+	usage: CachedUsageTuple,
+];
+
+type CachedToolUsageTuple = [
+	sourceIdIdx: number,
+	timestamp: number,
+	reportedUsage: CachedUsageTuple | null,
+	runIdIdx: number,
+	children: CachedChildToolUsageTuple[],
+];
+
 interface CacheFileEntry {
 	size: number;
 	mtimeMs: number;
 	sessionId: string;
 	cwd: string;
 	messages: CachedMessageTuple[];
+	toolUsages: CachedToolUsageTuple[];
 }
 
 export interface CachedFileState {
@@ -481,7 +821,8 @@ export async function loadUsageCache(cachePath: string): Promise<Map<string, Cac
 			typeof entry.mtimeMs !== "number" ||
 			typeof entry.sessionId !== "string" ||
 			typeof entry.cwd !== "string" ||
-			!Array.isArray(entry.messages)
+			!Array.isArray(entry.messages) ||
+			!Array.isArray(entry.toolUsages)
 		) {
 			continue;
 		}
@@ -523,13 +864,68 @@ export async function loadUsageCache(cachePath: string): Promise<Map<string, Cac
 			});
 		}
 		if (!valid) continue;
+		const toolUsages: ToolUsageRecord[] = [];
+		for (const tuple of entry.toolUsages) {
+			if (!Array.isArray(tuple) || tuple.length !== 5 || !Array.isArray(tuple[4])) {
+				valid = false;
+				break;
+			}
+			const sourceId = names[tuple[0]];
+			const runId = names[tuple[3]];
+			const reportedUsage = cachedUsageAmount(tuple[2]);
+			if (typeof sourceId !== "string" || typeof runId !== "string" || (tuple[2] !== null && !reportedUsage)) {
+				valid = false;
+				break;
+			}
+			const children: ChildToolUsage[] = [];
+			for (const childTuple of tuple[4]) {
+				if (!Array.isArray(childTuple) || childTuple.length !== 3) {
+					valid = false;
+					break;
+				}
+				const sessionFile = names[childTuple[1]];
+				const usage = cachedUsageAmount(childTuple[2]);
+				if (typeof childTuple[0] !== "number" || typeof sessionFile !== "string" || !usage) {
+					valid = false;
+					break;
+				}
+				children.push({ resultIndex: childTuple[0], sessionFile, usage });
+			}
+			if (!valid) break;
+			toolUsages.push({
+				sourceId,
+				timestamp: Number(tuple[1]) || 0,
+				reportedUsage,
+				runId,
+				children,
+			});
+		}
+		if (!valid) continue;
 		result.set(filePath, {
 			size: entry.size,
 			mtimeMs: entry.mtimeMs,
-			parsed: { sessionId: entry.sessionId, cwd: entry.cwd, messages },
+			parsed: { sessionId: entry.sessionId, cwd: entry.cwd, messages, toolUsages },
 		});
 	}
 	return result;
+}
+
+function cachedUsageAmount(value: unknown): UsageAmount | null {
+	if (!Array.isArray(value) || value.length !== 6 || value.some((part) => typeof part !== "number" || !Number.isFinite(part))) {
+		return null;
+	}
+	return {
+		cost: value[0],
+		input: value[1],
+		output: value[2],
+		cacheRead: value[3],
+		cacheWrite: value[4],
+		reasoning: value[5],
+	};
+}
+
+function cacheUsageAmount(usage: UsageAmount): CachedUsageTuple {
+	return [usage.cost, usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.reasoning];
 }
 
 export async function saveUsageCache(cachePath: string, states: Map<string, CachedFileState>): Promise<void> {
@@ -566,6 +962,17 @@ export async function saveUsageCache(cachePath: string, states: Map<string, Cach
 				m.afterCompaction ? 1 : 0,
 				m.source === "auxiliary" ? 1 : 0,
 				intern(m.source === "auxiliary" ? m.sourceId : ""),
+			]),
+			toolUsages: state.parsed.toolUsages.map((tool): CachedToolUsageTuple => [
+				intern(tool.sourceId),
+				tool.timestamp,
+				tool.reportedUsage ? cacheUsageAmount(tool.reportedUsage) : null,
+				intern(tool.runId),
+				tool.children.map((child): CachedChildToolUsageTuple => [
+					child.resultIndex,
+					intern(child.sessionFile),
+					cacheUsageAmount(child.usage),
+				]),
 			]),
 		};
 	}
@@ -836,6 +1243,252 @@ function addMessagesToUsageData(
 }
 
 // =============================================================================
+// Nested tool-usage reconciliation
+// =============================================================================
+
+// Costs are persisted as decimal USD but accumulated through binary floating
+// point. Compare exact picodollar units so subtraction noise is normalised
+// without admitting fuzzy token/cost matches.
+const USAGE_COST_SCALE = 1_000_000_000_000;
+const USAGE_FIELDS = ["input", "output", "cacheRead", "cacheWrite"] as const;
+
+function usageCostUnits(cost: number): number {
+	return Math.round(cost * USAGE_COST_SCALE);
+}
+
+function emptyUsageAmount(): UsageAmount {
+	return { cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 };
+}
+
+function addUsageAmount(target: UsageAmount, usage: UsageAmount): void {
+	target.cost += usage.cost;
+	target.input += usage.input;
+	target.output += usage.output;
+	target.cacheRead += usage.cacheRead;
+	target.cacheWrite += usage.cacheWrite;
+	target.reasoning += usage.reasoning;
+}
+
+function usageAmountHasValue(usage: UsageAmount): boolean {
+	return usage.cost !== 0 || usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0;
+}
+
+function usageTokenKey(usage: UsageAmount): string {
+	return `${usage.input}:${usage.output}:${usage.cacheRead}:${usage.cacheWrite}`;
+}
+
+interface ChildUsageIndex {
+	prefixes: UsageAmount[];
+	prefixIndexesByTokens: Map<string, number[]>;
+}
+
+function buildChildUsageIndex(messages: SessionMessage[]): ChildUsageIndex {
+	const prefixes: UsageAmount[] = [emptyUsageAmount()];
+	const prefixIndexesByTokens = new Map<string, number[]>([[usageTokenKey(prefixes[0]!), [0]]]);
+	for (const message of messages) {
+		if (message.source !== "assistant") continue;
+		const next = { ...prefixes[prefixes.length - 1]! };
+		addUsageAmount(next, message);
+		const index = prefixes.length;
+		prefixes.push(next);
+		const key = usageTokenKey(next);
+		const indexes = prefixIndexesByTokens.get(key);
+		if (indexes) indexes.push(index);
+		else prefixIndexesByTokens.set(key, [index]);
+	}
+	return { prefixes, prefixIndexesByTokens };
+}
+
+/** Return reasoning from an exact contiguous assistant-usage span, if present. */
+function findChildUsageSpan(index: ChildUsageIndex, expected: UsageAmount): UsageAmount | null {
+	for (let endIndex = 1; endIndex < index.prefixes.length; endIndex++) {
+		const end = index.prefixes[endIndex]!;
+		const requiredPrefix = {
+			cost: 0,
+			input: end.input - expected.input,
+			output: end.output - expected.output,
+			cacheRead: end.cacheRead - expected.cacheRead,
+			cacheWrite: end.cacheWrite - expected.cacheWrite,
+			reasoning: 0,
+		};
+		if (USAGE_FIELDS.some((field) => requiredPrefix[field] < 0)) continue;
+		const startIndexes = index.prefixIndexesByTokens.get(usageTokenKey(requiredPrefix));
+		if (!startIndexes) continue;
+		for (const startIndex of startIndexes) {
+			if (startIndex >= endIndex) break;
+			const start = index.prefixes[startIndex]!;
+			if (usageCostUnits(end.cost - start.cost) === usageCostUnits(expected.cost)) {
+				return { ...expected, reasoning: end.reasoning - start.reasoning };
+			}
+		}
+	}
+	return null;
+}
+
+interface ResolvedSessionState {
+	filePath: string;
+	state: CachedFileState;
+}
+
+interface ToolReconciliationIndex {
+	byPath: Map<string, ResolvedSessionState>;
+	filesByDir: Map<string, ResolvedSessionState[]>;
+	usageByPath: Map<string, ChildUsageIndex>;
+}
+
+function buildToolReconciliationIndex(states: Map<string, CachedFileState>): ToolReconciliationIndex {
+	const byPath = new Map<string, ResolvedSessionState>();
+	const filesByDir = new Map<string, ResolvedSessionState[]>();
+	for (const [filePath, state] of states) {
+		const resolved = resolve(filePath);
+		const item = { filePath: resolved, state };
+		byPath.set(resolved, item);
+		const dir = dirname(resolved);
+		const siblings = filesByDir.get(dir);
+		if (siblings) siblings.push(item);
+		else filesByDir.set(dir, [item]);
+	}
+	return { byPath, filesByDir, usageByPath: new Map() };
+}
+
+function resolveChildSession(
+	parentFilePath: string,
+	tool: ToolUsageRecord,
+	child: ChildToolUsage,
+	index: ToolReconciliationIndex
+): ResolvedSessionState | null {
+	const candidates: string[] = [];
+	if (child.sessionFile) {
+		candidates.push(isAbsolute(child.sessionFile) ? child.sessionFile : resolve(dirname(parentFilePath), child.sessionFile));
+	}
+	if (tool.runId) {
+		const runDir = join(dirname(parentFilePath), basename(parentFilePath, ".jsonl"), tool.runId, `run-${child.resultIndex}`);
+		candidates.push(join(runDir, "session.jsonl"));
+		const filesInRunDir = index.filesByDir.get(resolve(runDir));
+		if (filesInRunDir?.length === 1) candidates.push(filesInRunDir[0]!.filePath);
+	}
+	for (const candidate of candidates) {
+		const resolved = index.byPath.get(resolve(candidate));
+		if (resolved?.state.parsed.sessionId) return resolved;
+	}
+	return null;
+}
+
+interface ToolUsageOccurrence {
+	parentFilePath: string;
+	tool: ToolUsageRecord;
+}
+
+interface ChildUsageOccurrence extends ToolUsageOccurrence {
+	child: ChildToolUsage;
+}
+
+function toolUsageIdentity(tool: ToolUsageRecord): string {
+	const reported = tool.reportedUsage ? `${usageTokenKey(tool.reportedUsage)}:${usageCostUnits(tool.reportedUsage.cost)}` : "legacy";
+	const children = tool.children
+		.map((child) => `${child.resultIndex}:${usageTokenKey(child.usage)}:${usageCostUnits(child.usage.cost)}`)
+		.join("|");
+	// Pi entry ids are short rather than globally unique. Timestamp and usage
+	// distinguish an unrelated collision while copied branch history stays grouped.
+	return `${tool.sourceId ? `id:${tool.sourceId}` : "anonymous"}:${tool.timestamp}:${reported}:${children}`;
+}
+
+function matchedChildUsage(occurrences: ChildUsageOccurrence[], index: ToolReconciliationIndex): UsageAmount | null {
+	for (const occurrence of occurrences) {
+		const childSession = resolveChildSession(occurrence.parentFilePath, occurrence.tool, occurrence.child, index);
+		if (!childSession) continue;
+		let childIndex = index.usageByPath.get(childSession.filePath);
+		if (!childIndex) {
+			childIndex = buildChildUsageIndex(childSession.state.parsed.messages);
+			index.usageByPath.set(childSession.filePath, childIndex);
+		}
+		const matched = findChildUsageSpan(childIndex, occurrence.child.usage);
+		if (matched) return matched;
+	}
+	return null;
+}
+
+function reconcileToolUsageGroup(occurrences: ToolUsageOccurrence[], index: ToolReconciliationIndex): SessionMessage[] {
+	const representative = occurrences[0]!.tool;
+	const reportedUsage = occurrences.find((occurrence) => occurrence.tool.reportedUsage)?.tool.reportedUsage ?? null;
+	const childGroups = new Map<string, ChildUsageOccurrence[]>();
+	for (const occurrence of occurrences) {
+		for (const child of occurrence.tool.children) {
+			const key = `${child.resultIndex}:${usageTokenKey(child.usage)}:${usageCostUnits(child.usage.cost)}`;
+			let group = childGroups.get(key);
+			if (!group) {
+				group = [];
+				childGroups.set(key, group);
+			}
+			group.push({ ...occurrence, child });
+		}
+	}
+
+	const covered = emptyUsageAmount();
+	const uncovered: ChildToolUsage[] = [];
+	for (const childOccurrences of childGroups.values()) {
+		const child = childOccurrences[0]!.child;
+		const matched = matchedChildUsage(childOccurrences, index);
+		if (matched) addUsageAmount(covered, matched);
+		else uncovered.push(child);
+	}
+
+	if (reportedUsage) {
+		const canSubtract =
+			USAGE_FIELDS.every((field) => covered[field] <= reportedUsage[field]) &&
+			usageCostUnits(covered.cost) <= usageCostUnits(reportedUsage.cost);
+		const residual = canSubtract
+			? {
+					cost: Math.max(0, reportedUsage.cost - covered.cost),
+					input: reportedUsage.input - covered.input,
+					output: reportedUsage.output - covered.output,
+					cacheRead: reportedUsage.cacheRead - covered.cacheRead,
+					cacheWrite: reportedUsage.cacheWrite - covered.cacheWrite,
+					reasoning: Math.max(0, reportedUsage.reasoning - covered.reasoning),
+				}
+			: reportedUsage;
+		return usageAmountHasValue(residual) ? [auxiliaryMessage(residual, representative.timestamp, representative.sourceId)] : [];
+	}
+
+	// Before Pi 0.81, recognised nested-agent tools could only persist exact
+	// child usage in details. Count just the children not already represented
+	// by a recursively scanned session.
+	return uncovered.map((child) => {
+		const childSourceId = representative.sourceId ? `${representative.sourceId}:child:${child.resultIndex}` : "";
+		return auxiliaryMessage(child.usage, representative.timestamp, childSourceId);
+	});
+}
+
+function reconcileAllToolUsages(
+	states: Map<string, CachedFileState>,
+	index: ToolReconciliationIndex
+): Map<string, SessionMessage[]> {
+	const groups = new Map<string, ToolUsageOccurrence[]>();
+	for (const [parentFilePath, state] of states) {
+		for (const tool of state.parsed.toolUsages) {
+			const key = toolUsageIdentity(tool);
+			let group = groups.get(key);
+			if (!group) {
+				group = [];
+				groups.set(key, group);
+			}
+			group.push({ parentFilePath, tool });
+		}
+	}
+
+	const byParentFile = new Map<string, SessionMessage[]>();
+	for (const occurrences of groups.values()) {
+		const parentFilePath = occurrences[0]!.parentFilePath;
+		const messages = reconcileToolUsageGroup(occurrences, index);
+		if (messages.length === 0) continue;
+		const existing = byParentFile.get(parentFilePath);
+		if (existing) existing.push(...messages);
+		else byParentFile.set(parentFilePath, messages);
+	}
+	return byParentFile;
+}
+
+// =============================================================================
 // Collection orchestration
 // =============================================================================
 
@@ -1031,6 +1684,8 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 	const costByDayIdx = new Map<number, number>();
 	const seenSessions = new Set<string>();
 	const seenHashes = new Set<string>();
+	const toolReconciliation = buildToolReconciliationIndex(current);
+	const reconciledToolMessages = reconcileAllToolUsages(current, toolReconciliation);
 	let processedFiles = 0;
 
 	for (const filePath of filePaths) {
@@ -1045,7 +1700,8 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 		// Deduplicate copied history across branched session files, computing
 		// adjacency metadata (idle gaps, previous context) on the raw file order
 		// so branch copies do not distort miss classification.
-		const rawMsgs = state.parsed.messages;
+		const toolMessages = reconciledToolMessages.get(filePath);
+		const rawMsgs = toolMessages ? [...state.parsed.messages, ...toolMessages] : state.parsed.messages;
 		const deduped: SessionMessage[] = [];
 		const meta: MessageMeta[] = [];
 		let previousAssistant: SessionMessage | null = null;

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Summary
- reconcile canonical tool-result aggregates against exact contiguous child-session token-and-cost vectors
- count only unmatched residuals, with legacy `subagent` / `subagent_wait` details as fallback when child sessions are unavailable
- reconcile copied parent history globally, preserve reasoning-token accounting, and cache child-link metadata in cache v5
- keep large tool-result parsing allocation-safe and document the irrecoverable historical summary boundary

## Validation
- `node --experimental-strip-types --test tests/*.test.mjs` — 62/62 pass
- focused TypeScript check for `usage-extension/data.ts`
- `git diff --check`
- package inspection: `@tmustier/pi-usage-extension@0.9.3` (11 files) and `pi-extensions@0.1.60` (182 files), no nested `node_modules`
- 10 GB / 6,316-file corpus: all 696 resolvable child reports matched exact contiguous spans; all 837 unavailable reports remained as fallback; zero linked-vector mismatches
- cold scan ~9.1 s; warm cached scan ~1.0 s

## Historical boundary
Historical compaction and branch-summary entries that never persisted usage cannot be reconstructed. The compatibility audit found 2,753 such compactions and 20 branch summaries; this is now explicit in the README and changelog.
