### PR TITLE
Radically simplify nested child usage reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.61] - 2026-07-22
+
+### Changed
+- `usage-extension` 0.9.4: radically simplified nested-agent reconciliation — scanned child session files are trusted as the record and matching parent aggregates are skipped via a file-existence check, replacing 0.9.3's exact vector matching. Byte-identical totals on the validation corpus; cache stays v5 with no rebuild.
+
 ## [0.1.60] - 2026-07-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -459,7 +459,7 @@ test("collectUsageData suppresses canonical tool usage already present in a link
 	assert.equal(data.today.providers.has("Tools"), false);
 });
 
-test("collectUsageData counts only the unmatched residual of mixed child usage", async (t) => {
+test("collectUsageData counts the full aggregate when any child session is missing", async (t) => {
 	const { sessionsDir, cachePath } = fixture(t);
 	const parentPath = join(sessionsDir, "mixed.jsonl");
 	const childPath = join(sessionsDir, "mixed", "run-a", "run-0", "session.jsonl");
@@ -485,19 +485,16 @@ test("collectUsageData counts only the unmatched residual of mixed child usage",
 	);
 
 	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
-	assert.equal(data.today.totals.cost, 5, "the $2 child plus the $3 residual, not the $5 report again");
+	// One child is missing, so the $5 aggregate is counted whole next to the
+	// scanned $2 child — a deliberate small overcount instead of residual math.
+	assert.equal(data.today.totals.cost, 7);
 	assert.equal(data.today.totals.messages, 1);
 	assert.equal(data.today.providers.get("anthropic").cost, 2);
-	assert.equal(data.today.providers.get("Tools").cost, 3);
-	const toolsReasoning = [...data.hourly.values()].reduce(
-		(total, cells) => total + [...cells.entries()].reduce((sum, [key, cell]) => sum + (key.startsWith("Tools\0") ? cell.reasoning : 0), 0),
-		0
-	);
-	assert.equal(toolsReasoning, 3);
-	assert.equal(data.today.providers.get("Tools").models.get("summaries").cost, 3);
+	assert.equal(data.today.providers.get("Tools").cost, 5);
+	assert.equal(data.today.providers.get("Tools").models.get("summaries").cost, 5);
 });
 
-test("collectUsageData backfills legacy nested usage only when no scanned child span represents it", async (t) => {
+test("collectUsageData backfills legacy nested usage only when no scanned child session represents it", async (t) => {
 	const { sessionsDir, cachePath } = fixture(t);
 	const parentPath = join(sessionsDir, "legacy.jsonl");
 	const childPath = join(sessionsDir, "legacy", "run-a", "run-0", "session.jsonl");
@@ -532,7 +529,7 @@ test("collectUsageData backfills legacy nested usage only when no scanned child 
 	assert.equal(data.today.providers.get("Tools").cost, 3);
 });
 
-test("collectUsageData requires an exact cost vector before suppressing linked child usage", async (t) => {
+test("collectUsageData trusts scanned child sessions over their reported usage", async (t) => {
 	const { sessionsDir, cachePath } = fixture(t);
 	const childPath = join(sessionsDir, "exact-child.jsonl");
 	writeFileSync(
@@ -552,8 +549,10 @@ test("collectUsageData requires an exact cost vector before suppressing linked c
 	);
 
 	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
-	assert.equal(data.today.totals.cost, 4.000001);
-	assert.equal(data.today.providers.get("Tools").cost, 2.000001);
+	// The child session file exists, so it is the record — the reported child
+	// usage is skipped even though rounding noise makes the vectors differ.
+	assert.equal(data.today.totals.cost, 2);
+	assert.equal(data.today.providers.has("Tools"), false);
 });
 
 test("collectUsageData dedupes copied legacy child reports by parent entry id", async (t) => {
@@ -572,7 +571,7 @@ test("collectUsageData dedupes copied legacy child reports by parent entry id", 
 	assert.equal(data.today.providers.get("Tools").cost, 3);
 });
 
-test("collectUsageData reconciles copied tool reports globally rather than trusting the first parent copy", async (t) => {
+test("collectUsageData suppresses copied tool reports when any copy resolves its children", async (t) => {
 	const { sessionsDir, cachePath } = fixture(t);
 	const childPath = join(sessionsDir, "child.jsonl");
 	writeFileSync(

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.9.4] - 2026-07-22
+
+### Changed
+- Radically simplified nested-agent reconciliation. Child sessions on disk are now trusted as the record: when every child session file behind a tool report is part of the scan, the parent's aggregate is skipped; otherwise the whole report (or each unresolved legacy child) is counted under `Tools / summaries`. This replaces 0.9.3's exact contiguous token-and-cost vector matching and residual arithmetic (~250 lines) with a file-existence check — validated byte-identical against 0.9.3 on a 10 GB / 6,166-session corpus.
+- Resolved child identities are unioned across copied parent history before emission, because branch copies change runId-derived child paths. Same outcome as 0.9.3's global reconciliation, without vector identity keys.
+- Known trade-offs: a crash-truncated child session slightly undercounts, and a partially-missing child set counts the full aggregate (slight overcount). Neither case appeared in the audit corpus.
+
+### Internal
+- Cache format stays **v5** — no rebuild on upgrade.
+
 ## [0.9.3] - 2026-07-22
 
 ### Fixed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -9,7 +9,7 @@ A Pi extension that displays aggregated usage statistics across all sessions.
 - **Pi version:** 0.42.4+
 - **Last updated:** 2026-07-22 (0.9.3)
 
-Pi 0.81.0+ can persist tool-result, compaction, and branch-summary usage. `/usage` includes that auxiliary usage in totals under `Tools / summaries`. Nested-agent reports are reconciled against recursively scanned child sessions, so a child call is counted once; when only part of an aggregate is already present, only the unmatched residual is added. Older Pi versions remain supported.
+Pi 0.81.0+ can persist tool-result, compaction, and branch-summary usage. `/usage` includes that auxiliary usage in totals under `Tools / summaries`. Nested-agent reports are reconciled against recursively scanned child sessions, so a child call is counted once: when every child session file behind a report is part of the scan, the children are the record and the parent's aggregate is skipped; otherwise the report is counted. Older Pi versions remain supported.
 
 ## Installation
 
@@ -227,7 +227,7 @@ The "Cache" column combines both read and write tokens.
 
 Statistics are parsed recursively from session files in `~/.pi/agent/sessions/`, including nested subagent runs such as `run-0/` directories. Each session is a JSONL file containing assistant messages and, on Pi 0.81.0+, optional usage on tool-result, compaction, and branch-summary entries.
 
-Assistant messages duplicated across branched session files are deduplicated by timestamp + total tokens. Auxiliary usage is deduplicated by its stable session entry id, which avoids collapsing parallel tools that happen to report identical usage. Tool reports are reconciled globally across copied parent history: an exact contiguous child-session token-and-cost vector suppresses the matching portion of the parent aggregate, while missing children and unmatched residuals stay under `Tools / summaries`. Tool and summary usage contributes cost and tokens to totals, graphs, project/session mix, and burn trend, but does not count as an assistant message or distort conversation context/cache insights.
+Assistant messages duplicated across branched session files are deduplicated by timestamp + total tokens. Auxiliary usage is deduplicated by its stable session entry id, which avoids collapsing parallel tools that happen to report identical usage. Nested-agent reports are suppressed when their child session files are part of the scan (resolved across all copies of the parent entry, since branch copies change runId-derived paths); reports whose children are missing stay under `Tools / summaries`. Tool and summary usage contributes cost and tokens to totals, graphs, project/session mix, and burn trend, but does not count as an assistant message or distort conversation context/cache insights.
 
 Respects the `PI_CODING_AGENT_DIR` environment variable if set.
 

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -1243,251 +1243,102 @@ function addMessagesToUsageData(
 }
 
 // =============================================================================
-// Nested tool-usage reconciliation
+// Nested tool-usage accounting
 // =============================================================================
 
-// Costs are persisted as decimal USD but accumulated through binary floating
-// point. Compare exact picodollar units so subtraction noise is normalised
-// without admitting fuzzy token/cost matches.
-const USAGE_COST_SCALE = 1_000_000_000_000;
-const USAGE_FIELDS = ["input", "output", "cacheRead", "cacheWrite"] as const;
+// Recognised nested-agent tool results report usage for child runs that
+// pi-subagents also persists as ordinary session files, which this scan
+// already counts with full model attribution. When every child session file
+// behind a report is part of the scan, the children speak for themselves and
+// the parent's aggregate is skipped. Otherwise the aggregate (or, for pre-0.81
+// legacy entries, each unresolved child's reported usage) is counted under
+// Tools / summaries.
+//
+// Copied branch history gets a new parent filename, so a copy's runId-derived
+// child paths can dangle even though the original's resolve. Resolved child
+// identities are therefore unioned across all copies of an entry before any
+// emission, and identical emissions collapse in the sourceId dedupe.
 
-function usageCostUnits(cost: number): number {
-	return Math.round(cost * USAGE_COST_SCALE);
+interface ScannedSessionIndex {
+	/** Resolved paths of scanned files that have a session header. */
+	paths: Set<string>;
+	/** Directory of each scanned file → number of scanned files inside it. */
+	fileCountByDir: Map<string, number>;
 }
 
-function emptyUsageAmount(): UsageAmount {
-	return { cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0 };
-}
-
-function addUsageAmount(target: UsageAmount, usage: UsageAmount): void {
-	target.cost += usage.cost;
-	target.input += usage.input;
-	target.output += usage.output;
-	target.cacheRead += usage.cacheRead;
-	target.cacheWrite += usage.cacheWrite;
-	target.reasoning += usage.reasoning;
-}
-
-function usageAmountHasValue(usage: UsageAmount): boolean {
-	return usage.cost !== 0 || usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0;
-}
-
-function usageTokenKey(usage: UsageAmount): string {
-	return `${usage.input}:${usage.output}:${usage.cacheRead}:${usage.cacheWrite}`;
-}
-
-interface ChildUsageIndex {
-	prefixes: UsageAmount[];
-	prefixIndexesByTokens: Map<string, number[]>;
-}
-
-function buildChildUsageIndex(messages: SessionMessage[]): ChildUsageIndex {
-	const prefixes: UsageAmount[] = [emptyUsageAmount()];
-	const prefixIndexesByTokens = new Map<string, number[]>([[usageTokenKey(prefixes[0]!), [0]]]);
-	for (const message of messages) {
-		if (message.source !== "assistant") continue;
-		const next = { ...prefixes[prefixes.length - 1]! };
-		addUsageAmount(next, message);
-		const index = prefixes.length;
-		prefixes.push(next);
-		const key = usageTokenKey(next);
-		const indexes = prefixIndexesByTokens.get(key);
-		if (indexes) indexes.push(index);
-		else prefixIndexesByTokens.set(key, [index]);
-	}
-	return { prefixes, prefixIndexesByTokens };
-}
-
-/** Return reasoning from an exact contiguous assistant-usage span, if present. */
-function findChildUsageSpan(index: ChildUsageIndex, expected: UsageAmount): UsageAmount | null {
-	for (let endIndex = 1; endIndex < index.prefixes.length; endIndex++) {
-		const end = index.prefixes[endIndex]!;
-		const requiredPrefix = {
-			cost: 0,
-			input: end.input - expected.input,
-			output: end.output - expected.output,
-			cacheRead: end.cacheRead - expected.cacheRead,
-			cacheWrite: end.cacheWrite - expected.cacheWrite,
-			reasoning: 0,
-		};
-		if (USAGE_FIELDS.some((field) => requiredPrefix[field] < 0)) continue;
-		const startIndexes = index.prefixIndexesByTokens.get(usageTokenKey(requiredPrefix));
-		if (!startIndexes) continue;
-		for (const startIndex of startIndexes) {
-			if (startIndex >= endIndex) break;
-			const start = index.prefixes[startIndex]!;
-			if (usageCostUnits(end.cost - start.cost) === usageCostUnits(expected.cost)) {
-				return { ...expected, reasoning: end.reasoning - start.reasoning };
-			}
-		}
-	}
-	return null;
-}
-
-interface ResolvedSessionState {
-	filePath: string;
-	state: CachedFileState;
-}
-
-interface ToolReconciliationIndex {
-	byPath: Map<string, ResolvedSessionState>;
-	filesByDir: Map<string, ResolvedSessionState[]>;
-	usageByPath: Map<string, ChildUsageIndex>;
-}
-
-function buildToolReconciliationIndex(states: Map<string, CachedFileState>): ToolReconciliationIndex {
-	const byPath = new Map<string, ResolvedSessionState>();
-	const filesByDir = new Map<string, ResolvedSessionState[]>();
+function buildScannedSessionIndex(states: Map<string, CachedFileState>): ScannedSessionIndex {
+	const paths = new Set<string>();
+	const fileCountByDir = new Map<string, number>();
 	for (const [filePath, state] of states) {
+		if (!state.parsed.sessionId) continue;
 		const resolved = resolve(filePath);
-		const item = { filePath: resolved, state };
-		byPath.set(resolved, item);
+		paths.add(resolved);
 		const dir = dirname(resolved);
-		const siblings = filesByDir.get(dir);
-		if (siblings) siblings.push(item);
-		else filesByDir.set(dir, [item]);
+		fileCountByDir.set(dir, (fileCountByDir.get(dir) ?? 0) + 1);
 	}
-	return { byPath, filesByDir, usageByPath: new Map() };
+	return { paths, fileCountByDir };
 }
 
-function resolveChildSession(
+function childSessionScanned(
 	parentFilePath: string,
 	tool: ToolUsageRecord,
 	child: ChildToolUsage,
-	index: ToolReconciliationIndex
-): ResolvedSessionState | null {
-	const candidates: string[] = [];
+	index: ScannedSessionIndex
+): boolean {
 	if (child.sessionFile) {
-		candidates.push(isAbsolute(child.sessionFile) ? child.sessionFile : resolve(dirname(parentFilePath), child.sessionFile));
+		const explicit = isAbsolute(child.sessionFile)
+			? resolve(child.sessionFile)
+			: resolve(dirname(parentFilePath), child.sessionFile);
+		if (index.paths.has(explicit)) return true;
 	}
 	if (tool.runId) {
-		const runDir = join(dirname(parentFilePath), basename(parentFilePath, ".jsonl"), tool.runId, `run-${child.resultIndex}`);
-		candidates.push(join(runDir, "session.jsonl"));
-		const filesInRunDir = index.filesByDir.get(resolve(runDir));
-		if (filesInRunDir?.length === 1) candidates.push(filesInRunDir[0]!.filePath);
+		const runDir = resolve(dirname(parentFilePath), basename(parentFilePath, ".jsonl"), tool.runId, `run-${child.resultIndex}`);
+		// The run directory holds exactly one session per child run, so either the
+		// conventional name or a lone scanned file inside it identifies the child.
+		if (index.paths.has(join(runDir, "session.jsonl"))) return true;
+		if (index.fileCountByDir.get(runDir) === 1) return true;
 	}
-	for (const candidate of candidates) {
-		const resolved = index.byPath.get(resolve(candidate));
-		if (resolved?.state.parsed.sessionId) return resolved;
-	}
-	return null;
+	return false;
 }
 
-interface ToolUsageOccurrence {
-	parentFilePath: string;
-	tool: ToolUsageRecord;
+/** Identity of one child slot of one tool entry, stable across copied history. */
+function toolChildIdentity(tool: ToolUsageRecord, child: ChildToolUsage): string {
+	const fingerprint = child.usage.input + child.usage.output + child.usage.cacheRead + child.usage.cacheWrite;
+	return `${tool.sourceId}:${tool.timestamp}:${child.resultIndex}:${fingerprint}`;
 }
 
-interface ChildUsageOccurrence extends ToolUsageOccurrence {
-	child: ChildToolUsage;
-}
-
-function toolUsageIdentity(tool: ToolUsageRecord): string {
-	const reported = tool.reportedUsage ? `${usageTokenKey(tool.reportedUsage)}:${usageCostUnits(tool.reportedUsage.cost)}` : "legacy";
-	const children = tool.children
-		.map((child) => `${child.resultIndex}:${usageTokenKey(child.usage)}:${usageCostUnits(child.usage.cost)}`)
-		.join("|");
-	// Pi entry ids are short rather than globally unique. Timestamp and usage
-	// distinguish an unrelated collision while copied branch history stays grouped.
-	return `${tool.sourceId ? `id:${tool.sourceId}` : "anonymous"}:${tool.timestamp}:${reported}:${children}`;
-}
-
-function matchedChildUsage(occurrences: ChildUsageOccurrence[], index: ToolReconciliationIndex): UsageAmount | null {
-	for (const occurrence of occurrences) {
-		const childSession = resolveChildSession(occurrence.parentFilePath, occurrence.tool, occurrence.child, index);
-		if (!childSession) continue;
-		let childIndex = index.usageByPath.get(childSession.filePath);
-		if (!childIndex) {
-			childIndex = buildChildUsageIndex(childSession.state.parsed.messages);
-			index.usageByPath.set(childSession.filePath, childIndex);
-		}
-		const matched = findChildUsageSpan(childIndex, occurrence.child.usage);
-		if (matched) return matched;
-	}
-	return null;
-}
-
-function reconcileToolUsageGroup(occurrences: ToolUsageOccurrence[], index: ToolReconciliationIndex): SessionMessage[] {
-	const representative = occurrences[0]!.tool;
-	const reportedUsage = occurrences.find((occurrence) => occurrence.tool.reportedUsage)?.tool.reportedUsage ?? null;
-	const childGroups = new Map<string, ChildUsageOccurrence[]>();
-	for (const occurrence of occurrences) {
-		for (const child of occurrence.tool.children) {
-			const key = `${child.resultIndex}:${usageTokenKey(child.usage)}:${usageCostUnits(child.usage.cost)}`;
-			let group = childGroups.get(key);
-			if (!group) {
-				group = [];
-				childGroups.set(key, group);
-			}
-			group.push({ ...occurrence, child });
-		}
-	}
-
-	const covered = emptyUsageAmount();
-	const uncovered: ChildToolUsage[] = [];
-	for (const childOccurrences of childGroups.values()) {
-		const child = childOccurrences[0]!.child;
-		const matched = matchedChildUsage(childOccurrences, index);
-		if (matched) addUsageAmount(covered, matched);
-		else uncovered.push(child);
-	}
-
-	if (reportedUsage) {
-		const canSubtract =
-			USAGE_FIELDS.every((field) => covered[field] <= reportedUsage[field]) &&
-			usageCostUnits(covered.cost) <= usageCostUnits(reportedUsage.cost);
-		const residual = canSubtract
-			? {
-					cost: Math.max(0, reportedUsage.cost - covered.cost),
-					input: reportedUsage.input - covered.input,
-					output: reportedUsage.output - covered.output,
-					cacheRead: reportedUsage.cacheRead - covered.cacheRead,
-					cacheWrite: reportedUsage.cacheWrite - covered.cacheWrite,
-					reasoning: Math.max(0, reportedUsage.reasoning - covered.reasoning),
-				}
-			: reportedUsage;
-		return usageAmountHasValue(residual) ? [auxiliaryMessage(residual, representative.timestamp, representative.sourceId)] : [];
-	}
-
-	// Before Pi 0.81, recognised nested-agent tools could only persist exact
-	// child usage in details. Count just the children not already represented
-	// by a recursively scanned session.
-	return uncovered.map((child) => {
-		const childSourceId = representative.sourceId ? `${representative.sourceId}:child:${child.resultIndex}` : "";
-		return auxiliaryMessage(child.usage, representative.timestamp, childSourceId);
-	});
-}
-
-function reconcileAllToolUsages(
-	states: Map<string, CachedFileState>,
-	index: ToolReconciliationIndex
-): Map<string, SessionMessage[]> {
-	const groups = new Map<string, ToolUsageOccurrence[]>();
-	for (const [parentFilePath, state] of states) {
+function resolvedToolChildIdentities(states: Map<string, CachedFileState>, index: ScannedSessionIndex): Set<string> {
+	const resolved = new Set<string>();
+	for (const [filePath, state] of states) {
 		for (const tool of state.parsed.toolUsages) {
-			const key = toolUsageIdentity(tool);
-			let group = groups.get(key);
-			if (!group) {
-				group = [];
-				groups.set(key, group);
+			if (!tool.sourceId) continue;
+			for (const child of tool.children) {
+				if (childSessionScanned(filePath, tool, child, index)) resolved.add(toolChildIdentity(tool, child));
 			}
-			group.push({ parentFilePath, tool });
 		}
 	}
-
-	const byParentFile = new Map<string, SessionMessage[]>();
-	for (const occurrences of groups.values()) {
-		const parentFilePath = occurrences[0]!.parentFilePath;
-		const messages = reconcileToolUsageGroup(occurrences, index);
-		if (messages.length === 0) continue;
-		const existing = byParentFile.get(parentFilePath);
-		if (existing) existing.push(...messages);
-		else byParentFile.set(parentFilePath, messages);
-	}
-	return byParentFile;
+	return resolved;
 }
 
+function toolUsageMessages(
+	parentFilePath: string,
+	tool: ToolUsageRecord,
+	index: ScannedSessionIndex,
+	resolvedChildren: Set<string>
+): SessionMessage[] {
+	const scanned = (child: ChildToolUsage) =>
+		childSessionScanned(parentFilePath, tool, child, index) ||
+		(tool.sourceId !== "" && resolvedChildren.has(toolChildIdentity(tool, child)));
+	if (tool.reportedUsage) {
+		if (tool.children.length > 0 && tool.children.every(scanned)) return [];
+		return [auxiliaryMessage(tool.reportedUsage, tool.timestamp, tool.sourceId)];
+	}
+	// Before Pi 0.81, recognised nested-agent tools persisted per-child usage in
+	// details only. Count just the children whose sessions this scan cannot see.
+	return tool.children
+		.filter((child) => !scanned(child))
+		.map((child) => auxiliaryMessage(child.usage, tool.timestamp, tool.sourceId ? `${tool.sourceId}:child:${child.resultIndex}` : ""));
+}
 // =============================================================================
 // Collection orchestration
 // =============================================================================
@@ -1684,8 +1535,8 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 	const costByDayIdx = new Map<number, number>();
 	const seenSessions = new Set<string>();
 	const seenHashes = new Set<string>();
-	const toolReconciliation = buildToolReconciliationIndex(current);
-	const reconciledToolMessages = reconcileAllToolUsages(current, toolReconciliation);
+	const scannedSessions = buildScannedSessionIndex(current);
+	const resolvedToolChildren = resolvedToolChildIdentities(current, scannedSessions);
 	let processedFiles = 0;
 
 	for (const filePath of filePaths) {
@@ -1700,8 +1551,8 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 		// Deduplicate copied history across branched session files, computing
 		// adjacency metadata (idle gaps, previous context) on the raw file order
 		// so branch copies do not distort miss classification.
-		const toolMessages = reconciledToolMessages.get(filePath);
-		const rawMsgs = toolMessages ? [...state.parsed.messages, ...toolMessages] : state.parsed.messages;
+		const toolMessages = state.parsed.toolUsages.flatMap((tool) => toolUsageMessages(filePath, tool, scannedSessions, resolvedToolChildren));
+		const rawMsgs = toolMessages.length > 0 ? [...state.parsed.messages, ...toolMessages] : state.parsed.messages;
 		const deduped: SessionMessage[] = [];
 		const meta: MessageMeta[] = [];
 		let previousAssistant: SessionMessage | null = null;

--- a/usage-extension/package.json
+++ b/usage-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-usage-extension",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Usage statistics dashboard for Pi sessions.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Summary
- Replace 0.9.3's exact contiguous token-and-cost vector matching, picodollar identity keys, and residual arithmetic (~250 lines) with a simple rule: **scanned child session files are the record** — when every child session behind a nested-agent report is part of the scan, the parent's aggregate is skipped; otherwise the report is counted under `Tools / summaries`.
- Resolved child identities are still unioned across copied parent history (branch copies change runId-derived paths), via a small `Set` of `id:ts:index` keys instead of vector grouping.
- Cache stays **v5** — no rebuild on upgrade. The allocation-safe large-line parser is retained.
- `usage-extension` → 0.9.4, root → 0.1.61. Net **−150 lines** in `data.ts`.

## Trade-offs (documented in changelog)
- Crash-truncated child session → slight undercount; partially-missing child set → full aggregate counted (slight overcount). Neither appeared in the audit corpus.

## Validation
- 62/62 tests, focused `tsc`, `git diff --check`, pack dry-run (11 files)
- Live 10 GB / 6,166-session corpus, back-to-back warm runs vs 0.9.3: **identical totals, identical session sets, identical `Tools` cost ($691.114318) to the femtodollar**
- Cold ~10.2 s / warm ~0.8 s (unchanged vs 0.9.3)
