### PR TITLE
feat(usage): Add current calendar month as period

### DIFF
--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -16,6 +16,8 @@ const TS_LAST_WEEK = new Date(2026, 6, 10, 10, 0, 0).getTime(); // Friday last w
 const TS_OLD = new Date(2026, 5, 1, 10, 0, 0).getTime(); // 1 June — outside the 30-day window
 const TS_30D_EDGE_IN = new Date(2026, 5, 16, 0, 0, 0).getTime(); // midnight 29 days before 15 July — first instant inside
 const TS_30D_EDGE_OUT = new Date(2026, 5, 15, 23, 59, 59).getTime(); // one second earlier — outside
+const TS_MONTH_EDGE_IN = new Date(2026, 6, 1, 0, 0, 0).getTime(); // first instant of July
+const TS_MONTH_EDGE_OUT = new Date(2026, 5, 30, 23, 59, 59).getTime(); // final second of June
 
 function fixture(t) {
 	const root = mkdtempSync(join(tmpdir(), "usage-data-"));
@@ -367,6 +369,10 @@ test("collectUsageData aggregates periods, providers, and dedupes branched histo
 	assert.equal(data.last30Days.totals.messages, 3);
 	assert.equal(data.last30Days.totals.cost, 7);
 	assert.equal(data.last30Days.totals.sessions, 2);
+	// All three messages are in the current calendar month (July).
+	assert.equal(data.monthly.totals.messages, 3);
+	assert.equal(data.monthly.totals.cost, 7);
+	assert.equal(data.monthly.totals.sessions, 2);
 
 	// Provider breakdown.
 	const anthropic = data.allTime.providers.get("anthropic");
@@ -645,6 +651,26 @@ test("collectUsageData buckets the rolling 30-day window from midnight 29 days b
 	// The 30-day window overlaps but does not replace the week buckets.
 	assert.equal(data.lastWeek.totals.cost, 4);
 	assert.equal(data.today.totals.cost, 8);
+});
+
+test("collectUsageData buckets Monthly from local midnight on the first day", async (t) => {
+	const { sessionsDir, cachePath } = fixture(t);
+	writeFileSync(
+		join(sessionsDir, "a.jsonl"),
+		[
+			sessionLine("s1", TS_MONTH_EDGE_OUT),
+			assistantLine({ ts: TS_MONTH_EDGE_OUT, cost: 1 }),
+			assistantLine({ ts: TS_MONTH_EDGE_IN, cost: 2 }),
+			assistantLine({ ts: TS_TODAY, cost: 4 }),
+		].join("\n") + "\n"
+	);
+
+	const data = await collectUsageData({ sessionsDir, cachePath, now: NOW });
+	assert.equal(data.allTime.totals.messages, 3);
+	assert.equal(data.monthly.totals.messages, 2);
+	assert.equal(data.monthly.totals.cost, 6);
+	assert.equal(data.monthly.totals.sessions, 1);
+	assert.equal(data.bounds.monthStartMs, TS_MONTH_EDGE_IN);
 });
 
 test("collectUsageData ignores files without a session header", async (t) => {

--- a/tests/usage-data.test.mjs
+++ b/tests/usage-data.test.mjs
@@ -671,6 +671,11 @@ test("collectUsageData buckets Monthly from local midnight on the first day", as
 	assert.equal(data.monthly.totals.cost, 6);
 	assert.equal(data.monthly.totals.sessions, 1);
 	assert.equal(data.bounds.monthStartMs, TS_MONTH_EDGE_IN);
+	const june = new Date(2026, 5, 1).getTime();
+	assert.equal(data.months.get(june).totals.cost, 1);
+	assert.equal(data.months.get(june).totals.sessions, 1);
+	assert.equal(data.months.get(june).providers.get("anthropic").cost, 1);
+	assert.ok(data.months.get(june).insights.insights.length > 0);
 });
 
 test("collectUsageData ignores files without a session header", async (t) => {

--- a/tests/usage-graph.test.mjs
+++ b/tests/usage-graph.test.mjs
@@ -21,6 +21,7 @@ const BOUNDS = {
 	weekStartMs: new Date(2026, 6, 13, 0, 0, 0).getTime(), // Monday
 	lastWeekStartMs: new Date(2026, 6, 6, 0, 0, 0).getTime(),
 	last30DaysStartMs: new Date(2026, 5, 16, 0, 0, 0).getTime(),
+	monthStartMs: new Date(2026, 6, 1, 0, 0, 0).getTime(),
 	nowMs: NOW,
 };
 
@@ -196,6 +197,18 @@ test("buildGraphModel uses daily buckets and the domain rules per period", () =>
 	assert.equal(m30.series[0].total, 3, "out-of-window usage must be excluded");
 	assert.equal(m30.domainStartMs, BOUNDS.last30DaysStartMs);
 	assert.equal(m30.domainEndMs, NOW);
+
+	const monthly = buildGraphModel(hourly, {
+		period: "monthly",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: false,
+		bounds: BOUNDS,
+	});
+	assert.equal(monthly.bucketMs, DAY);
+	assert.equal(monthly.series[0].total, 2, "previous-month usage must be excluded");
+	assert.equal(monthly.domainStartMs, BOUNDS.monthStartMs);
+	assert.equal(monthly.domainEndMs, NOW);
 
 	// lastWeek has a fixed end (this Monday), not now.
 	const lw = buildGraphModel(hourly, {

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- **Monthly period.** New tab labelled with the current month and year (for example, `Jul 2026`), covering the calendar month from local midnight on the first day. Available in graphs, table, insights, and exports.
+- **Monthly period.** New `‹Mon YYYY›` tab covering a calendar month in graphs, table, insights, and exports. Use `[` / `]` to select the previous or next month with recorded usage.
 
 ## [0.9.4] - 2026-07-22
 

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Monthly period.** New tab labelled with the current month and year (for example, `Jul 2026`), covering the calendar month from local midnight on the first day. Available in graphs, table, insights, and exports.
+
 ## [0.9.4] - 2026-07-22
 
 ### Changed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -149,10 +149,10 @@ Thinking levels are replayed from `thinking_level_change` entries in each sessio
 | **This Week** | From Monday 00:00 of the current week |
 | **Last Week** | Previous week (Monday 00:00 → this Monday 00:00) |
 | **Last 30 Days** | Rolling window: the last 30 calendar days including today (from midnight 29 days back) |
-| **Mon YYYY** *(e.g. Jul 2026)* | Current calendar month, from local midnight on the first day |
+| **‹Mon YYYY›** *(e.g. ‹Jul 2026›)* | Selected calendar month |
 | **All Time** | All recorded sessions |
 
-Use `Tab` or `←`/`→` to switch between periods.
+Use `Tab` or `←`/`→` to switch between periods. On the monthly period, `[` and `]` select the previous or next month with recorded usage.
 
 ### Timezone
 
@@ -180,6 +180,7 @@ On narrow terminals, `/usage` automatically switches to a compact table instead 
 | Key | Action |
 |-----|--------|
 | `Tab` / `←` `→` | Switch time period |
+| `[` `]` | Select previous/next recorded month *(monthly period)* |
 | `↑` `↓` | Select provider *(table)* / move legend cursor *(graphs)* |
 | `Enter` / `Space` | Expand/collapse provider *(table)* / toggle series visibility *(graphs)* |
 | `v` | Cycle Graphs → Table → Insights view |

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -136,7 +136,7 @@ The **Graphs** view plots usage over time for the active period as a braille lin
 - **Grouping** (`g` to cycle): by provider, by model, by thinking level, or total only. The top 6 series are shown individually; the rest merge into an `other` series. A bold **Total** line is always drawn.
 - **Cumulative vs per-bucket** (`c` to toggle): running total across the period (default), or the raw per-bucket rate.
 - **Filtering**: move the legend cursor with `↑`/`↓` and toggle series visibility with `Enter`/`Space` (`a` shows all again). The y-axis rescales to the visible series — hide the big lines to zoom into the small ones.
-- **Buckets**: hourly for Today / This Week / Last Week, daily for Last 30 Days / All Time.
+- **Buckets**: hourly for Today / This Week / Last Week, daily for Last 30 Days / Monthly / All Time.
 - **Line clipping**: every series (provider, model, thinking level, `other`, Total) is drawn only between its first and last bucket with usage, so late-starting or retired series don't drag a flat zero/flat tail across the whole period.
 
 Thinking levels are replayed from `thinking_level_change` entries in each session file; messages before the first recorded change appear as `unknown`. Auxiliary usage has no reliable thinking-level attribution and appears as `Tools/summaries` in that grouping. Reasoning token counts come from `usage.reasoning` where providers report them; pi only records this field since **pi 0.80.3 (30 June 2026)**, so earlier sessions show zero reasoning tokens even though thinking models were in use.
@@ -149,6 +149,7 @@ Thinking levels are replayed from `thinking_level_change` entries in each sessio
 | **This Week** | From Monday 00:00 of the current week |
 | **Last Week** | Previous week (Monday 00:00 → this Monday 00:00) |
 | **Last 30 Days** | Rolling window: the last 30 calendar days including today (from midnight 29 days back) |
+| **Mon YYYY** *(e.g. Jul 2026)* | Current calendar month, from local midnight on the first day |
 | **All Time** | All recorded sessions |
 
 Use `Tab` or `←`/`→` to switch between periods.

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -161,6 +161,8 @@ export interface UsageData {
 	last30Days: TimeFilteredStats;
 	monthly: TimeFilteredStats;
 	allTime: TimeFilteredStats;
+	/** Calendar-month start (local ms) → stats. */
+	months: Map<number, TimeFilteredStats>;
 	/** Deduped usage bucketed by hour start (ms) → series key → metrics. */
 	hourly: Map<number, Map<HourlyKey, HourlyCell>>;
 	bounds: PeriodBounds;
@@ -1058,13 +1060,15 @@ export function projectLabelFromCwd(cwd: string): string {
 }
 
 function emptyUsageData(bounds: PeriodBounds): UsageData {
+	const monthly = emptyTimeFilteredStats();
 	return {
 		today: emptyTimeFilteredStats(),
 		thisWeek: emptyTimeFilteredStats(),
 		lastWeek: emptyTimeFilteredStats(),
 		last30Days: emptyTimeFilteredStats(),
-		monthly: emptyTimeFilteredStats(),
+		monthly,
 		allTime: emptyTimeFilteredStats(),
+		months: new Map([[bounds.monthStartMs, monthly]]),
 		hourly: new Map(),
 		bounds,
 	};
@@ -1146,9 +1150,11 @@ function addMessagesToUsageData(
 	last30DaysStartMs: number,
 	monthStartMs: number,
 	rawByPeriod: Record<TabName, PeriodRawData>,
+	rawByMonth: Map<number, PeriodRawData>,
 	costByDayIdx: Map<number, number>
 ): void {
 	const sessionContributed = { today: false, thisWeek: false, lastWeek: false, last30Days: false, monthly: false, allTime: false };
+	const monthsContributed = new Set<number>();
 
 	for (let mi = 0; mi < messages.length; mi++) {
 		const msg = messages[mi]!;
@@ -1176,46 +1182,31 @@ function addMessagesToUsageData(
 			cacheRead: msg.cacheRead,
 			cacheWrite: msg.cacheWrite,
 		};
-
-		for (const period of periods) {
-			const stats = data[period];
-
+		const add = (stats: TimeFilteredStats, raw: PeriodRawData): void => {
 			let providerStats = stats.providers.get(msg.provider);
 			if (!providerStats) {
 				providerStats = emptyProviderStats();
 				stats.providers.set(msg.provider, providerStats);
 			}
-
 			let modelStats = providerStats.models.get(msg.model);
 			if (!modelStats) {
 				modelStats = emptyModelStats();
 				providerStats.models.set(msg.model, modelStats);
 			}
-
 			const isAssistant = msg.source === "assistant";
 			modelStats.sessions.add(sessionId);
 			accumulateStats(modelStats, msg.cost, tokens, isAssistant);
-
 			providerStats.sessions.add(sessionId);
 			accumulateStats(providerStats, msg.cost, tokens, isAssistant);
-
 			accumulateStats(stats.totals, msg.cost, tokens, isAssistant);
-			sessionContributed[period] = true;
-
-			const raw = rawByPeriod[period];
 			raw.totalCost += msg.cost;
 			raw.projectCosts.set(project, (raw.projectCosts.get(project) ?? 0) + msg.cost);
 			raw.sessionCosts.set(sessionId, (raw.sessionCosts.get(sessionId) ?? 0) + msg.cost);
-
-			// Auxiliary calls belong in accounting totals, project/session mix, and
-			// burn trend. They are not assistant turns, so do not let their synthetic
-			// model identity or nested context distort turn/cache insights.
 			if (!isAssistant) {
 				raw.auxiliaryCost += msg.cost;
-				continue;
+				return;
 			}
 			raw.assistantCost += msg.cost;
-
 			const ctx = msg.input + msg.cacheRead + msg.cacheWrite;
 			if (ctx >= CTX_TAX_THRESHOLD) {
 				raw.ctxHigh.cost += msg.cost;
@@ -1225,11 +1216,7 @@ function addMessagesToUsageData(
 				raw.ctxLow.messages++;
 			}
 			if (mm.isSessionStart) raw.upfrontCost += msg.cost;
-			if (
-				!msg.afterCompaction &&
-				mm.prevCtx >= MISS_MIN_PREV_CONTEXT &&
-				msg.cacheRead < Math.min(MISS_MAX_CACHE_READ, 0.3 * mm.prevCtx)
-			) {
+			if (!msg.afterCompaction && mm.prevCtx >= MISS_MIN_PREV_CONTEXT && msg.cacheRead < Math.min(MISS_MAX_CACHE_READ, 0.3 * mm.prevCtx)) {
 				if (mm.gapMs > TTL_GAP_MS) raw.ttlMissCost += msg.cost;
 				else if (mm.gapMs >= 0 && mm.modelSwitched) raw.modelSwitchMissCost += msg.cost;
 				else if (mm.gapMs >= 0) raw.prefixMissCost += msg.cost;
@@ -1238,6 +1225,23 @@ function addMessagesToUsageData(
 			raw.outputTokens += msg.output;
 			raw.cacheReadTokens += msg.cacheRead;
 			raw.freshTokens += msg.input + msg.cacheWrite;
+		};
+
+		for (const period of periods) {
+			add(data[period], rawByPeriod[period]);
+			sessionContributed[period] = true;
+		}
+		if (msg.timestamp > 0) {
+			const month = new Date(msg.timestamp);
+			month.setDate(1);
+			month.setHours(0, 0, 0, 0);
+			const monthMs = month.getTime();
+			if (monthMs !== monthStartMs) {
+				if (!data.months.has(monthMs)) data.months.set(monthMs, emptyTimeFilteredStats());
+				if (!rawByMonth.has(monthMs)) rawByMonth.set(monthMs, emptyPeriodRawData());
+				add(data.months.get(monthMs)!, rawByMonth.get(monthMs)!);
+				monthsContributed.add(monthMs);
+			}
 		}
 	}
 
@@ -1245,7 +1249,8 @@ function addMessagesToUsageData(
 	if (sessionContributed.thisWeek) data.thisWeek.totals.sessions++;
 	if (sessionContributed.lastWeek) data.lastWeek.totals.sessions++;
 	if (sessionContributed.last30Days) data.last30Days.totals.sessions++;
-	if (sessionContributed.monthly) data.monthly.totals.sessions++;
+	if (sessionContributed.monthly) data.months.get(monthStartMs)!.totals.sessions++;
+	for (const monthMs of monthsContributed) data.months.get(monthMs)!.totals.sessions++;
 	if (sessionContributed.allTime) data.allTime.totals.sessions++;
 }
 
@@ -1545,6 +1550,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 		monthly: emptyPeriodRawData(),
 		allTime: emptyPeriodRawData(),
 	};
+	const rawByMonth = new Map([[monthStartMs, rawByPeriod.monthly]]);
 	const costByDayIdx = new Map<number, number>();
 	const seenSessions = new Set<string>();
 	const seenHashes = new Set<string>();
@@ -1611,6 +1617,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 			last30DaysStartMs,
 			monthStartMs,
 			rawByPeriod,
+			rawByMonth,
 			costByDayIdx
 		);
 	}
@@ -1626,6 +1633,9 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 
 	for (const period of TAB_ORDER) {
 		data[period].insights = computeInsights(rawByPeriod[period], trend);
+	}
+	for (const [monthMs, raw] of rawByMonth) {
+		data.months.get(monthMs)!.insights = computeInsights(raw, trend);
 	}
 
 	return data;

--- a/usage-extension/data.ts
+++ b/usage-extension/data.ts
@@ -150,6 +150,7 @@ export interface PeriodBounds {
 	weekStartMs: number;
 	lastWeekStartMs: number;
 	last30DaysStartMs: number;
+	monthStartMs: number;
 	nowMs: number;
 }
 
@@ -158,15 +159,16 @@ export interface UsageData {
 	thisWeek: TimeFilteredStats;
 	lastWeek: TimeFilteredStats;
 	last30Days: TimeFilteredStats;
+	monthly: TimeFilteredStats;
 	allTime: TimeFilteredStats;
 	/** Deduped usage bucketed by hour start (ms) → series key → metrics. */
 	hourly: Map<number, Map<HourlyKey, HourlyCell>>;
 	bounds: PeriodBounds;
 }
 
-export type TabName = "today" | "thisWeek" | "lastWeek" | "last30Days" | "allTime";
+export type TabName = "today" | "thisWeek" | "lastWeek" | "last30Days" | "monthly" | "allTime";
 
-export const TAB_ORDER: TabName[] = ["today", "thisWeek", "lastWeek", "last30Days", "allTime"];
+export const TAB_ORDER: TabName[] = ["today", "thisWeek", "lastWeek", "last30Days", "monthly", "allTime"];
 
 export type UsageSource = "assistant" | "auxiliary";
 
@@ -1061,6 +1063,7 @@ function emptyUsageData(bounds: PeriodBounds): UsageData {
 		thisWeek: emptyTimeFilteredStats(),
 		lastWeek: emptyTimeFilteredStats(),
 		last30Days: emptyTimeFilteredStats(),
+		monthly: emptyTimeFilteredStats(),
 		allTime: emptyTimeFilteredStats(),
 		hourly: new Map(),
 		bounds,
@@ -1113,7 +1116,8 @@ function getPeriodsForTimestamp(
 	todayMs: number,
 	weekStartMs: number,
 	lastWeekStartMs: number,
-	last30DaysStartMs: number
+	last30DaysStartMs: number,
+	monthStartMs: number
 ): TabName[] {
 	const periods: TabName[] = ["allTime"];
 	if (timestamp >= todayMs) periods.push("today");
@@ -1123,6 +1127,7 @@ function getPeriodsForTimestamp(
 		periods.push("lastWeek");
 	}
 	if (timestamp >= last30DaysStartMs) periods.push("last30Days");
+	if (timestamp >= monthStartMs) periods.push("monthly");
 	return periods;
 }
 
@@ -1139,10 +1144,11 @@ function addMessagesToUsageData(
 	weekStartMs: number,
 	lastWeekStartMs: number,
 	last30DaysStartMs: number,
+	monthStartMs: number,
 	rawByPeriod: Record<TabName, PeriodRawData>,
 	costByDayIdx: Map<number, number>
 ): void {
-	const sessionContributed = { today: false, thisWeek: false, lastWeek: false, last30Days: false, allTime: false };
+	const sessionContributed = { today: false, thisWeek: false, lastWeek: false, last30Days: false, monthly: false, allTime: false };
 
 	for (let mi = 0; mi < messages.length; mi++) {
 		const msg = messages[mi]!;
@@ -1159,7 +1165,7 @@ function addMessagesToUsageData(
 
 		addToHourlyBuckets(data.hourly, msg);
 
-		const periods = getPeriodsForTimestamp(msg.timestamp, todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs);
+		const periods = getPeriodsForTimestamp(msg.timestamp, todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs, monthStartMs);
 		const tokens = {
 			// Count fresh tokens processed this turn.
 			// Include cacheWrite because those prompt tokens were newly written and billed.
@@ -1239,6 +1245,7 @@ function addMessagesToUsageData(
 	if (sessionContributed.thisWeek) data.thisWeek.totals.sessions++;
 	if (sessionContributed.lastWeek) data.lastWeek.totals.sessions++;
 	if (sessionContributed.last30Days) data.last30Days.totals.sessions++;
+	if (sessionContributed.monthly) data.monthly.totals.sessions++;
 	if (sessionContributed.allTime) data.allTime.totals.sessions++;
 }
 
@@ -1401,6 +1408,11 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 	startOfLast30Days.setDate(startOfLast30Days.getDate() - 29);
 	const last30DaysStartMs = startOfLast30Days.getTime();
 
+	// Current calendar month from local midnight on the first day.
+	const startOfMonth = new Date(startOfToday);
+	startOfMonth.setDate(1);
+	const monthStartMs = startOfMonth.getTime();
+
 	// 1. Discover session files.
 	const filePaths = await getAllSessionFiles(sessionsDir, signal);
 	if (signal?.aborted) return null;
@@ -1524,12 +1536,13 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 	}
 
 	// 6. Aggregate in sorted path order with cross-file dedupe.
-	const data = emptyUsageData({ todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs, nowMs: now.getTime() });
+	const data = emptyUsageData({ todayMs, weekStartMs, lastWeekStartMs, last30DaysStartMs, monthStartMs, nowMs: now.getTime() });
 	const rawByPeriod: Record<TabName, PeriodRawData> = {
 		today: emptyPeriodRawData(),
 		thisWeek: emptyPeriodRawData(),
 		lastWeek: emptyPeriodRawData(),
 		last30Days: emptyPeriodRawData(),
+		monthly: emptyPeriodRawData(),
 		allTime: emptyPeriodRawData(),
 	};
 	const costByDayIdx = new Map<number, number>();
@@ -1596,6 +1609,7 @@ export async function collectUsageData(options: CollectUsageOptions = {}): Promi
 			weekStartMs,
 			lastWeekStartMs,
 			last30DaysStartMs,
+			monthStartMs,
 			rawByPeriod,
 			costByDayIdx
 		);

--- a/usage-extension/graph.ts
+++ b/usage-extension/graph.ts
@@ -120,6 +120,8 @@ function domainFor(period: TabName, bounds: PeriodBounds, hourly: Map<number, Ma
 			return { startMs: bounds.lastWeekStartMs, endMs: bounds.weekStartMs };
 		case "last30Days":
 			return { startMs: bounds.last30DaysStartMs, endMs: bounds.nowMs };
+		case "monthly":
+			return { startMs: bounds.monthStartMs, endMs: bounds.nowMs };
 		case "allTime": {
 			let first = Number.POSITIVE_INFINITY;
 			for (const hour of hourly.keys()) if (hour < first) first = hour;

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -2,7 +2,7 @@
  * /usage - Usage statistics dashboard
  *
  * Shows an inline view with usage stats grouped by provider.
- * - Tab cycles: Today → This Week → Last Week → All Time
+ * - Tab cycles: Today → This Week → Last Week → Last 30 Days → Monthly → All Time
  * - Arrow keys navigate providers
  * - Enter expands/collapses to show models
  *
@@ -274,6 +274,7 @@ const TAB_LABELS: Record<TabName, string> = {
 	thisWeek: "This Week",
 	lastWeek: "Last Week",
 	last30Days: "Last 30 Days",
+	monthly: "Monthly",
 	allTime: "All Time",
 };
 
@@ -753,12 +754,16 @@ class UsageComponent {
 
 	private renderTabs(width: number, layout: TableLayout): string[] {
 		const th = this.theme;
+		const tabLabel = (tab: TabName): string =>
+			tab === "monthly"
+				? new Date(this.data.bounds.monthStartMs).toLocaleDateString(undefined, { month: "short", year: "numeric" })
+				: TAB_LABELS[tab];
 		const fullTabs = TAB_ORDER.map((tab) => {
-			const label = TAB_LABELS[tab];
+			const label = tabLabel(tab);
 			return tab === this.activeTab ? th.fg("accent", `[${label}]`) : th.fg("dim", ` ${label} `);
 		}).join("  ");
 
-		const activeTabOnly = th.fg("accent", `[${TAB_LABELS[this.activeTab]}]`);
+		const activeTabOnly = th.fg("accent", `[${tabLabel(this.activeTab)}]`);
 		const tabLine = pickFittingText(width, [
 			fullTabs,
 			`${activeTabOnly}  ${th.fg("dim", "[Tab/←→]")}`,

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -15,7 +15,7 @@ import { CancellableLoader, Container, Spacer, matchesKey, visibleWidth, truncat
 
 import { collectUsageData, getAgentDir, TAB_ORDER } from "./data";
 import type { CollectProgress } from "./data";
-import type { BaseStats, ProviderStats, TabName, TotalStats, UsageData } from "./data";
+import type { BaseStats, ProviderStats, TabName, TimeFilteredStats, TotalStats, UsageData } from "./data";
 import {
 	buildGraphModel,
 	renderChart,
@@ -280,6 +280,7 @@ const TAB_LABELS: Record<TabName, string> = {
 
 class UsageComponent {
 	private activeTab: TabName = "allTime";
+	private selectedMonthMs: number;
 	private viewMode: ViewMode = "graph";
 	private data: UsageData;
 	private selectedIndex = 0;
@@ -305,11 +306,25 @@ class UsageComponent {
 		this.requestRender = requestRender;
 		this.done = done;
 		this.data = data;
+		this.selectedMonthMs = data.bounds.monthStartMs;
 		this.updateProviderOrder();
 	}
 
+	private activeStats(): TimeFilteredStats {
+		return this.activeTab === "monthly" ? this.data.months.get(this.selectedMonthMs)! : this.data[this.activeTab];
+	}
+
+	private shiftMonth(delta: number): void {
+		const months = [...this.data.months.keys()].sort((a, b) => a - b);
+		const next = months[months.indexOf(this.selectedMonthMs) + delta];
+		if (next === undefined) return;
+		this.selectedMonthMs = next;
+		this.updateProviderOrder();
+		this.exportNote = null;
+	}
+
 	private updateProviderOrder(): void {
-		const stats = this.data[this.activeTab];
+		const stats = this.activeStats();
 		this.providerOrder = Array.from(stats.providers.entries())
 			.sort((a, b) => b[1].cost - a[1].cost)
 			.map(([name]) => name);
@@ -327,7 +342,7 @@ class UsageComponent {
 	 * the totals row and exports reflect exactly what is on screen.
 	 */
 	private visibleTable(): { providers: Map<string, ProviderStats>; totals: TotalStats } {
-		const stats = this.data[this.activeTab];
+		const stats = this.activeStats();
 		const q = this.tableFilter.trim().toLowerCase();
 		// Always iterate providerOrder so the map is cost-sorted — selection
 		// indexes and rendered rows must agree on ordering.
@@ -416,6 +431,12 @@ class UsageComponent {
 
 		if (matchesKey(data, "e")) {
 			this.exportCurrentView();
+			this.requestRender();
+			return;
+		}
+
+		if (this.activeTab === "monthly" && (data === "[" || data === "]")) {
+			this.shiftMonth(data === "[" ? -1 : 1);
 			this.requestRender();
 			return;
 		}
@@ -518,18 +539,22 @@ class UsageComponent {
 		const now = new Date();
 		let name: string;
 		let content: string;
-		const stats = this.data[this.activeTab];
+		const stats = this.activeStats();
+		const month = new Date(this.selectedMonthMs);
+		const period = this.activeTab === "monthly"
+			? `${month.getFullYear()}-${String(month.getMonth() + 1).padStart(2, "0")}`
+			: this.activeTab;
 		if (this.viewMode === "graph") {
 			const slice = `${this.graphCumulative ? "cumulative" : "per-bucket"}-${this.graphMetric}-by-${this.graphGroupBy}`;
-			name = exportFileName("graph", this.activeTab, slice, "csv", now);
+			name = exportFileName("graph", period, slice, "csv", now);
 			content = buildGraphCsv(this.buildGraphModelForView());
 		} else if (this.viewMode === "insights") {
-			name = exportFileName("insights", this.activeTab, null, "json", now);
-			content = buildInsightsJson(this.activeTab, stats.totals, stats.insights.insights);
+			name = exportFileName("insights", period, null, "json", now);
+			content = buildInsightsJson(period, stats.totals, stats.insights.insights);
 		} else {
 			const visible = this.visibleTable();
 			const sliced = this.tableFilter.trim() !== "" || this.tableHidden.size > 0;
-			name = exportFileName("table", this.activeTab, sliced ? "filtered" : null, "csv", now);
+			name = exportFileName("table", period, sliced ? "filtered" : null, "csv", now);
 			content = buildTableCsv(visible.providers, visible.totals);
 		}
 		try {
@@ -552,13 +577,17 @@ class UsageComponent {
 	}
 
 	private buildGraphModelForView(): GraphModel {
+		const monthEnd = new Date(this.selectedMonthMs);
+		monthEnd.setMonth(monthEnd.getMonth() + 1);
 		return buildGraphModel(this.data.hourly, {
 			period: this.activeTab,
 			metric: this.graphMetric,
 			groupBy: this.graphGroupBy,
 			cumulative: this.graphCumulative,
 			hidden: this.graphHidden,
-			bounds: this.data.bounds,
+			bounds: this.activeTab === "monthly"
+				? { ...this.data.bounds, monthStartMs: this.selectedMonthMs, nowMs: Math.min(monthEnd.getTime(), this.data.bounds.nowMs) }
+				: this.data.bounds,
 		});
 	}
 
@@ -672,7 +701,7 @@ class UsageComponent {
 
 	private renderInsights(width: number): string[] {
 		const th = this.theme;
-		const stats = this.data[this.activeTab];
+		const stats = this.activeStats();
 		const { insights } = stats.insights;
 		const hasUsage =
 			stats.totals.messages > 0 ||
@@ -756,7 +785,7 @@ class UsageComponent {
 		const th = this.theme;
 		const tabLabel = (tab: TabName): string =>
 			tab === "monthly"
-				? new Date(this.data.bounds.monthStartMs).toLocaleDateString(undefined, { month: "short", year: "numeric" })
+				? `‹${new Date(this.selectedMonthMs).toLocaleDateString(undefined, { month: "short", year: "numeric" })}›`
 				: TAB_LABELS[tab];
 		const fullTabs = TAB_ORDER.map((tab) => {
 			const label = tabLabel(tab);
@@ -921,6 +950,7 @@ class UsageComponent {
 						"[↑↓] select  [q] close",
 						"[q] close",
 				  ];
+		if (this.activeTab === "monthly") variants.unshift(`[ / ] month  ${variants[0]}`);
 		const line = pickFittingText(width, variants);
 		return [...noteLines, this.theme.fg("dim", line)];
 	}


### PR DESCRIPTION
It is sometimes needed to report token costs per calendar month. This PR adds a period covering the current calendar month (starting at midnight on the first day of the month). The tab (header) is chosen to be an abbreviation of the month + year (e.g. `Jul 2026`), instead of the more generic "Monthly", in order to avoid confusion with the already existing "Last 30 days".

Note that this PR essentially follows #62, but only changes it to true calendar month instead of a rolling window of 30 days. It also includes a way to switch to previous months with "[" (previous) and "]" (next). It should be able to go through all the months for which there is a session available.