### PR TITLE
feat(session-recap): add configurable live recaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.62] - 2026-08-03
+
+### Changed
+- Bundle `@tmustier/pi-session-recap` 0.3.0 with strict layered JSON configuration, live `Done / Now / Next` recaps for long runs, bounded in-memory activity and transcripts, single-request scheduling, safe model fallback and templates, and focused lifecycle/configuration tests.
+
 ## [0.1.61] - 2026-07-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal extensions for the [Pi coding agent](https://github.com/badlogic/pi-mon
 | [/usage](usage-extension/) | 📊 Usage statistics dashboard. See cost, tokens, and messages by provider/model across Today, This Week, Last Week, and All Time — with a compact view for narrow terminals |
 | [/paste](raw-paste/) | Paste editable text, not [paste #1 +21 lines]. Running `/paste` with optional keybinding |
 | [/code](code-actions/) | Pick code blocks or inline snippets from assistant messages to copy, insert, or run with `/code` |
-| [session-recap](session-recap/) | While-you-were-away recap above the editor when you return to a session. Keeps you in flow while multi-clauding |
+| [session-recap](session-recap/) | Configurable live, away, idle, resume, and manual recaps with `Done / Now / Next` output |
 | [arcade](arcade/) | Play minigames while your tests run: 👾 sPIce-invaders, 👻 picman, 🏓 ping, 🧩 tetris, 🍄 mario-not |
 
 ## Agent Skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.3.0] - 2026-08-03
+
+### Added
+- Add shipped strict-JSON defaults plus deep-merged global, trusted-project, environment, and `--recap-config` overrides.
+- Add live recaps for long agent runs: first eligibility at 120 seconds, 90-second minimum refresh interval, meaningful-activity gating, current assistant/tool snapshots, and one scheduler/request slot.
+- Add safe text-only prompt/output templates and robust plain/fenced JSON parsing for default `Done / Now / Next` output.
+- Add deterministic tests for config precedence and failure safety, model fallback, templates, response parsing, focus parsing, live eligibility, completion-based throttling, long tools, fixed-length/capped tool updates, snapshot freshness, manual priority, and cleanup state.
+
+### Changed
+- Validate non-overlapping focus sequences, event names, non-empty provider/model candidates, model enums, integer counts, required positive caps, and Node's maximum timer delay before applying config; safely reattach focus reporting and clear renamed widget/status keys on reload.
+- Load environment and CLI config as separate layers, deduplicate identical paths at highest precedence, and report either missing configured file precisely.
+- Preserve current-request and newest persisted reserves before allocating capped live evidence; ignore empty assistant updates, clear cancelled drafting statuses, and remove completed tools from the running snapshot map.
+- Throttle visible live refreshes from successful completion rather than request start, and accumulate changed tool output beyond fixed-length/capped snapshots.
+- Move all consumer-tunable behavior from TypeScript defaults to `defaults.json`.
+- Default recap generation to `$active` with explicit `reasoning: "off"`, preventing implicit cross-provider transcript disclosure; Luna remains an explicit opt-in candidate.
+- Keep old behavior flags as deprecated in-memory overrides; JSON configuration is canonical.
+
+### Fixed
+- Ignore `<ctx.cwd>/.pi/session-recap.json` until Pi marks the project trusted; global and explicit environment/CLI config remain available.
+- Preserve newest streaming, finalized-assistant, running-tool, and tool-completion evidence under live caps, including `latest:` progress after long arguments.
+- Reserve transcript space for the current request and newest persisted detail before bounded live activity, including under small total caps.
+- Accept model IDs containing slashes by splitting candidates only at the first provider separator.
+- Preserve trailing errors and next steps when one assistant or tool-result entry exceeds its transcript cap.
+- Drain one pending away recap when `agent_end` clears and cancels the live request that owned the request slot while the terminal remains blurred.
+- Recheck automatic reason gates when delayed callbacks fire, cancel resume work on `agent_start`, and invalidate deferred away work on input, refocus, or shutdown.
+- Bound missing-end running-tool records with deterministic oldest-first eviction through `activity.maxRunningTools`.
+- Reject nested or stray template delimiters while preserving ordinary single braces in prose.
+
 ## [0.2.2] - 2026-07-21
 
 ### Fixed

--- a/session-recap/DESIGN.md
+++ b/session-recap/DESIGN.md
@@ -1,181 +1,67 @@
-# session-recap — design & plan
+# session-recap design
 
-> Status: **v0.2.1 — away-recap redesign + metadata-stable dedupe**  ·  Lives in `tmustier/pi-extensions/session-recap/`
-> v0.1 guessed at Claude Code's recap design; v0.2 is informed by the actual
-> implementation from the leaked Claude Code source (`tmustier/cc-inv`,
-> 2026-03-31): `src/services/awaySummary.ts` + `src/hooks/useAwaySummary.ts`.
+## Package boundary
 
-## Summary
+`session-recap` is available as a standalone npm package and as one extension in the `pi-extensions` collection. Runtime code for this extension is:
 
-When you've genuinely been away from a Pi session, a short recap is drafted
-while you're gone and parked above the editor so it's waiting when you return.
-Targets the "multi-clauding / multi-pi" workflow where several agent sessions
-run in parallel tabs.
+- `index.ts`: Pi event, timer, focus, widget, and cancellation adapter
+- `config.ts`: strict JSON loading, validation, precedence, deep merge, deprecated flag mapping
+- `recap.ts`: transcript, safe templates, model fallback, response parsing
+- `live-state.ts`: deterministic scheduler state and in-memory streaming/tool snapshot
+- `ui-state.ts`: request-owned drafting-status cleanup
+- `defaults.json`: all consumer-tunable defaults
 
-```
-✦ recap
-You're migrating the billing tables to the v2 schema; 4 of 7 are done and
-invoices.ts still fails its FK constraint. Next: fix the foreign key on
-line 142.
-```
+## Configuration boundary
 
-## What Claude Code actually does (from cc-inv)
+Each reload is atomic:
 
-| Aspect | Claude Code (leaked source) | session-recap v0.2 |
-|---|---|---|
-| Trigger | Blur → 5-min timer → generate while still away. Refocus cancels timer + in-flight. Timer fires mid-turn → pending bit, generate at turn end if still blurred. | Same shape, but 90s default + an extra trigger: turn ends while blurred (debounced 3s). Multi-tab agent workflows context-switch faster than CC's 5 min assumes. |
-| Idle fallback | None — focus state `unknown` (no DECSET 1004) = feature off. | Kept, but only armed when the terminal has *not* demonstrated focus support (no `ESC[I`/`ESC[O` seen this session). |
-| Output | Persistent dim `※` transcript system message (`away_summary` subtype), excluded from API context. | Transient widget above the editor (pi-idiomatic, non-polluting), cleared on next input. |
-| Model | `getSmallFastModel()` — Haiku or `ANTHROPIC_SMALL_FAST_MODEL`. Never the active model. | Active model (no auth surprises across custom providers) + `--recap-model` override. See trade-off below. |
-| Context | Last **30 raw messages** + session memory, instruction appended as a user message, `skipCacheWrite: true`. | Two-tier compact text transcript (~12k char cap). 30 raw messages is only affordable at Haiku pricing; on the active model it could be 30–80k tokens per throwaway hint. |
-| Prompt | "Write exactly 1-3 short sentences. Start by stating the high-level task — what they are building or debugging, not implementation details. Next: the concrete next step. **Skip status reports and commit recaps.**" | Adopted near-verbatim. This was v0.1's biggest miss — our old prompt asked for a status report, which is exactly what CC bans. |
-| Dedupe | Max one summary per user turn (`hasSummarySinceLastUserTurn`). | Recap-prompt fingerprinting (same prompt = no new model call, even if Pi appends metadata entries). |
-| In-flight abort on refocus | Yes — summary appended to transcript late would be weird. | No — a widget landing moments after return is exactly when it helps. |
-
-## Triggers (v0.2)
-
-| Trigger | Detection | Behaviour |
-|---|---|---|
-| Away timer | DECSET `?1004` focus-out, then `--recap-away-seconds` (default 90) of continuous blur | Generate and show; the widget is parked above the editor for when you return. |
-| Turn ends while away | `turn_end` while blurred, debounced `3s` | The prime multi-tab moment: the agent finished while you were in another tab. Debounce lets mid-loop `turn_end`→`turn_start` pairs pass without drafting. |
-| Idle fallback | `setTimeout` armed on `turn_end`, **only when focus reporting is unproven** | Generate after `--recap-idle-seconds` (default 120) of no input. Covers terminals without `?1004`. Disarmed permanently once a real focus event is seen. |
-| `/resume` / `/fork` | `session_start { reason: "resume" \| "fork" }` | Auto-recap the prior session so you know where you left off. |
-| Manual | `/recap` command | Generate now, bypass the activity gate. |
-
-All triggers share one in-flight slot (`AbortController`); the next `input`,
-`agent_start`, or `turn_start` cancels drafts and clears the widget.
-
-Removed from v0.1: draft-on-every-focus-out + reveal-on-focus-in with a
-min-away threshold (`--recap-focus-min-seconds`). That design fired a model
-call on every alt-tab and cancelled most of them; the blur-timer model spends
-one call only after a genuine absence, and the park/reveal/cancel machinery
-(`pendingRecap`, quick-glance suppression) disappears entirely.
-
-### Focus-out during long-running agent activity
-
-Unchanged from v0.1, and matches CC's pending bit: if an away/post-turn
-trigger fires while a turn is still loading, generation is deferred to
-`agent_end` (if still blurred). `--recap-during-active` opts back into
-mid-flight drafts.
-
-## Display
-
-- `ctx.ui.setWidget("session-recap", [...], { placement: "aboveEditor" })`
-- Accent-bold `✦ recap` header + up to 4 dim wrapped lines (~100 cols).
-- Cleared on: user input, new turn start, session reload, session shutdown.
-- **No session persistence.** CC appends a transcript message instead; for pi
-  a widget is idiomatic and avoids polluting the session file.
-
-## Model selection — decision (unchanged from v0.1)
-
-Default must not surprise users with auth/login issues.
-
-**Decision:** default to the **currently active model**, invoked as a tiny
-throwaway completion: no tools, reasoning disabled, `cacheRetention: "none"`,
-`maxTokens: 256`. Any OAuth / env-var / custom-provider credential the user
-already has just works. No active model / failed auth resolution → skip
-silently.
-
-- CC uses Haiku here. We deliberately diverge: pi sessions run against
-  arbitrary providers and there is no universally-available cheap model we can
-  assume auth for. The cost envelope is protected by the transcript cap
-  (~3k input tokens) rather than by the model choice.
-- `apiKey` may legitimately be absent when `ok: true` (env/ambient-auth
-  providers such as Bedrock) — only bail when auth resolution itself fails,
-  and pass `env` through to `completeSimple`.
-- Escape hatch: `--recap-model "<provider>/<id>"`.
-
-> **Import note:** as of pi 0.80.x, `completeSimple`/`getModel` live in
-> `@earendil-works/pi-ai/compat` — the root export dropped them, which
-> silently broke v0.1.3 at runtime.
-
-## Context fed to the model — two-tier transcript
-
-CC's insight: the recap's job is task re-orientation, and the task framing
-lives in the *conversation*, not in the last tool call. CC affords the last 30
-raw messages because it pays Haiku prices; we get the same orientation for
-~500 extra tokens by being selective:
-
-**Tier 1 — task framing (cheap):**
-- Most recent compaction or branch-summary entry, trimmed to 600 chars —
-  already-distilled task context (pi's analog of CC's session memory).
-- Up to 4 user prompts *before* the latest one, trimmed to 300 chars each.
-  Old assistant text and tool results add cost, not orientation.
-
-**Tier 2 — recent detail (since the last user message, inclusive):**
-- User text (≤1200 chars), assistant text (≤1200 chars)
-- Tool calls as `- <name>(<JSON args, ≤280 chars>)`
-- Tool results as `Result(<name>): <text, ≤400 chars>`
-
-Whole transcript capped at 12,000 chars (~3k tokens), so worst-case cost is
-unchanged from v0.1. The same builder serves resume/fork recaps (v0.1 passed
-the whole branch for resume; tier 1 now covers that need).
-
-## Prompt
-
-One user message plus a terse system prompt (some providers require a
-non-empty instruction string). Philosophy from CC: orient, don't report.
-
-```
-The user stepped away from this coding-agent session and is coming back.
-Write a short recap so they can re-enter flow.
-
-Rules:
-- Write 1-3 short sentences of plain text. No preamble, no markdown, no bullets.
-- Start by stating the high-level task — what the user is building, fixing, or
-  debugging — not implementation minutiae.
-- End with the concrete next step, if there is one.
-- Skip status reports and commit recaps; orient the reader instead.
-- If the last turn was aborted or errored, say so explicitly (e.g. "aborted
-  during X", "errored at Y").
-- Use file/function names where they matter. Max ~400 characters.
-
-<transcript>
-…
-</transcript>
+```text
+shipped defaults < global < project < explicit env < explicit CLI
 ```
 
-Post-processing: whitespace collapsed to single spaces, capped at 600 chars,
-soft-wrapped into ≤4 widget lines.
+The project layer participates only when `ctx.isProjectTrusted()` is true. This prevents an untrusted clone from configuring prompts or terminal focus sequences. Global, explicit environment, and explicit CLI layers remain user-controlled. Environment and CLI overrides are separate deep-merged layers; identical paths load once at their highest-precedence position.
 
-## Edge cases
+Each present override must parse as JSON, contain only known keys and events, match default value types, and pass semantic checks for enums, focus sequences, integer counts, caps, and Node's `2147483647` ms timer limit. Objects deep-merge; arrays replace. One bad layer rejects the reload and preserves the last valid canonical JSON config; deprecated flags derive a separate effective copy. Files are data, never imported or executed. Reload clears renamed widget/status keys and safely detaches then reattaches changed focus reporting configuration.
 
-1. **Turn still running when a trigger fires** — deferred to `agent_end` via
-   the pending bit (CC-equivalent). `--recap-during-active` opts out.
-2. **Repeated blur/refocus with no new activity** — recap-prompt fingerprinting skips
-   regeneration. The fingerprint is derived from the capped transcript sent to
-   the model, not from the raw session leaf, so metadata-only entries do not
-   spend another call.
-3. **Errored/aborted turns** — triggers arm on `turn_end`, which fires
-   regardless of outcome; the prompt asks the model to say so explicitly.
-4. **Terminal without DECSET `?1004`** — idle fallback covers it, and only
-   runs there: the first real focus event disarms the idle path for the
-   session. Caveat: on a supporting terminal where the user never switches
-   focus, the idle path stays armed (indistinguishable) — acceptable, since
-   the recap is then merely redundant, and the 120s default keeps it rare.
-5. **tmux** — needs `set -g focus-events on`; documented in README. Idle
-   fallback covers it otherwise.
-6. **User returns mid-draft** — the draft finishes and shows; it was triggered
-   by a genuine absence and lands at the "just got back" moment. Typing
-   cancels and clears as always.
-7. **Branch advances during a draft** — the recap prompt fingerprint is
-   snapshotted before the model call; stale drafts are discarded only when the
-   recap-relevant transcript changed. Metadata-only leaf changes remain valid.
+Most reloaded values are read by the next applicable eligibility check, render, or model call. Already armed one-shot timers retain their deadlines. Activity-buffer sizing and dirty-threshold options plus the polling interval are fixed for an active run and apply on the next `agent_start`; replacing them mid-run would discard captured evidence.
 
-## Non-goals
+The text template grammar recognizes only `{{identifier}}`. Prompts receive `transcript`; the structured response template receives configured string fields. Nested or stray delimiters, unknown names, and expression syntax fail safely; ordinary single braces remain prose.
 
-- Session persistence of recap history (CC does persist; see Display).
-- Multi-recap / rolling summary across many focus cycles.
-- Recap UI beyond the widget (no modal, no notifications).
-- Matching CC's small-fast-model choice (see Model selection).
+Protocol invariants stay in code: Pi event names, single-request ownership, abort rules, safe JSON extraction, `done/current/next` structured semantics, and transcript dedupe hashing. Configuration cannot replace parsers or callbacks.
 
-## Follow-ups (v0.3+)
+## Live scheduler
 
-- [ ] Optional e2e harness driving fake focus sequences + `turn_end` events
-      and asserting widget state transitions (manual tmux testing works but is
-      tedious).
-- [ ] Consider a provider-aware cheap-model default (e.g. Haiku when the
-      active provider is Anthropic) once pi exposes a reliable "sibling small
-      model" lookup.
-- [ ] Revisit widget wrap width — read the real terminal width from the TUI
-      instead of assuming ~100 cols.
+`agent_start` resets `LiveRecapState`, resets `LiveActivityBuffer`, and starts one polling interval. Events only update memory and increment an activity version after configured thresholds. They never start model calls.
+
+Eligibility requires:
+
+1. an active agent run;
+2. live and automatic recap enabled;
+3. at least `liveFirstMs` since `agent_start`;
+4. at least `liveMinIntervalMs` since the prior successful live recap completed and became visible;
+5. `activityVersion > lastRequestedVersion`;
+6. no recap request in flight.
+
+A tool start is meaningful immediately, so one tool running longer than two minutes remains eligible. Empty assistant text does not dirty the run. Streaming assistant and tool updates refresh their current snapshot every event but dirty the scheduler only when configured cumulative character thresholds are crossed. Completed/error tools become capped final events and are removed from the running-tool map. If end events never arrive, `activity.maxRunningTools` bounds the map by evicting its oldest insertion deterministically. All live text caps retain bounded head and tail evidence; running-tool formatting reserves room for the `latest:` result after long arguments. Tool end, finalized assistant message, and turn end are meaningful boundaries. Event and character caps bound memory.
+
+A request snapshots transcript text and activity version before awaiting the model. Later progress does not invalidate that result: a slightly stale recap remains useful. Only the current request owner may display, so an aborted or replaced request cannot overwrite a newer recap. The completion timestamp starts the next refresh interval, preventing slow calls from producing back-to-back widgets. Manual recap aborts and replaces automatic work. Input and shutdown abort. `agent_end` stops polling; config chooses whether the widget stays or clears. If clearing cancels the live request that owned the shared slot, one pending away recap is rescheduled when the terminal remains blurred and automatic away recap is still enabled.
+
+## Away, idle, resume, and manual paths
+
+Away focus reporting uses DECSET `?1004`. Continuous blur and turn-end debounce share the same request slot as live recap. By default, away generation waits until `agent_end` when an agent loop is active. Deferred zero-delay away work uses a generation token: a newer schedule invalidates the older one, while refocus, keyboard input, focus shutdown, and session shutdown invalidate all pending work. Keyboard input also clears stale blurred state. The idle fallback runs only until a real focus event proves focus reporting works. Resume/fork uses the persisted branch; `agent_start` cancels its timer. Every delayed automatic callback rechecks `enabled.automatic` and its reason flag when it fires. Manual recap includes the in-memory snapshot when available and has highest request priority.
+
+Automatic non-live recaps use a hash of the exact capped transcript to avoid duplicate calls. Live dirty versions handle active refreshes instead.
+
+## Model and response pipeline
+
+Candidate strings resolve in configured order by splitting at the first `/`, so model IDs may contain further slashes. `$active` resolves at call time. It is the sole shipped default, preventing implicit cross-provider transcript disclosure. Other providers, including Luna, require an explicit candidate override. Auth and completion failure may fall through according to policy. Calls use configured system prompt, reason prompt, reasoning, cache retention, and token cap.
+
+Plain mode normalizes text. JSON mode accepts a plain object or a fenced JSON object, validates configured fields as strings, fills empty fields, and renders a deterministic text template. Malformed output uses a configured fixed fallback. Default live output is `Done / Now / Next` and the prompt forbids unsupported claims. Transcript capping first allocates explicit reserves to the current request and newest persisted detail. When those protected reserves exceed the total cap, they scale proportionally. Live evidence receives the remaining space up to `liveMaxChars`; older framing uses only what remains after that. Sections render in readable chronological order. Long user, assistant, tool-result, and live entries retain bounded head and tail text so their latest error, progress, or next step survives per-entry limits.
+
+## Rate and cost
+
+Defaults permit the first active recap at 120 seconds, then require 90 seconds after each successful visible live recap plus meaningful activity. Model latency cannot increase concurrency or compress visible refreshes because there is one request slot and completion-based throttling. Input is capped at 12,000 characters and output at 256 tokens. Provider billing still applies; disabling live recap or increasing intervals is the cost control.
+
+## Display and persistence
+
+The extension uses `ctx.ui.setWidget` above the editor. Header, colors, width, line cap, status text, placement, and lifecycle clears are configurable. Recaps do not enter model conversation history or persist to the session file.

--- a/session-recap/README.md
+++ b/session-recap/README.md
@@ -1,57 +1,31 @@
 # session-recap
 
-"While you were away" recap for Pi, modelled on Claude Code's away-summary. When you've genuinely been away from a Pi session, a short recap is drafted while you're gone and parked above the editor so it's waiting when you return.
+A configurable recap widget for Pi. It covers terminal absence, idle turns, resumed sessions, manual `/recap`, and long active agent runs.
 
-![session-recap widget in a live Pi session](./assets/recap.png)
+Default live output:
 
-Built for multi-clauding / multi-pi workflows where several agent sessions run in parallel tabs.
-
-The recap orients rather than reports: it states the high-level task first (what you're building or debugging), then the concrete next step — the last assistant message is already on screen; what you've lost after a context switch is the task thread.
-
-## How it triggers
-
-1. **Away timer.** The extension enables terminal focus reporting (DECSET `?1004`) on session start. After the terminal has been continuously blurred for `--recap-away-seconds` (default 90s), a recap is generated and shown, so it's parked above the editor when you refocus.
-2. **Turn ends while you're away.** If the agent finishes a turn while the terminal is blurred — the prime multi-tab moment — a recap is drafted after a short debounce.
-3. **Idle fallback.** Only on terminals that haven't demonstrated focus-reporting support: `--recap-idle-seconds` (default 120s) after the last `turn_end` with no input, a recap is generated anyway. The first real focus event disarms this path for the session.
-
-Also fires automatically on `/resume` and `/fork` so you know where the prior session left off.
-
-Clears cleanly on: next user input, new turn start, session reload, or session shutdown.
-
-Quick alt-tabs cost nothing: no model call is made until you've actually been away for the full threshold. If you return while a recap is still drafting, it's allowed to finish — it lands moments after you're back, which is exactly when it helps.
-
-## Terminal compatibility
-
-| Terminal | Focus reporting | Notes |
-|---|---|---|
-| iTerm2, Ghostty, Alacritty, Kitty, WezTerm, xterm | ✅ | Works out of the box. |
-| VS Code integrated terminal, Warp | ✅ | Works. |
-| Apple Terminal | ⚠️ Partial | Idle fallback covers it. |
-| tmux | ✅ (with config) | Add `set -g focus-events on` to `~/.tmux.conf`, then `tmux source-file ~/.tmux.conf`. |
-
-If focus events cause any weirdness in your terminal, run with `--recap-disable-focus` and the idle fallback still works.
-
-## Model
-
-Defaults to the **currently active model** in your Pi session, but with recap-specific low-cost settings. This piggybacks on the auth you already have configured, so there are no extra login prompts. Custom providers registered through `pi.registerProvider` work when they use one of pi-ai's built-in API types. Providers that register a custom API handler only inside Pi's runtime are skipped silently because pi-ai's standalone compatibility layer cannot route the recap call; use `--recap-model` to select a supported provider if you still want recaps in those sessions.
-
-- No tools or Agent Skills are loaded into the recap call — only a compact two-tier transcript is sent (recent activity in detail, plus your earlier prompts and any compaction summary for task framing), capped at ~12k chars.
-- Reasoning/thinking is disabled for the recap call.
-- Prompt cache writes/reads are disabled with `cacheRetention: "none"`.
-- Output is capped with `maxTokens: 256`.
-- No active model, failed auth resolution, or an unsupported custom API handler → the recap is skipped silently.
-
-Override with `--recap-model "<provider>/<id>"` if you want a specific model regardless of the session's active one.
+```text
+✦ recap
+Done: Added config loading and tests.
+Now: Running the typecheck.
+Next: Fix any type errors, then review the diff.
+```
 
 ## Install
 
-### Pi package manager
+Install the standalone npm package:
+
+```bash
+pi install npm:@tmustier/pi-session-recap
+```
+
+Or install it from this extension collection:
 
 ```bash
 pi install git:github.com/tmustier/pi-extensions
 ```
 
-Filter to just this extension in `~/.pi/agent/settings.json`:
+To load only this extension from the collection, filter it in `~/.pi/agent/settings.json`:
 
 ```json
 {
@@ -64,47 +38,116 @@ Filter to just this extension in `~/.pi/agent/settings.json`:
 }
 ```
 
-### Local clone
+## Triggers and lifecycle
+
+- **Live:** starts with `agent_start`. The first eligible model call is 120 seconds later. After a recap becomes visible, the next live call waits at least 90 seconds and requires meaningful new streaming, tool, or finalized-message activity.
+- **Away:** continuous terminal blur arms a 90-second timer through DECSET `?1004` focus reporting.
+- **Turn ended while away:** a 3-second debounce handles the common multi-tab completion case.
+- **Idle:** after `turn_end`, used only until the terminal proves that focus events work.
+- **Resume/fork:** runs after `session_start` for the prior branch.
+- **Manual:** `/recap` runs immediately and has priority over an automatic request.
+
+Events update an in-memory live snapshot; they do not call the model. One polling scheduler owns live calls. It includes current `message_update` text, `tool_execution_start/update/end`, finalized messages, turn boundaries, and the persisted branch. This covers one long tool, continuous output, and multi-turn loops.
+
+Only one recap call runs at a time. A completed snapshot may be slightly stale if work advanced during generation; request ownership prevents an older call from overwriting a newer one. New user input and session shutdown abort active calls. `agent_end` stops the live scheduler. `lifecycle.liveWidgetOnAgentEnd` selects `keep` or `clear`.
+
+## Configuration
+
+[`defaults.json`](defaults.json) is the shipped, authoritative full default configuration. Put partial strict-JSON overrides at:
+
+1. `~/.pi/agent/session-recap.json`, or `$PI_CODING_AGENT_DIR/session-recap.json`
+2. `<ctx.cwd>/.pi/session-recap.json`
+3. the path in `$PI_SESSION_RECAP_CONFIG`
+4. the path passed through `--recap-config` (wins over the environment variable)
+
+The project layer is loaded only when Pi reports `ctx.isProjectTrusted()`. Untrusted clones cannot change recap prompts, terminal focus sequences, model selection, or other settings through `<ctx.cwd>/.pi/session-recap.json`. Global config and paths explicitly selected through the environment or CLI remain user-controlled and load regardless of project trust.
+
+Shipped defaults have the lowest priority. The environment and CLI files are both loaded when both are set; CLI values win per key. Identical paths load once at their highest-precedence position. Objects deep-merge. Arrays replace arrays. Relative explicit paths resolve from `ctx.cwd`; `~/` expands to the home directory.
+
+The extension reloads config on `session_start`, every `agent_start`, and before `/recap`. Reloaded prompts, model and response settings, transcript limits, widget settings, enabled gates, and live eligibility timings are read by the next applicable check or model call; an already armed one-shot timer keeps its original deadline, then rechecks `enabled.automatic` and its reason flag before starting work. `agent_start` cancels a pending resume recap. The in-memory activity buffer options (`assistantCharsPerLiveVersion`, `toolUpdateCharsPerLiveVersion`, `maxLiveEvents`, `maxLiveEventChars`, `maxRunningTools`, and `liveAssistantChars`) and the `livePollMs` interval apply on the next `agent_start`, which preserves evidence already captured by the current run. A change to focus enablement, sequences, or parser cap safely disables the old terminal mode and reattaches the new parser. Focus input sequences must be non-empty, distinct, and not prefixes of each other. Widget/status key changes clear the old keys before rendering under new ones. Cancelling manual or idle work clears its owning drafting status even when widget lifecycle clearing is disabled. A malformed file, unknown key or event, wrong type, invalid enum, unsafe focus sequence, invalid cap, or invalid model candidate rejects the whole reload. Pi logs/notifies the exact path and retains the last valid canonical JSON config, or shipped defaults if none loaded. Deprecated flags are derived afterward and never mutate that canonical state. Missing optional files are ignored.
+
+Config is parsed only with `JSON.parse`. Prompt and output templates permit named text interpolation such as `{{transcript}}` and `{{done}}`. Unknown, nested, stray, or expression-like delimiters fail, including `{{{transcript}}}` and `{{transcript}}}`; ordinary single braces remain valid prose. There is no `eval`, module loading, Handlebars logic, or code execution.
+
+### Example
 
 ```json
 {
-  "extensions": [
-    "~/pi-extensions/session-recap/index.ts"
-  ]
+  "timings": {
+    "liveFirstMs": 180000,
+    "liveMinIntervalMs": 120000
+  },
+  "model": {
+    "candidates": ["anthropic/claude-haiku", "$active"],
+    "maxTokens": 192
+  },
+  "response": {
+    "template": "Done: {{done}}\nNow: {{current}}\nNext: {{next}}"
+  },
+  "lifecycle": {
+    "liveWidgetOnAgentEnd": "clear"
+  }
 }
 ```
 
-## Flags
+### Full field reference
 
-| Flag | Default | Description |
-|---|---|---|
-| `--recap-away-seconds <n>` | `90` | Seconds of continuous terminal blur before an away recap is generated. |
-| `--recap-idle-seconds <n>` | `120` | Idle-fallback delay after `turn_end`, used only when the terminal doesn't report focus. |
-| `--recap-disable-focus` | `false` | Disable DECSET `?1004` focus reporting. Idle fallback still runs. |
-| `--recap-during-active` | `false` | Allow away recaps while an agent turn is still running, instead of deferring to the end of the turn. |
-| `--recap-disable` | `false` | Disable the automatic recap entirely. `/recap` still works. |
-| `--recap-model "<p/id>"` | (active model) | Override the default, e.g. `anthropic/claude-sonnet-4-6`. |
+- `enabled`: toggles `automatic`, `manual`, `away`, `idle`, `resume`, `live`, and `focusReporting` independently.
+- `timings`: `awayMs`, `idleMs`, `postTurnDebounceMs`, `resumeDelayMs`, `liveFirstMs`, `liveMinIntervalMs`, and scheduler `livePollMs`.
+- `focus`: terminal `enableSequence`, `disableSequence`, `inSequence`, `outSequence`, parser `inputBufferCap`, `allowAwayDuringAgent`, and `finishDraftAfterRefocus`.
+- `activity`: persisted recap `assistantMinWords`; live dirty thresholds `assistantCharsPerLiveVersion` and `toolUpdateCharsPerLiveVersion`; allowed `liveEvents`; snapshot `maxLiveEvents` and `maxLiveEventChars`; running-tool map cap `maxRunningTools`. Missing tool-end events evict the oldest running record first at this cap.
+- `transcript`: caps for `earlierUserPrompts`, `earlierPromptChars`, `compactionSummaryChars`, `userChars`, `assistantChars`, `toolArgumentsChars`, `toolResultChars`, total input `totalChars`, current-request reserve `currentUserReserveChars`, newest persisted-detail reserve `persistedReserveChars`, live-section cap `liveMaxChars`, and current stream `liveAssistantChars`. The reserves protect the current request and newest persisted evidence before remaining space goes to high-priority live evidence; older framing uses only leftover space. Scarce budgets scale the protected sections proportionally. Rendered order remains framing, current request, persisted detail, live activity.
+- `model`: ordered `candidates` (`provider/id` or `$active`; IDs may contain further `/` characters), `reasoning`, `cacheRetention`, `maxTokens`, `fallbackOnAuthError`, `fallbackOnCompletionError`, and `silentUnsupportedApi`.
+- `prompts`: `system` plus reason-specific `away`, `idle`, `resume`, `manual`, and `live`. Reason prompts may interpolate only `{{transcript}}`.
+- `response.modes`: `plain` or `json` per reason. Default live mode is JSON; other reasons stay plain.
+- `response`: structured `fields`, deterministic `template`, `malformedFallback`, `emptyFieldFallback`, and visible `maxChars`.
+- `widget`: `key`, `statusKey`, `header`, theme color names, `wrapWidth`, `maxBodyLines`, `placement`, and `draftingStatus`.
+- `lifecycle`: `clearOnInput`, `clearOnAgentStart`, `clearOnTurnStart`, `liveWidgetOnAgentEnd`, `clearOnSessionShutdown`, and `persistWidgetAcrossResume`.
 
-> v0.1's `--recap-focus-min-seconds` was removed: recaps are no longer drafted on every focus-out, so there is no quick-glance suppression to tune.
+The defaults file gives exact types and current values. JSON arrays replace defaults, so include `$active` explicitly when active-model fallback is wanted. Timing zero means immediate where allowed; `livePollMs` stays positive. Every timing value must be at most Node's timer limit, `2147483647` ms. Zero prompt-count or per-component transcript caps disable that component. Transcript allocation reserves and the live-section cap, model/output/widget caps, focus parser capacity, running-tool cap, and activity dirty thresholds must stay positive integers.
 
-## Command
+## Models, output, cost
 
-| Command | Description |
-|---|---|
-| `/recap` | Force-generate a recap right now, bypassing the activity gate. |
+The sole default candidate is `$active`, so the package does not send transcript data to a provider other than the one already active in Pi. Auth or completion failure falls through only when more candidates are explicitly configured and the matching policy flag is enabled. Runtime-only custom APIs unsupported by `pi-ai/compat` can be skipped silently. Reasoning is off, cache retention is none, output is capped at 256 tokens, and transcript input is capped at 12,000 characters by default.
 
-## Behaviour notes
+To opt in to Luna first, configure the provider explicitly:
 
-- **Uses `turn_end`, not `agent_end`**, to arm triggers, so a turn that errors or is aborted still gets recapped — and the prompt asks the model to say so explicitly.
-- **No duplicate drafts**: the last-drafted recap prompt is fingerprinted; blur/refocus churn or session metadata-only changes reuse the recap rather than regenerating.
-- **Defers during active work by default**: if a trigger fires while a turn is still loading, the draft waits for the agent to finish, matching Claude Code's away-summary pending behaviour. Use `--recap-during-active` to allow mid-flight recaps.
-- **Aborts on new input**: any in-flight recap request is cancelled when you start typing or a new turn begins.
-- **No session persistence**: the recap lives only in the widget for the active session — nothing is stored.
+```json
+{
+  "model": {
+    "candidates": ["openai-codex/gpt-5.6-luna", "$active"]
+  }
+}
+```
 
-## Design
+Live mode requests evidence-bound JSON fields `done`, `current`, and `next`. Plain or fenced JSON is accepted. Wrong field types or malformed output display the configured safe fallback. Away, idle, resume, and manual modes default to plain text but can select the same JSON path.
 
-See [DESIGN.md](./DESIGN.md) for the design-of-record, including a comparison with Claude Code's actual away-summary implementation.
+At defaults, a continuously active run costs at most one recap request after two minutes and another no sooner than 90 seconds after the prior recap becomes visible, when meaningful activity exists. Actual provider billing follows the selected model. Raise `liveFirstMs` or `liveMinIntervalMs`, remove expensive candidates, or set `enabled.live` to `false` to reduce cost.
 
-## License
+## Terminal focus behavior
 
-MIT
+The extension writes DECSET `?1004` on session start and listens for `ESC[I` and `ESC[O`. iTerm2, Ghostty, Alacritty, Kitty, WezTerm, xterm, VS Code, and Warp generally support it. For tmux:
+
+```text
+set -g focus-events on
+```
+
+Apple Terminal may need the idle fallback. Set `enabled.focusReporting` to `false` if focus events interfere with input. The idle path remains available.
+
+## Flags and migration
+
+Canonical configuration is JSON. `--recap-config <path>` is the supported selector. These old flags remain as deprecated final in-memory overrides:
+
+- `--recap-away-seconds`
+- `--recap-idle-seconds`
+- `--recap-disable-focus`
+- `--recap-during-active`
+- `--recap-disable`
+- `--recap-model provider/id`
+
+Migrate them to `timings.awayMs`, `timings.idleMs`, `enabled.focusReporting`, `focus.allowAwayDuringAgent`, `enabled.automatic`, and `model.candidates`. The removed v0.1 `--recap-focus-min-seconds` has no replacement because quick focus changes do not call the model.
+
+## Residual constraints
+
+Protocol event names, request ownership, abort behavior, JSON parsing, required `done/current/next` semantics, SHA-256 deduplication, and the no-code template grammar remain implementation invariants. Making them configurable would weaken correctness or security. Widgets are not written into the session transcript or persisted across process shutdown. Focus support still depends on the terminal or multiplexer forwarding DECSET `?1004` events.
+
+See [DESIGN.md](DESIGN.md) for the state model.

--- a/session-recap/config.ts
+++ b/session-recap/config.ts
@@ -1,0 +1,417 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type RecapReason = "away" | "idle" | "resume" | "manual" | "live";
+export type ResponseMode = "plain" | "json";
+
+export type RecapConfig = {
+	enabled: {
+		automatic: boolean;
+		manual: boolean;
+		away: boolean;
+		idle: boolean;
+		resume: boolean;
+		live: boolean;
+		focusReporting: boolean;
+	};
+	timings: {
+		awayMs: number;
+		idleMs: number;
+		postTurnDebounceMs: number;
+		resumeDelayMs: number;
+		liveFirstMs: number;
+		liveMinIntervalMs: number;
+		livePollMs: number;
+	};
+	focus: {
+		enableSequence: string;
+		disableSequence: string;
+		inSequence: string;
+		outSequence: string;
+		inputBufferCap: number;
+		allowAwayDuringAgent: boolean;
+		finishDraftAfterRefocus: boolean;
+	};
+	activity: {
+		assistantMinWords: number;
+		assistantCharsPerLiveVersion: number;
+		toolUpdateCharsPerLiveVersion: number;
+		liveEvents: string[];
+		maxLiveEvents: number;
+		maxLiveEventChars: number;
+		maxRunningTools: number;
+	};
+	transcript: {
+		earlierUserPrompts: number;
+		earlierPromptChars: number;
+		compactionSummaryChars: number;
+		userChars: number;
+		assistantChars: number;
+		toolArgumentsChars: number;
+		toolResultChars: number;
+		totalChars: number;
+		currentUserReserveChars: number;
+		persistedReserveChars: number;
+		liveMaxChars: number;
+		liveAssistantChars: number;
+	};
+	model: {
+		candidates: string[];
+		reasoning: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+		cacheRetention: "none" | "short" | "long";
+		maxTokens: number;
+		fallbackOnAuthError: boolean;
+		fallbackOnCompletionError: boolean;
+		silentUnsupportedApi: boolean;
+	};
+	prompts: Record<"system" | RecapReason, string>;
+	response: {
+		modes: Record<RecapReason, ResponseMode>;
+		fields: string[];
+		template: string;
+		malformedFallback: string;
+		emptyFieldFallback: string;
+		maxChars: number;
+	};
+	widget: {
+		key: string;
+		statusKey: string;
+		header: string;
+		headerColor: string;
+		bodyColor: string;
+		wrapWidth: number;
+		maxBodyLines: number;
+		placement: "aboveEditor" | "belowEditor";
+		draftingStatus: string;
+	};
+	lifecycle: {
+		clearOnInput: boolean;
+		clearOnAgentStart: boolean;
+		clearOnTurnStart: boolean;
+		liveWidgetOnAgentEnd: "keep" | "clear";
+		clearOnSessionShutdown: boolean;
+		persistWidgetAcrossResume: boolean;
+	};
+};
+
+export type ConfigSourceOptions = {
+	cwd: string;
+	projectTrusted: boolean;
+	agentDir?: string;
+	explicitPath?: string;
+	env?: NodeJS.ProcessEnv;
+};
+
+export type ConfigLoadResult = {
+	config: RecapConfig;
+	loadedFiles: string[];
+	valid: boolean;
+};
+
+const DEFAULTS_PATH = join(dirname(fileURLToPath(import.meta.url)), "defaults.json");
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function parseJson(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateShape(value: unknown, shape: unknown, path = "config"): string | undefined {
+	if (Array.isArray(shape)) {
+		if (!Array.isArray(value)) return `${path} must be an array`;
+		if (shape.length > 0 && typeof shape[0] === "string" && value.some((item) => typeof item !== "string")) {
+			return `${path} must contain only strings`;
+		}
+		return undefined;
+	}
+	if (isObject(shape)) {
+		if (!isObject(value)) return `${path} must be an object`;
+		for (const key of Object.keys(value)) {
+			if (!(key in shape)) return `${path}.${key} is unknown`;
+		}
+		for (const [key, child] of Object.entries(value)) {
+			const error = validateShape(child, shape[key], `${path}.${key}`);
+			if (error) return error;
+		}
+		return undefined;
+	}
+	if (typeof value !== typeof shape) return `${path} must be ${typeof shape}`;
+	if (typeof value === "number" && (!Number.isFinite(value) || value < 0)) {
+		return `${path} must be a finite non-negative number`;
+	}
+	return undefined;
+}
+
+function deepMerge<T>(base: T, override: unknown): T {
+	if (!isObject(base) || !isObject(override)) return structuredClone(override) as T;
+	const result: Record<string, unknown> = structuredClone(base) as Record<string, unknown>;
+	for (const [key, value] of Object.entries(override)) {
+		result[key] = isObject(value) && isObject(result[key]) ? deepMerge(result[key], value) : structuredClone(value);
+	}
+	return result as T;
+}
+
+function validateTemplate(template: string, allowed: string[], path: string): string | undefined {
+	if (/{{{|}}}/.test(template)) return `${path} contains an invalid interpolation token`;
+	const token = /{{\s*([a-zA-Z][a-zA-Z0-9_]*)\s*}}/g;
+	for (const match of template.matchAll(token)) {
+		if (!allowed.includes(match[1])) return `${path} references unknown value ${match[1]}`;
+	}
+	if (template.replace(token, "").match(/{{|}}/)) return `${path} contains an invalid interpolation token`;
+	return undefined;
+}
+
+const LIVE_EVENTS = new Set([
+	"message_update",
+	"message_end",
+	"tool_execution_start",
+	"tool_execution_update",
+	"tool_execution_end",
+	"turn_end",
+]);
+const REASONING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+const CACHE_RETENTIONS = new Set(["none", "short", "long"]);
+
+const THEME_COLORS = new Set([
+	"accent", "border", "borderAccent", "borderMuted", "success", "error", "warning", "muted", "dim", "text",
+	"thinkingText", "userMessageText", "customMessageText", "customMessageLabel", "toolTitle", "toolOutput", "mdHeading",
+	"mdLink", "mdLinkUrl", "mdCode", "mdCodeBlock", "mdCodeBlockBorder", "mdQuote", "mdQuoteBorder", "mdHr", "mdListBullet",
+	"toolDiffAdded", "toolDiffRemoved", "toolDiffContext", "syntaxComment", "syntaxKeyword", "syntaxFunction", "syntaxVariable",
+	"syntaxString", "syntaxNumber", "syntaxType", "syntaxOperator", "syntaxPunctuation", "thinkingOff", "thinkingMinimal",
+	"thinkingLow", "thinkingMedium", "thinkingHigh", "thinkingXhigh", "bashMode",
+]);
+
+function validateConfig(config: RecapConfig): string | undefined {
+	const integer = (value: number, path: string, allowZero = true): string | undefined => {
+		if (!Number.isInteger(value) || value < (allowZero ? 0 : 1)) {
+			return `${path} must be ${allowZero ? "a non-negative" : "a positive"} integer`;
+		}
+		return undefined;
+	};
+	for (const reason of ["away", "idle", "resume", "manual", "live"] as const) {
+		if (config.response.modes[reason] !== "plain" && config.response.modes[reason] !== "json") {
+			return `config.response.modes.${reason} must be plain or json`;
+		}
+	}
+	if (!config.focus.inSequence || !config.focus.outSequence) {
+		return "config focus input sequences must be non-empty";
+	}
+	if (
+		config.focus.inSequence === config.focus.outSequence ||
+		config.focus.inSequence.startsWith(config.focus.outSequence) ||
+		config.focus.outSequence.startsWith(config.focus.inSequence)
+	) {
+		return "config focus input sequences must be distinct and not prefix-overlapping";
+	}
+	const focusCapError = integer(config.focus.inputBufferCap, "config.focus.inputBufferCap", false);
+	if (focusCapError) return focusCapError;
+	if (config.focus.inputBufferCap < Math.max(config.focus.inSequence.length, config.focus.outSequence.length)) {
+		return "config.focus.inputBufferCap must fit the longest focus input sequence";
+	}
+	if (config.widget.placement !== "aboveEditor" && config.widget.placement !== "belowEditor") {
+		return "config.widget.placement must be aboveEditor or belowEditor";
+	}
+	if (!THEME_COLORS.has(config.widget.headerColor) || !THEME_COLORS.has(config.widget.bodyColor)) {
+		return "config widget colors must be Pi theme color names";
+	}
+	if (config.lifecycle.liveWidgetOnAgentEnd !== "keep" && config.lifecycle.liveWidgetOnAgentEnd !== "clear") {
+		return "config.lifecycle.liveWidgetOnAgentEnd must be keep or clear";
+	}
+	if (config.model.candidates.length === 0) {
+		return "config.model.candidates must not be empty";
+	}
+	if (config.model.candidates.some((candidate) => {
+		if (candidate === "$active") return false;
+		const separator = candidate.indexOf("/");
+		if (separator <= 0 || separator === candidate.length - 1) return true;
+		const provider = candidate.slice(0, separator);
+		const id = candidate.slice(separator + 1);
+		return !provider.trim() || provider !== provider.trim() || !id.trim() || id !== id.trim();
+	})) {
+		return "config.model.candidates entries must be $active or provider/model with non-empty components";
+	}
+	if (!REASONING_LEVELS.has(config.model.reasoning)) {
+		return "config.model.reasoning must be off, minimal, low, medium, high, xhigh, or max";
+	}
+	if (!CACHE_RETENTIONS.has(config.model.cacheRetention)) {
+		return "config.model.cacheRetention must be none, short, or long";
+	}
+	const maxTokensError = integer(config.model.maxTokens, "config.model.maxTokens", false);
+	if (maxTokensError) return maxTokensError;
+	const liveEventsError = config.activity.liveEvents.find((event) => !LIVE_EVENTS.has(event));
+	if (liveEventsError) return `config.activity.liveEvents contains unknown event ${liveEventsError}`;
+	if (!config.response.fields.includes("done") || !config.response.fields.includes("current") || !config.response.fields.includes("next")) {
+		return "config.response.fields must include done, current, and next";
+	}
+	for (const reason of ["away", "idle", "resume", "manual", "live"] as const) {
+		const error = validateTemplate(config.prompts[reason], ["transcript"], `config.prompts.${reason}`);
+		if (error) return error;
+	}
+	const systemError = validateTemplate(config.prompts.system, [], "config.prompts.system");
+	if (systemError) return systemError;
+	const responseError = validateTemplate(config.response.template, config.response.fields, "config.response.template");
+	if (responseError) return responseError;
+	for (const [path, value] of [
+		["config.timings.awayMs", config.timings.awayMs],
+		["config.timings.idleMs", config.timings.idleMs],
+		["config.timings.postTurnDebounceMs", config.timings.postTurnDebounceMs],
+		["config.timings.resumeDelayMs", config.timings.resumeDelayMs],
+		["config.timings.liveFirstMs", config.timings.liveFirstMs],
+		["config.timings.liveMinIntervalMs", config.timings.liveMinIntervalMs],
+		["config.timings.livePollMs", config.timings.livePollMs],
+	] as const) {
+		if (value > MAX_TIMER_DELAY_MS) return `${path} must be <= ${MAX_TIMER_DELAY_MS}`;
+	}
+	for (const [path, value, allowZero] of [
+		["config.timings.awayMs", config.timings.awayMs, true],
+		["config.timings.idleMs", config.timings.idleMs, true],
+		["config.timings.postTurnDebounceMs", config.timings.postTurnDebounceMs, true],
+		["config.timings.resumeDelayMs", config.timings.resumeDelayMs, true],
+		["config.timings.liveFirstMs", config.timings.liveFirstMs, true],
+		["config.timings.liveMinIntervalMs", config.timings.liveMinIntervalMs, true],
+		["config.timings.livePollMs", config.timings.livePollMs, false],
+		["config.activity.assistantMinWords", config.activity.assistantMinWords, true],
+		["config.activity.assistantCharsPerLiveVersion", config.activity.assistantCharsPerLiveVersion, false],
+		["config.activity.toolUpdateCharsPerLiveVersion", config.activity.toolUpdateCharsPerLiveVersion, false],
+		["config.activity.maxLiveEvents", config.activity.maxLiveEvents, false],
+		["config.activity.maxLiveEventChars", config.activity.maxLiveEventChars, false],
+		["config.activity.maxRunningTools", config.activity.maxRunningTools, false],
+		["config.transcript.earlierUserPrompts", config.transcript.earlierUserPrompts, true],
+		["config.transcript.earlierPromptChars", config.transcript.earlierPromptChars, true],
+		["config.transcript.compactionSummaryChars", config.transcript.compactionSummaryChars, true],
+		["config.transcript.userChars", config.transcript.userChars, true],
+		["config.transcript.assistantChars", config.transcript.assistantChars, true],
+		["config.transcript.toolArgumentsChars", config.transcript.toolArgumentsChars, true],
+		["config.transcript.toolResultChars", config.transcript.toolResultChars, true],
+		["config.transcript.totalChars", config.transcript.totalChars, false],
+		["config.transcript.currentUserReserveChars", config.transcript.currentUserReserveChars, false],
+		["config.transcript.persistedReserveChars", config.transcript.persistedReserveChars, false],
+		["config.transcript.liveMaxChars", config.transcript.liveMaxChars, false],
+		["config.transcript.liveAssistantChars", config.transcript.liveAssistantChars, true],
+		["config.response.maxChars", config.response.maxChars, false],
+		["config.widget.wrapWidth", config.widget.wrapWidth, false],
+		["config.widget.maxBodyLines", config.widget.maxBodyLines, false],
+	] as const) {
+		const error = integer(value, path, allowZero);
+		if (error) return error;
+	}
+	return undefined;
+}
+
+export function shippedDefaults(): RecapConfig {
+	const parsed = parseJson(DEFAULTS_PATH);
+	if (!isObject(parsed)) throw new Error(`${DEFAULTS_PATH}: defaults must be an object`);
+	const config = parsed as RecapConfig;
+	const error = validateConfig(config);
+	if (error) throw new Error(`${DEFAULTS_PATH}: ${error}`);
+	return config;
+}
+
+function expandPath(path: string, cwd: string): string {
+	const expanded = path === "~" ? homedir() : path.startsWith("~/") ? join(homedir(), path.slice(2)) : path;
+	return isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
+}
+
+type ConfigSource = { path: string; required: boolean };
+
+function configSources(options: ConfigSourceOptions): ConfigSource[] {
+	const env = options.env ?? process.env;
+	const agentDir = options.agentDir ?? env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	const layers: ConfigSource[] = [
+		{ path: join(agentDir, "session-recap.json"), required: false },
+	];
+	if (options.projectTrusted) {
+		layers.push({ path: join(options.cwd, ".pi", "session-recap.json"), required: false });
+	}
+	if (env.PI_SESSION_RECAP_CONFIG) {
+		layers.push({ path: expandPath(env.PI_SESSION_RECAP_CONFIG, options.cwd), required: true });
+	}
+	if (options.explicitPath) {
+		layers.push({ path: expandPath(options.explicitPath, options.cwd), required: true });
+	}
+	const deduplicated: ConfigSource[] = [];
+	for (const layer of layers) {
+		const existingIndex = deduplicated.findIndex((source) => source.path === layer.path);
+		const required = layer.required || (existingIndex >= 0 && deduplicated[existingIndex].required);
+		if (existingIndex >= 0) deduplicated.splice(existingIndex, 1);
+		deduplicated.push({ ...layer, required });
+	}
+	return deduplicated;
+}
+
+export function configPaths(options: ConfigSourceOptions): string[] {
+	return configSources(options).map((source) => source.path);
+}
+
+export function loadConfig(
+	options: ConfigSourceOptions,
+	previous: RecapConfig | undefined,
+	report: (message: string) => void = console.error,
+): ConfigLoadResult {
+	let config: RecapConfig;
+	try {
+		config = shippedDefaults();
+	} catch (error) {
+		if (previous) return { config: previous, loadedFiles: [], valid: false };
+		throw error;
+	}
+	const defaults = config;
+	const loadedFiles: string[] = [];
+	for (const source of configSources(options)) {
+		const path = source.path;
+		if (!existsSync(path)) {
+			if (source.required) {
+				report(`[session-recap] invalid config ${path}: file does not exist; keeping last valid configuration`);
+				return { config: previous ?? defaults, loadedFiles: [], valid: false };
+			}
+			continue;
+		}
+		try {
+			const override = parseJson(path);
+			const shapeError = validateShape(override, defaults);
+			if (shapeError) throw new Error(shapeError);
+			config = deepMerge(config, override);
+			const configError = validateConfig(config);
+			if (configError) throw new Error(configError);
+			loadedFiles.push(path);
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			report(`[session-recap] invalid config ${path}: ${detail}; keeping last valid configuration`);
+			return { config: previous ?? defaults, loadedFiles: [], valid: false };
+		}
+	}
+	return { config, loadedFiles, valid: true };
+}
+
+export function applyDeprecatedFlagOverrides(
+	config: RecapConfig,
+	flags: {
+		awaySeconds?: string;
+		idleSeconds?: string;
+		disableFocus?: boolean;
+		duringActive?: boolean;
+		disable?: boolean;
+		model?: string;
+	},
+): RecapConfig {
+	const result = structuredClone(config);
+	const applySeconds = (value: string | undefined, current: number): number => {
+		const seconds = Number(value);
+		const milliseconds = Math.max(5, seconds) * 1000;
+		return value && Number.isFinite(seconds) && Number.isInteger(milliseconds) && milliseconds <= MAX_TIMER_DELAY_MS
+			? milliseconds
+			: current;
+	};
+	result.timings.awayMs = applySeconds(flags.awaySeconds, result.timings.awayMs);
+	result.timings.idleMs = applySeconds(flags.idleSeconds, result.timings.idleMs);
+	if (flags.disableFocus) result.enabled.focusReporting = false;
+	if (flags.duringActive) result.focus.allowAwayDuringAgent = true;
+	if (flags.disable) result.enabled.automatic = false;
+	if (flags.model) result.model.candidates = [flags.model, ...result.model.candidates.filter((candidate) => candidate !== flags.model)];
+	return result;
+}

--- a/session-recap/defaults.json
+++ b/session-recap/defaults.json
@@ -1,0 +1,115 @@
+{
+  "enabled": {
+    "automatic": true,
+    "manual": true,
+    "away": true,
+    "idle": true,
+    "resume": true,
+    "live": true,
+    "focusReporting": true
+  },
+  "timings": {
+    "awayMs": 90000,
+    "idleMs": 120000,
+    "postTurnDebounceMs": 3000,
+    "resumeDelayMs": 300,
+    "liveFirstMs": 120000,
+    "liveMinIntervalMs": 90000,
+    "livePollMs": 1000
+  },
+  "focus": {
+    "enableSequence": "\u001b[?1004h",
+    "disableSequence": "\u001b[?1004l",
+    "inSequence": "\u001b[I",
+    "outSequence": "\u001b[O",
+    "inputBufferCap": 64,
+    "allowAwayDuringAgent": false,
+    "finishDraftAfterRefocus": true
+  },
+  "activity": {
+    "assistantMinWords": 30,
+    "assistantCharsPerLiveVersion": 80,
+    "toolUpdateCharsPerLiveVersion": 200,
+    "liveEvents": [
+      "message_update",
+      "message_end",
+      "tool_execution_start",
+      "tool_execution_update",
+      "tool_execution_end",
+      "turn_end"
+    ],
+    "maxLiveEvents": 40,
+    "maxLiveEventChars": 1200,
+    "maxRunningTools": 64
+  },
+  "transcript": {
+    "earlierUserPrompts": 4,
+    "earlierPromptChars": 300,
+    "compactionSummaryChars": 600,
+    "userChars": 1200,
+    "assistantChars": 1200,
+    "toolArgumentsChars": 280,
+    "toolResultChars": 400,
+    "totalChars": 12000,
+    "currentUserReserveChars": 1400,
+    "persistedReserveChars": 2200,
+    "liveMaxChars": 6000,
+    "liveAssistantChars": 2400
+  },
+  "model": {
+    "candidates": [
+      "$active"
+    ],
+    "reasoning": "off",
+    "cacheRetention": "none",
+    "maxTokens": 256,
+    "fallbackOnAuthError": true,
+    "fallbackOnCompletionError": true,
+    "silentUnsupportedApi": true
+  },
+  "prompts": {
+    "system": "You write terse, evidence-bound session recaps for a coding agent UI.",
+    "away": "The user is returning to this coding-agent session. Write a short orientation grounded only in the transcript. State the high-level task and concrete next step. If the turn failed or was aborted, say so. Return plain text only.\n\n<transcript>\n{{transcript}}\n</transcript>",
+    "idle": "The coding-agent session has been idle. Write a short orientation grounded only in the transcript. State the high-level task and concrete next step. Return plain text only.\n\n<transcript>\n{{transcript}}\n</transcript>",
+    "resume": "The user resumed or forked this coding-agent session. Write a short orientation grounded only in the transcript. State the high-level task and concrete next step. Return plain text only.\n\n<transcript>\n{{transcript}}\n</transcript>",
+    "manual": "Summarize this coding-agent session now, grounded only in the transcript. Return plain text unless the response mode requests JSON.\n\n<transcript>\n{{transcript}}\n</transcript>",
+    "live": "Summarize the active coding-agent run using only evidence in the snapshot. Return one JSON object with string fields done, current, and next. Use an empty string when a field is unknown; never invent progress.\n\n<snapshot>\n{{transcript}}\n</snapshot>"
+  },
+  "response": {
+    "modes": {
+      "away": "plain",
+      "idle": "plain",
+      "resume": "plain",
+      "manual": "plain",
+      "live": "json"
+    },
+    "fields": [
+      "done",
+      "current",
+      "next"
+    ],
+    "template": "Done: {{done}}\nNow: {{current}}\nNext: {{next}}",
+    "malformedFallback": "Recap unavailable: the model returned an invalid structured response.",
+    "emptyFieldFallback": "Unknown",
+    "maxChars": 1200
+  },
+  "widget": {
+    "key": "session-recap",
+    "statusKey": "session-recap",
+    "header": "✦ recap",
+    "headerColor": "accent",
+    "bodyColor": "dim",
+    "wrapWidth": 100,
+    "maxBodyLines": 6,
+    "placement": "aboveEditor",
+    "draftingStatus": "✦ drafting recap…"
+  },
+  "lifecycle": {
+    "clearOnInput": true,
+    "clearOnAgentStart": true,
+    "clearOnTurnStart": false,
+    "liveWidgetOnAgentEnd": "keep",
+    "clearOnSessionShutdown": true,
+    "persistWidgetAcrossResume": false
+  }
+}

--- a/session-recap/focus-parser.ts
+++ b/session-recap/focus-parser.ts
@@ -1,0 +1,44 @@
+export type FocusEvent = "in" | "out";
+
+/** Incremental parser for configurable terminal focus sequences. */
+export class FocusSequenceParser {
+	private buffer = "";
+	private readonly sequences: Array<{ value: string; event: FocusEvent }>;
+	private readonly bufferCap: number;
+
+	constructor(inSequence: string, outSequence: string, bufferCap: number) {
+		if (!inSequence || !outSequence) throw new Error("focus sequences must be non-empty");
+		if (inSequence === outSequence || inSequence.startsWith(outSequence) || outSequence.startsWith(inSequence)) {
+			throw new Error("focus sequences must be distinct and not prefix-overlapping");
+		}
+		if (!Number.isInteger(bufferCap) || bufferCap < Math.max(inSequence.length, outSequence.length)) {
+			throw new Error("focus parser cap must fit the longest sequence");
+		}
+		this.bufferCap = bufferCap;
+		this.sequences = [
+			{ value: inSequence, event: "in" as const },
+			{ value: outSequence, event: "out" as const },
+		].sort((left, right) => right.value.length - left.value.length);
+	}
+
+	push(chunk: string): FocusEvent[] {
+		this.buffer += chunk;
+		const events: FocusEvent[] = [];
+		while (this.buffer.length > 0) {
+			const full = this.sequences.find(({ value }) => this.buffer.startsWith(value));
+			if (full) {
+				const ambiguousLonger = this.sequences.some(
+					({ value }) => value.length > full.value.length && value.startsWith(full.value) && this.buffer.length < value.length,
+				);
+				if (ambiguousLonger) break;
+				events.push(full.event);
+				this.buffer = this.buffer.slice(full.value.length);
+				continue;
+			}
+			if (this.sequences.some(({ value }) => value.startsWith(this.buffer))) break;
+			this.buffer = this.buffer.slice(1);
+		}
+		if (this.buffer.length > this.bufferCap) this.buffer = this.buffer.slice(-this.bufferCap);
+		return events;
+	}
+}

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -1,747 +1,506 @@
-/**
- * session-recap
- *
- * "While you were away" recap for pi, modelled on Claude Code's away-summary
- * (services/awaySummary.ts + hooks/useAwaySummary.ts). A recap is only drafted
- * after a *genuine* absence, and is waiting above the editor when you return:
- *
- *   1) Away timer: terminal focus reporting via DECSET ?1004. After the
- *      terminal has been continuously blurred for `--recap-away-seconds`
- *      (default 90s), a recap is generated and shown so it's parked above
- *      the editor when you refocus.
- *
- *   2) Turn-end while away: if a turn finishes while the terminal is blurred
- *      (the prime multi-tab moment — the agent finished while you were in
- *      another tab), a recap is drafted after a short debounce.
- *
- *   3) Idle fallback: only when the terminal has not demonstrated focus
- *      reporting support (no ESC[I / ESC[O seen this session). N seconds
- *      after the last `turn_end` with no input, generate anyway. `turn_end`
- *      (not `agent_end`) is used so this fires even for errored/aborted turns.
- *
- * Also fires on `/resume` / `/fork` (session_start reason) to recap where the
- * prior session left off.
- *
- * Recap content follows Claude Code's prompt philosophy: state the high-level
- * task first (what the user is building/fixing), then the concrete next step.
- * Skip status reports — the last assistant message is already on screen; what
- * the user has lost is the task thread.
- *
- * Model: defaults to the user's currently active model with reasoning/thinking
- * disabled and cache writes disabled. This piggybacks on the user's configured
- * auth. Custom providers using a built-in pi-ai API work normally; providers
- * with a custom API handler are skipped silently. Override explicitly with
- * `--recap-model "<provider>/<id>"`.
- *
- * Flags:
- *   --recap-away-seconds <n>   Continuous blur before an away recap (default 90)
- *   --recap-idle-seconds <n>   Idle-fallback delay after turn_end (default 120)
- *   --recap-disable-focus      Disable DECSET ?1004 focus reporting
- *   --recap-during-active      Allow away recaps while an agent turn is running
- *   --recap-disable            Disable the automatic recap entirely
- *   --recap-model <p/id>       Override the default (active) model
- *
- * Command:
- *   /recap                     Force-generate a recap right now
- */
-
-import { createHash } from "node:crypto";
-import { completeSimple, getModel } from "@earendil-works/pi-ai/compat";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	applyDeprecatedFlagOverrides,
+	loadConfig,
+	shippedDefaults,
+	type RecapConfig,
+	type RecapReason,
+} from "./config.ts";
+import { FocusSequenceParser } from "./focus-parser.ts";
+import { consumePendingAway, DeferredTriggerState, LiveActivityBuffer, LiveRecapState, type LiveRequest } from "./live-state.ts";
+import {
+	buildTranscript,
+	extractText,
+	generateRecap,
+	hasMeaningfulActivity,
+	recapStateKey,
+	type CompleteFunction,
+	type Entry,
+	type RecapContext,
+} from "./recap.ts";
+import { clearOwnedStatus } from "./ui-state.ts";
 
-type ContentBlock = {
-	type?: string;
-	text?: string;
-	name?: string;
-	arguments?: Record<string, unknown>;
-};
-
-type Entry = {
-	id?: string;
-	type: string;
-	summary?: string; // compaction / branch_summary entries
-	message?: {
-		role?: string;
-		content?: unknown;
-		toolName?: string;
-	};
-};
-
-type Model = Parameters<typeof completeSimple>[0];
-
-type RecapReason = "idle" | "manual" | "resume" | "focus";
-
-const WIDGET_KEY = "session-recap";
-const STATUS_KEY = "session-recap";
-
-const DEFAULT_AWAY_SECONDS = 90;
-const DEFAULT_IDLE_SECONDS = 120;
-
-// Debounce after a turn ends while blurred, so mid-loop turn_ends (which are
-// immediately followed by the next turn_start) don't trigger drafts.
-const POST_TURN_DEBOUNCE_MS = 3000;
-
-// Task-framing context limits (tier 1 of the transcript).
-const EARLIER_USER_PROMPTS = 4;
-const EARLIER_PROMPT_CHARS = 300;
-const COMPACTION_SUMMARY_CHARS = 600;
-
-// Model input cap. The dedupe fingerprint hashes exactly this capped prompt
-// payload, so irrelevant session metadata or over-cap transcript changes do
-// not spend another recap call.
-const TRANSCRIPT_CHAR_CAP = 12000;
-
-// Widget body wrapping.
-const WRAP_WIDTH = 100;
-const MAX_BODY_LINES = 4;
-
-// DECSET 1004 focus reporting — https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-const FOCUS_ENABLE = "\x1b[?1004h";
-const FOCUS_DISABLE = "\x1b[?1004l";
-const FOCUS_IN_SEQ = "\x1b[I";
-const FOCUS_OUT_SEQ = "\x1b[O";
-
-// --- helpers -----------------------------------------------------------------
-
-function splitModel(spec: string): { provider: string; id: string } | undefined {
-	const idx = spec.indexOf("/");
-	if (idx <= 0) return undefined;
-	return { provider: spec.slice(0, idx), id: spec.slice(idx + 1) };
-}
-
-function extractText(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return "";
-	const parts: string[] = [];
-	for (const part of content) {
-		if (!part || typeof part !== "object") continue;
-		const b = part as ContentBlock;
-		if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
-	}
-	return parts.join("\n");
-}
-
-function extractToolCalls(content: unknown): string[] {
-	if (!Array.isArray(content)) return [];
-	const out: string[] = [];
-	for (const part of content) {
-		if (!part || typeof part !== "object") continue;
-		const b = part as ContentBlock;
-		if (b.type !== "toolCall" || typeof b.name !== "string") continue;
-		const args = b.arguments ?? {};
-		const summary = JSON.stringify(args).slice(0, 280);
-		out.push(`- ${b.name}(${summary})`);
-	}
-	return out;
-}
-
-/**
- * Two-tier transcript:
- *
- *   Tier 1 — task framing (cheap): the most recent compaction/branch summary
- *   if present, plus the last few *user* prompts before the latest one,
- *   trimmed hard. This is what lets the model state the high-level task
- *   instead of parroting the last tool call. (Claude Code feeds the last 30
- *   raw messages to Haiku for this; we're on the active model, so we keep the
- *   framing to user prompts only — old tool results add cost, not
- *   orientation.)
- *
- *   Tier 2 — recent detail: everything since the last user message, with the
- *   same per-item trimming as before (assistant text, tool calls, results).
- */
-function buildTranscript(entries: Entry[]): string {
-	const userIdxs: number[] = [];
-	for (let i = 0; i < entries.length; i++) {
-		const e = entries[i];
-		if (e.type === "message" && e.message?.role === "user") userIdxs.push(i);
-	}
-	const lastUserIdx = userIdxs.length > 0 ? userIdxs[userIdxs.length - 1] : -1;
-
-	const lines: string[] = [];
-
-	// Tier 1a: most recent compaction / branch summary — already-distilled task context.
-	for (let i = entries.length - 1; i >= 0; i--) {
-		const e = entries[i];
-		if (
-			(e.type === "compaction" || e.type === "branch_summary") &&
-			typeof e.summary === "string" &&
-			e.summary.trim()
-		) {
-			lines.push(`Session summary so far: ${e.summary.trim().slice(0, COMPACTION_SUMMARY_CHARS)}`);
-			break;
-		}
-	}
-
-	// Tier 1b: earlier user prompts (task framing), oldest → newest.
-	const earlier = userIdxs.slice(0, -1).slice(-EARLIER_USER_PROMPTS);
-	const earlierLines: string[] = [];
-	for (const i of earlier) {
-		const t = extractText(entries[i].message?.content).trim();
-		if (t) earlierLines.push(`- ${t.slice(0, EARLIER_PROMPT_CHARS)}`);
-	}
-	if (earlierLines.length > 0) {
-		lines.push("Earlier user prompts (task framing):");
-		lines.push(...earlierLines);
-	}
-
-	// Tier 2: full compact detail since the last user message (inclusive).
-	const slice = lastUserIdx >= 0 ? entries.slice(lastUserIdx) : entries;
-	const detail: string[] = [];
-	for (const e of slice) {
-		if (e.type !== "message" || !e.message?.role) continue;
-		const role = e.message.role;
-		if (role === "user") {
-			const t = extractText(e.message.content).trim();
-			if (t) detail.push(`User: ${t.slice(0, 1200)}`);
-		} else if (role === "assistant") {
-			const t = extractText(e.message.content).trim();
-			if (t) detail.push(`Assistant: ${t.slice(0, 1200)}`);
-			const calls = extractToolCalls(e.message.content);
-			if (calls.length) detail.push(...calls);
-		} else if (role === "toolResult") {
-			const t = extractText(e.message.content).trim();
-			const name = e.message.toolName ?? "tool";
-			if (t) detail.push(`Result(${name}): ${t.slice(0, 400)}`);
-		}
-	}
-	if (detail.length > 0) {
-		lines.push("Recent activity (since the user's last message):");
-		lines.push(...detail);
-	}
-
-	return lines.join("\n");
-}
-
-function recapStateKey(transcript: string): string {
-	return createHash("sha256").update(transcript.slice(0, TRANSCRIPT_CHAR_CAP)).digest("hex");
-}
-
-/**
- * Only draft a recap if there has been real agent activity since the last user
- * message: at least one tool call, or ~30+ words of assistant text.
- */
-function hasMeaningfulActivity(entries: Entry[]): boolean {
-	let lastUserIdx = -1;
-	for (let i = entries.length - 1; i >= 0; i--) {
-		const e = entries[i];
-		if (e.type === "message" && e.message?.role === "user") {
-			lastUserIdx = i;
-			break;
-		}
-	}
-	const tail = lastUserIdx >= 0 ? entries.slice(lastUserIdx + 1) : entries;
-	let assistantWords = 0;
-	let toolCalls = 0;
-	for (const e of tail) {
-		if (e.type !== "message") continue;
-		if (e.message?.role === "assistant") {
-			const t = extractText(e.message.content);
-			assistantWords += t.split(/\s+/).filter(Boolean).length;
-			toolCalls += extractToolCalls(e.message.content).length;
-		}
-	}
-	return toolCalls > 0 || assistantWords >= 30;
+function isAssistantMessage(message: unknown): message is AssistantMessage {
+	return (
+		typeof message === "object" &&
+		message !== null &&
+		"role" in message &&
+		message.role === "assistant" &&
+		"content" in message &&
+		Array.isArray(message.content)
+	);
 }
 
 function wrapText(text: string, width: number, maxLines: number): string[] {
-	const words = text.split(/\s+/).filter(Boolean);
-	const lines: string[] = [];
-	let cur = "";
-	for (const w of words) {
-		if (cur && cur.length + 1 + w.length > width) {
-			lines.push(cur);
-			cur = w;
-		} else {
-			cur = cur ? `${cur} ${w}` : w;
+	const output: string[] = [];
+	for (const sourceLine of text.split("\n")) {
+		let current = "";
+		for (const word of sourceLine.split(/\s+/).filter(Boolean)) {
+			if (current && current.length + word.length + 1 > width) {
+				output.push(current);
+				current = word;
+			} else current = current ? `${current} ${word}` : word;
 		}
+		if (current) output.push(current);
 	}
-	if (cur) lines.push(cur);
-	if (lines.length > maxLines) {
-		const kept = lines.slice(0, maxLines);
-		kept[maxLines - 1] += " …";
-		return kept;
-	}
-	return lines;
+	if (output.length <= maxLines) return output;
+	const kept = output.slice(0, maxLines);
+	kept[maxLines - 1] = `${kept[maxLines - 1]} …`;
+	return kept;
 }
 
-async function generateRecap(
-	transcript: string,
-	ctx: ExtensionContext,
-	overrideSpec: string | undefined,
-	signal: AbortSignal | undefined,
-): Promise<string | undefined> {
-	// Prefer explicit override flag; otherwise use the active model.
-	let model: Model | undefined = ctx.model;
-	if (overrideSpec) {
-		const parsed = splitModel(overrideSpec);
-		if (parsed) {
-			const found = (getModel as (provider: string, id: string) => Model | undefined)(
-				parsed.provider,
-				parsed.id,
-			);
-			if (found) model = found;
-		}
-	}
-	if (!model) return undefined;
-
-	// Note: apiKey may legitimately be absent for env/ambient-auth providers —
-	// only bail when auth resolution itself failed.
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-	if (!auth?.ok) return undefined;
-
-	// Prompt philosophy mirrors Claude Code's away-summary: orient the user in
-	// the high-level task, don't produce a status report — the last assistant
-	// message is already visible in scrollback.
-	const prompt =
-		"The user stepped away from this coding-agent session and is coming back. " +
-		"Write a short recap so they can re-enter flow.\n\n" +
-		"Rules:\n" +
-		"- Write 1-3 short sentences of plain text. No preamble, no markdown, no bullets.\n" +
-		"- Start by stating the high-level task — what the user is building, fixing, or " +
-		"debugging — not implementation minutiae.\n" +
-		"- End with the concrete next step, if there is one.\n" +
-		"- Skip status reports and commit recaps; orient the reader instead.\n" +
-		"- If the last turn was aborted or errored, say so explicitly " +
-		'(e.g. "aborted during X", "errored at Y").\n' +
-		"- Use file/function names where they matter. Max ~400 characters.\n\n" +
-		"<transcript>\n" +
-		transcript.slice(0, TRANSCRIPT_CHAR_CAP) +
-		"\n</transcript>";
-
-	let response;
-	try {
-		response = await completeSimple(
-			model,
-			{
-				// Some providers (notably openai-codex-responses) require a non-empty
-				// top-level instruction string even for simple one-shot completions.
-				systemPrompt: "You write terse, concrete session recaps for a coding agent UI.",
-				messages: [
-					{
-						role: "user",
-						content: [{ type: "text", text: prompt }],
-						timestamp: Date.now(),
-					},
-				],
-			},
-			{
-				apiKey: auth.apiKey,
-				headers: auth.headers,
-				env: auth.env,
-				signal,
-				// Recaps are tiny, throwaway UI hints. Do not pay to create/read prompt
-				// cache entries, and do not spend reasoning tokens. Claude Code's away
-				// summary path likewise disables thinking for this job.
-				cacheRetention: "none",
-				maxTokens: 256,
-			},
-		);
-	} catch (err) {
-		// Custom providers registered only with pi (e.g. via a bridge extension)
-		// are unknown to pi-ai's compat provider registry, so completeSimple
-		// cannot route the call. Skip the recap silently, matching the documented
-		// "failed auth resolution → skipped silently" behavior.
-		if (err instanceof Error && err.message.startsWith("No API provider registered for api:")) {
-			return undefined;
-		}
-		throw err;
-	}
-
-	const text = response.content
-		.filter((c): c is { type: "text"; text: string } => c.type === "text")
-		.map((c) => c.text)
-		.join(" ")
-		.replace(/\s+/g, " ")
-		.trim();
-
-	return text ? text.slice(0, 600) : undefined;
+function focusConfigKey(config: RecapConfig): string {
+	return JSON.stringify({ enabled: config.enabled.focusReporting, ...config.focus });
 }
 
-function showRecap(ctx: ExtensionContext, recap: string) {
-	if (!ctx.hasUI) return;
-	const theme = ctx.ui.theme;
-	const header = theme.fg("accent", theme.bold("✦ recap"));
-	const body = wrapText(recap, WRAP_WIDTH, MAX_BODY_LINES).map((l) => theme.fg("dim", l));
-	ctx.ui.setWidget(WIDGET_KEY, [header, ...body], { placement: "aboveEditor" });
+function activityOptions(config: RecapConfig) {
+	return {
+		assistantCharsPerVersion: config.activity.assistantCharsPerLiveVersion,
+		toolUpdateCharsPerVersion: config.activity.toolUpdateCharsPerLiveVersion,
+		maxEvents: config.activity.maxLiveEvents,
+		maxEventChars: config.activity.maxLiveEventChars,
+		maxRunningTools: config.activity.maxRunningTools,
+		liveAssistantChars: config.transcript.liveAssistantChars,
+	};
 }
 
-function clearRecap(ctx: ExtensionContext) {
-	if (!ctx.hasUI) return;
-	ctx.ui.setWidget(WIDGET_KEY, undefined);
-	ctx.ui.setStatus(STATUS_KEY, undefined);
-}
-
-// --- extension ---------------------------------------------------------------
-
-export default function (pi: ExtensionAPI) {
-	pi.registerFlag("recap-away-seconds", {
-		description: "Seconds of continuous terminal blur before an away recap is generated",
-		type: "string",
-		default: String(DEFAULT_AWAY_SECONDS),
-	});
-	pi.registerFlag("recap-idle-seconds", {
-		description:
-			"Idle-fallback: seconds after turn_end before a recap when the terminal doesn't report focus",
-		type: "string",
-		default: String(DEFAULT_IDLE_SECONDS),
-	});
-	pi.registerFlag("recap-disable-focus", {
-		description: "Disable DECSET ?1004 focus reporting (idle fallback still runs)",
-		type: "boolean",
-		default: false,
-	});
-	pi.registerFlag("recap-during-active", {
-		description: "Allow away recaps while an agent turn is still running",
-		type: "boolean",
-		default: false,
-	});
-	pi.registerFlag("recap-disable", {
-		description: "Disable the automatic session recap",
-		type: "boolean",
-		default: false,
-	});
-	pi.registerFlag("recap-model", {
-		description: "Override the default (active) model, e.g. anthropic/claude-sonnet-4-6",
+export default function sessionRecap(pi: ExtensionAPI) {
+	pi.registerFlag("recap-config", {
+		description: "Path to a session-recap JSON override (overrides PI_SESSION_RECAP_CONFIG)",
 		type: "string",
 		default: "",
 	});
+	for (const [name, description, type] of [
+		["recap-away-seconds", "Deprecated: override timings.awayMs", "string"],
+		["recap-idle-seconds", "Deprecated: override timings.idleMs", "string"],
+		["recap-disable-focus", "Deprecated: set enabled.focusReporting=false", "boolean"],
+		["recap-during-active", "Deprecated: set focus.allowAwayDuringAgent=true", "boolean"],
+		["recap-disable", "Deprecated: set enabled.automatic=false", "boolean"],
+		["recap-model", "Deprecated: prepend a provider/model candidate", "string"],
+	] as const) {
+		pi.registerFlag(name, { description, type, default: type === "boolean" ? false : "" });
+	}
 
-	// Timers. Only one recap request is ever in flight; starting a new one
-	// aborts the previous.
-	let idleTimer: NodeJS.Timeout | undefined; // fallback for no-focus-support terminals
-	let awayTimer: NodeJS.Timeout | undefined; // continuous-blur timer
-	let postTurnTimer: NodeJS.Timeout | undefined; // turn ended while blurred
-	let activeController: AbortController | undefined;
-
-	// Agent activity state. Like Claude Code's away summary, we don't draft
-	// while a turn is still loading: if the away/post-turn trigger fires
-	// mid-turn, we set a pending bit and generate on agent_end (if still
-	// blurred). This avoids summarising a half-written branch.
+	let canonicalConfig = shippedDefaults();
+	let config = applyDeprecatedFlagOverrides(canonicalConfig, {});
+	let liveBuffer = new LiveActivityBuffer(activityOptions(config));
+	const liveState = new LiveRecapState();
+	const deferredAway = new DeferredTriggerState();
+	let liveTimer: NodeJS.Timeout | undefined;
+	let idleTimer: NodeJS.Timeout | undefined;
+	let awayTimer: NodeJS.Timeout | undefined;
+	let postTurnTimer: NodeJS.Timeout | undefined;
+	let resumeTimer: NodeJS.Timeout | undefined;
+	let focusedOutAt: number | undefined;
+	let focusEventsSeen = false;
+	let focusEnabled = false;
+	let focusListener: ((chunk: Buffer) => void) | undefined;
+	let focusDisableSequence = "";
+	let renderedWidgetKey: string | undefined;
+	let renderedStatusKey: string | undefined;
+	let refreshFocusReporting: ((ctx: ExtensionContext) => void) | undefined;
 	let agentActive = false;
 	let focusDraftAfterAgent = false;
-
-	// Focus reporting state.
-	let focusListener: ((chunk: Buffer) => void) | undefined;
-	let focusEnabled = false;
-	let focusedOutAt: number | undefined;
-	// True once we've seen any ESC[I / ESC[O this session — i.e. the terminal
-	// demonstrably supports focus reporting, so the idle fallback is redundant.
-	let focusEventsSeen = false;
-
-	// Fingerprint of the recap-relevant transcript we last drafted. This is more
-	// precise than the raw branch leaf: Pi appends metadata entries such as
-	// session names, model/thinking changes, labels, or leaf markers that can
-	// advance the leaf without changing the recap prompt at all.
+	let pendingAwayAfterRequest = false;
 	let lastDraftedStateKey: string | undefined;
+	let requestSerial = 0;
+	let activeRequest:
+		| { id: number; controller: AbortController; reason: RecapReason; liveRequest?: LiveRequest; statusKey?: string }
+		| undefined;
 
-	const awayMs = (): number => {
-		const n = Number(pi.getFlag("recap-away-seconds") ?? DEFAULT_AWAY_SECONDS);
-		return Math.max(5, Number.isFinite(n) ? n : DEFAULT_AWAY_SECONDS) * 1000;
+	const clearTimer = (timer: NodeJS.Timeout | undefined): undefined => {
+		if (timer) clearTimeout(timer);
+		return undefined;
 	};
-	const idleMs = (): number => {
-		const n = Number(pi.getFlag("recap-idle-seconds") ?? DEFAULT_IDLE_SECONDS);
-		return Math.max(5, Number.isFinite(n) ? n : DEFAULT_IDLE_SECONDS) * 1000;
-	};
-	const isDisabled = (): boolean => Boolean(pi.getFlag("recap-disable"));
-	const isFocusDisabled = (): boolean => Boolean(pi.getFlag("recap-disable-focus"));
-	const allowDuringActive = (): boolean => Boolean(pi.getFlag("recap-during-active"));
-	const modelOverride = (): string | undefined => {
-		const v = String(pi.getFlag("recap-model") ?? "").trim();
-		return v.length > 0 ? v : undefined;
+	const stopLiveTimer = () => {
+		if (liveTimer) clearInterval(liveTimer);
+		liveTimer = undefined;
 	};
 
-	const clearIdleTimer = () => {
-		if (idleTimer) {
-			clearTimeout(idleTimer);
-			idleTimer = undefined;
+	const flagString = (name: string): string => String(pi.getFlag(name) ?? "").trim();
+	const reloadConfig = (ctx: ExtensionContext) => {
+		const previous = config;
+		const previousFocusKey = focusConfigKey(previous);
+		const explicitPath = flagString("recap-config") || undefined;
+		const result = loadConfig(
+			{ cwd: ctx.cwd, projectTrusted: ctx.isProjectTrusted(), explicitPath },
+			canonicalConfig,
+			(message) => {
+				console.error(message);
+				if (ctx.hasUI) ctx.ui.notify(message, "warning");
+			},
+		);
+		canonicalConfig = result.config;
+		config = applyDeprecatedFlagOverrides(canonicalConfig, {
+			awaySeconds: flagString("recap-away-seconds"),
+			idleSeconds: flagString("recap-idle-seconds"),
+			disableFocus: Boolean(pi.getFlag("recap-disable-focus")),
+			duringActive: Boolean(pi.getFlag("recap-during-active")),
+			disable: Boolean(pi.getFlag("recap-disable")),
+			model: flagString("recap-model"),
+		});
+		if (ctx.hasUI && previous.widget.key !== config.widget.key) {
+			ctx.ui.setWidget(renderedWidgetKey ?? previous.widget.key, undefined);
+			renderedWidgetKey = undefined;
 		}
-	};
-	const clearAwayTimer = () => {
-		if (awayTimer) {
-			clearTimeout(awayTimer);
-			awayTimer = undefined;
+		if (ctx.hasUI && previous.widget.statusKey !== config.widget.statusKey) {
+			ctx.ui.setStatus(renderedStatusKey ?? previous.widget.statusKey, undefined);
+			renderedStatusKey = undefined;
 		}
-	};
-	const clearPostTurnTimer = () => {
-		if (postTurnTimer) {
-			clearTimeout(postTurnTimer);
-			postTurnTimer = undefined;
-		}
+		if (!agentActive) liveBuffer = new LiveActivityBuffer(activityOptions(config));
+		if (previousFocusKey !== focusConfigKey(config)) refreshFocusReporting?.(ctx);
 	};
 
-	const cancelActive = () => {
-		if (activeController) {
-			activeController.abort();
-			activeController = undefined;
-		}
+	const showRecap = (ctx: ExtensionContext, recap: string) => {
+		if (!ctx.hasUI) return;
+		const theme = ctx.ui.theme;
+		const headerColor = config.widget.headerColor as Parameters<typeof theme.fg>[0];
+		const bodyColor = config.widget.bodyColor as Parameters<typeof theme.fg>[0];
+		const header = theme.fg(headerColor, theme.bold(config.widget.header));
+		const body = wrapText(recap, config.widget.wrapWidth, config.widget.maxBodyLines)
+			.map((line) => theme.fg(bodyColor, line));
+		if (renderedWidgetKey && renderedWidgetKey !== config.widget.key) ctx.ui.setWidget(renderedWidgetKey, undefined);
+		ctx.ui.setWidget(config.widget.key, [header, ...body], { placement: config.widget.placement });
+		renderedWidgetKey = config.widget.key;
+	};
+	const clearRecap = (ctx: ExtensionContext) => {
+		if (!ctx.hasUI) return;
+		ctx.ui.setWidget(renderedWidgetKey ?? config.widget.key, undefined);
+		ctx.ui.setStatus(renderedStatusKey ?? config.widget.statusKey, undefined);
+		renderedWidgetKey = undefined;
+		renderedStatusKey = undefined;
 	};
 
-	// The idle fallback only exists for terminals that don't report focus.
-	// Once we've seen a real focus event, the away/post-turn triggers own the
-	// job and the idle path would just be noise while the user is watching.
-	const idleFallbackEligible = (): boolean =>
-		!focusEnabled || isFocusDisabled() || !focusEventsSeen;
+	const cancelRequest = (ctx: ExtensionContext) => {
+		if (!activeRequest) return;
+		const request = activeRequest;
+		request.controller.abort();
+		if (request.liveRequest) liveState.cancel(request.liveRequest.id);
+		if (ctx.hasUI) {
+			renderedStatusKey = clearOwnedStatus(
+				(key, value) => ctx.ui.setStatus(key, value),
+				request.statusKey,
+				renderedStatusKey,
+			);
+		}
+		activeRequest = undefined;
+	};
 
-	const generateAndShow = async (ctx: ExtensionContext, opts: { reason: RecapReason }) => {
+	const snapshot = (ctx: ExtensionContext, includeLive: boolean): { transcript: string; key: string; entries: Entry[] } => {
 		const entries = ctx.sessionManager.getBranch() as Entry[];
-		if (!hasMeaningfulActivity(entries) && opts.reason !== "manual") return;
+		const transcript = buildTranscript(entries, config, includeLive ? liveBuffer.lines() : []);
+		return { entries, transcript, key: recapStateKey(transcript) };
+	};
 
-		const transcript = buildTranscript(entries);
-		if (!transcript.trim()) return;
+	const startRecap = async (
+		ctx: ExtensionContext,
+		reason: RecapReason,
+		options: { manual?: boolean; liveRequest?: LiveRequest } = {},
+	) => {
+		const releaseStateRequest = () => {
+			if (options.liveRequest) liveState.cancel(options.liveRequest.id);
+		};
+		if (!ctx.hasUI) {
+			releaseStateRequest();
+			return;
+		}
+		if (options.manual) cancelRequest(ctx);
+		else if (activeRequest) {
+			releaseStateRequest();
+			return;
+		}
+		const current = snapshot(ctx, reason === "live" || reason === "manual");
+		if (!current.transcript.trim()) {
+			releaseStateRequest();
+			return;
+		}
+		if (reason !== "manual" && reason !== "live" && !hasMeaningfulActivity(current.entries, config)) {
+			releaseStateRequest();
+			return;
+		}
+		if (reason !== "manual" && lastDraftedStateKey === current.key) {
+			releaseStateRequest();
+			return;
+		}
 
-		// Snapshot the exact recap prompt we're summarising BEFORE we await. If
-		// recap-relevant content changes while the model call is in flight, discard
-		// the stale draft; metadata-only leaf changes should not invalidate it.
-		const startStateKey = recapStateKey(transcript);
-		if (opts.reason !== "manual" && lastDraftedStateKey === startStateKey) return;
-
-		// Take ownership of the active-request slot. Any prior request is
-		// cancelled; we'll only clear shared state in the finally if we're
-		// still the current owner, so a late-completing aborted call can't
-		// stomp on a newer in-flight request.
-		cancelActive();
+		const id = ++requestSerial;
 		const controller = new AbortController();
-		activeController = controller;
-
-		const showStatus = opts.reason === "manual" || opts.reason === "idle";
-		if (showStatus && ctx.hasUI)
-			ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", "✦ drafting recap…"));
-
+		const requestStatusKey = reason === "manual" || reason === "idle" ? config.widget.statusKey : undefined;
+		activeRequest = { id, controller, reason, liveRequest: options.liveRequest, statusKey: requestStatusKey };
+		if (requestStatusKey) {
+			const statusColor = config.widget.bodyColor as Parameters<typeof ctx.ui.theme.fg>[0];
+			if (renderedStatusKey && renderedStatusKey !== requestStatusKey) ctx.ui.setStatus(renderedStatusKey, undefined);
+			ctx.ui.setStatus(requestStatusKey, ctx.ui.theme.fg(statusColor, config.widget.draftingStatus));
+			renderedStatusKey = requestStatusKey;
+		}
+		let displayed = false;
 		try {
-			const recap = await generateRecap(transcript, ctx, modelOverride(), controller.signal);
-			if (!recap || controller.signal.aborted) return;
-			// Discard the recap if the recap prompt changed while we were drafting.
-			// If only session metadata changed, the prompt key stays the same and the
-			// draft remains valid.
-			const currentTranscript = buildTranscript(ctx.sessionManager.getBranch() as Entry[]);
-			if (recapStateKey(currentTranscript) !== startStateKey) return;
-
-			// Stamp the prompt we actually summarised, not the live branch leaf.
-			lastDraftedStateKey = startStateKey;
-			// Another trigger has produced a recap for this content — kill the
-			// other timers so we don't issue a second call later.
-			clearIdleTimer();
-			clearPostTurnTimer();
-
-			// Show immediately. Away/post-turn recaps are drafted while the user
-			// is away, so the widget is parked above the editor when they return;
-			// if they returned mid-draft, it's still the "just got back" moment.
+			const recap = await generateRecap(
+				current.transcript,
+				reason,
+				ctx as unknown as RecapContext,
+				config,
+				controller.signal,
+				completeSimple as unknown as CompleteFunction,
+			);
+			if (!recap || controller.signal.aborted || activeRequest?.id !== id) return;
+			// Snapshot semantics: later activity does not invalidate this useful recap.
+			// Request ownership prevents an older completion from replacing a newer one.
+			lastDraftedStateKey = current.key;
 			showRecap(ctx, recap);
-		} catch (err) {
-			if (!controller.signal.aborted) console.error("[session-recap] failed:", err);
+			displayed = true;
+			idleTimer = clearTimer(idleTimer);
+			postTurnTimer = clearTimer(postTurnTimer);
+		} catch (error) {
+			if (!controller.signal.aborted) console.error("[session-recap] failed:", error);
 		} finally {
-			if (activeController === controller) {
-				activeController = undefined;
-				if (showStatus && ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+			if (activeRequest?.id === id) {
+				activeRequest = undefined;
+				if (options.liveRequest) liveState.complete(options.liveRequest.id, Date.now(), displayed);
+				renderedStatusKey = clearOwnedStatus(
+					(key, value) => ctx.ui.setStatus(key, value),
+					requestStatusKey,
+					renderedStatusKey,
+				);
+				const pendingAway = consumePendingAway(
+					pendingAwayAfterRequest,
+					focusedOutAt !== undefined,
+					config.enabled.automatic,
+					config.enabled.away,
+				);
+				pendingAwayAfterRequest = pendingAway.pending;
+				if (pendingAway.shouldSchedule) scheduleDeferredAway(ctx);
 			}
 		}
 	};
 
-	// Shared gate for the away-timer / post-turn / deferred-after-agent paths.
-	// Requires the terminal to still be blurred.
+	const markLiveActivity = (eventName: string, meaningful: boolean) => {
+		if (meaningful && config.activity.liveEvents.includes(eventName)) liveState.activity();
+	};
+	const pollLive = (ctx: ExtensionContext) => {
+		if (!config.enabled.automatic || !config.enabled.live || !agentActive || activeRequest) return;
+		const request = liveState.beginLive(Date.now(), config.timings.liveFirstMs, config.timings.liveMinIntervalMs);
+		if (request) void startRecap(ctx, "live", { liveRequest: request });
+	};
+	const startLiveTimer = (ctx: ExtensionContext) => {
+		stopLiveTimer();
+		if (!config.enabled.automatic || !config.enabled.live) return;
+		liveTimer = setInterval(() => pollLive(ctx), config.timings.livePollMs);
+	};
+
+	const idleFallbackEligible = () => !focusEnabled || !config.enabled.focusReporting || !focusEventsSeen;
 	const tryAwayRecap = (ctx: ExtensionContext) => {
-		if (isDisabled() || !ctx.hasUI) return;
-		if (focusedOutAt === undefined) return; // user came back — drop it
-		if (agentActive && !allowDuringActive()) {
-			// Turn still loading: defer to agent_end (Claude Code's pending bit).
+		if (!config.enabled.automatic || !config.enabled.away || focusedOutAt === undefined) return;
+		if (activeRequest) {
+			pendingAwayAfterRequest = true;
+			return;
+		}
+		if (agentActive && !config.focus.allowAwayDuringAgent) {
 			focusDraftAfterAgent = true;
 			return;
 		}
-		if (activeController) return; // one request at a time
-
-		// generateAndShow fingerprints the recap prompt and returns before the
-		// model call when we have already drafted for the same session content.
-		void generateAndShow(ctx, { reason: "focus" });
+		void startRecap(ctx, "away");
 	};
-
-	const scheduleIdleRecap = (ctx: ExtensionContext) => {
-		clearIdleTimer();
-		if (isDisabled() || !ctx.hasUI) return;
+	const scheduleDeferredAway = (ctx: ExtensionContext) => {
+		const generation = deferredAway.arm();
+		setTimeout(() => {
+			if (!deferredAway.consume(generation)) return;
+			tryAwayRecap(ctx);
+		}, 0);
+	};
+	const scheduleIdle = (ctx: ExtensionContext) => {
+		idleTimer = clearTimer(idleTimer);
+		if (!config.enabled.automatic || !config.enabled.idle) return;
 		idleTimer = setTimeout(() => {
 			idleTimer = undefined;
-			// Re-check at fire time: a focus event may have arrived since arming.
-			if (!idleFallbackEligible()) return;
-			void generateAndShow(ctx, { reason: "idle" });
-		}, idleMs());
+			if (!config.enabled.automatic || !config.enabled.idle) return;
+			if (idleFallbackEligible()) void startRecap(ctx, "idle");
+		}, config.timings.idleMs);
 	};
-
-	// --- focus reporting wiring -------------------------------------------
 
 	const handleFocusOut = (ctx: ExtensionContext) => {
 		focusEventsSeen = true;
 		focusedOutAt = Date.now();
-		// Focus reporting works — the idle fallback is now redundant.
-		clearIdleTimer();
-		if (isDisabled()) return;
-		clearAwayTimer();
+		idleTimer = clearTimer(idleTimer);
+		awayTimer = clearTimer(awayTimer);
+		if (!config.enabled.automatic || !config.enabled.away) return;
 		awayTimer = setTimeout(() => {
 			awayTimer = undefined;
 			tryAwayRecap(ctx);
-		}, awayMs());
+		}, config.timings.awayMs);
 	};
-
-	const handleFocusIn = (_ctx: ExtensionContext) => {
+	const handleFocusIn = (ctx: ExtensionContext) => {
 		focusEventsSeen = true;
 		focusedOutAt = undefined;
 		focusDraftAfterAgent = false;
-		clearAwayTimer();
-		// The user is back and looking at the output — a post-turn recap now
-		// would just repeat what's on screen.
-		clearPostTurnTimer();
-		clearIdleTimer();
-		// Note: an in-flight draft (triggered by a genuine absence) is left to
-		// finish — it lands moments after return, which is exactly when it helps.
+		pendingAwayAfterRequest = false;
+		deferredAway.cancel();
+		awayTimer = clearTimer(awayTimer);
+		postTurnTimer = clearTimer(postTurnTimer);
+		idleTimer = clearTimer(idleTimer);
+		if (!config.focus.finishDraftAfterRefocus && activeRequest?.reason === "away") cancelRequest(ctx);
 	};
 
 	const attachFocusReporting = (ctx: ExtensionContext) => {
-		if (focusEnabled || isFocusDisabled() || !ctx.hasUI) return;
-		if (!process.stdout.isTTY || !process.stdin.isTTY) return;
-
+		if (focusEnabled || !config.enabled.focusReporting || !ctx.hasUI || !process.stdout.isTTY || !process.stdin.isTTY) return;
+		const focus = { ...config.focus };
 		try {
-			process.stdout.write(FOCUS_ENABLE);
+			process.stdout.write(focus.enableSequence);
 		} catch {
 			return;
 		}
-
-		// Scan stdin for ESC[I / ESC[O. Sequences can straddle chunks, so we
-		// keep unconsumed trailing bytes in `buf` between calls. Consume each
-		// match by advancing `i`, so a completed sequence never fires twice.
-		// Adding a 'data' listener is safe: Node dispatches to all listeners
-		// and pi is already in flowing mode — we don't steal bytes from the
-		// TUI's input layer.
-		const MAX_SEQ = Math.max(FOCUS_IN_SEQ.length, FOCUS_OUT_SEQ.length);
-		let buf = "";
-		const listener = (chunk: Buffer) => {
-			try {
-				buf += chunk.toString("binary");
-				let i = 0;
-				while (i + MAX_SEQ <= buf.length) {
-					if (buf.startsWith(FOCUS_IN_SEQ, i)) {
-						handleFocusIn(ctx);
-						i += FOCUS_IN_SEQ.length;
-					} else if (buf.startsWith(FOCUS_OUT_SEQ, i)) {
-						handleFocusOut(ctx);
-						i += FOCUS_OUT_SEQ.length;
-					} else {
-						i++;
-					}
-				}
-				buf = buf.slice(i);
-				// Safety net — never let buf grow unbounded if we're reading a
-				// long non-escape stream on a terminal that streams ahead of us.
-				if (buf.length > 64) buf = buf.slice(-(MAX_SEQ - 1));
-			} catch {
-				/* best-effort */
+		const parser = new FocusSequenceParser(focus.inSequence, focus.outSequence, focus.inputBufferCap);
+		focusListener = (chunk: Buffer) => {
+			for (const event of parser.push(chunk.toString("binary"))) {
+				if (event === "in") handleFocusIn(ctx);
+				else handleFocusOut(ctx);
 			}
 		};
-		process.stdin.on("data", listener);
-		focusListener = listener;
+		process.stdin.on("data", focusListener);
 		focusEnabled = true;
+		focusDisableSequence = focus.disableSequence;
 	};
-
 	const detachFocusReporting = () => {
-		if (focusListener) {
-			try {
-				process.stdin.off("data", focusListener);
-			} catch {
-				/* noop */
-			}
-			focusListener = undefined;
-		}
+		if (focusListener) process.stdin.off("data", focusListener);
+		focusListener = undefined;
 		if (focusEnabled) {
-			try {
-				process.stdout.write(FOCUS_DISABLE);
-			} catch {
-				/* noop */
-			}
-			focusEnabled = false;
+			try { process.stdout.write(focusDisableSequence); } catch { /* best effort */ }
 		}
+		focusEnabled = false;
 		focusedOutAt = undefined;
 		focusDraftAfterAgent = false;
+		pendingAwayAfterRequest = false;
+		deferredAway.cancel();
+	};
+	refreshFocusReporting = (ctx) => {
+		detachFocusReporting();
+		focusEventsSeen = false;
+		attachFocusReporting(ctx);
 	};
 
-	// Lifecycle: recap triggers arm on turn_end (fires even on error/abort)
-	// and are cleared by anything that indicates new activity or input.
-
+	pi.on("message_update", async (event) => {
+		if (!isAssistantMessage(event.message)) return;
+		const meaningful = liveBuffer.assistantUpdate(extractText(event.message.content));
+		markLiveActivity("message_update", meaningful);
+	});
+	pi.on("message_end", async (event) => {
+		if (!isAssistantMessage(event.message)) return;
+		markLiveActivity("message_end", liveBuffer.messageEnd(extractText(event.message.content)));
+	});
+	pi.on("tool_execution_start", async (event) => {
+		markLiveActivity("tool_execution_start", liveBuffer.toolStart(event.toolCallId, event.toolName, event.args));
+	});
+	pi.on("tool_execution_update", async (event) => {
+		markLiveActivity("tool_execution_update", liveBuffer.toolUpdate(event.toolCallId, event.toolName, event.partialResult));
+	});
+	pi.on("tool_execution_end", async (event) => {
+		markLiveActivity("tool_execution_end", liveBuffer.toolEnd(event.toolCallId, event.toolName, event.result, event.isError));
+	});
 	pi.on("turn_end", async (_event, ctx) => {
-		if (isDisabled() || !ctx.hasUI) return;
-
-		// Prime multi-tab moment: the agent produced output while the user is
-		// away. Debounced so mid-loop turn_ends (followed by the next
-		// turn_start within moments) don't trigger drafts; tryAwayRecap also
-		// defers if the agent loop is still active when the timer fires.
-		if (focusedOutAt !== undefined) {
-			clearPostTurnTimer();
+		markLiveActivity("turn_end", liveBuffer.turnEnd());
+		if (!config.enabled.automatic) return;
+		if (focusedOutAt !== undefined && config.enabled.away) {
+			postTurnTimer = clearTimer(postTurnTimer);
 			postTurnTimer = setTimeout(() => {
 				postTurnTimer = undefined;
 				tryAwayRecap(ctx);
-			}, POST_TURN_DEBOUNCE_MS);
+			}, config.timings.postTurnDebounceMs);
 		}
-
-		// Fallback for terminals without focus reporting.
-		if (idleFallbackEligible()) scheduleIdleRecap(ctx);
+		if (idleFallbackEligible()) scheduleIdle(ctx);
 	});
-
-	pi.on("turn_start", async () => {
-		// Another turn is starting in the same agent loop — any armed trigger
-		// or in-flight draft is stale. The dedupe stamp itself is content-based,
-		// so it does not need manual invalidation.
-		clearIdleTimer();
-		clearPostTurnTimer();
-		cancelActive();
+	pi.on("turn_start", async (_event, ctx) => {
+		idleTimer = clearTimer(idleTimer);
+		postTurnTimer = clearTimer(postTurnTimer);
+		if (config.lifecycle.clearOnTurnStart) clearRecap(ctx);
 	});
-
 	pi.on("input", async (_event, ctx) => {
-		clearIdleTimer();
-		clearPostTurnTimer();
-		clearAwayTimer();
-		cancelActive();
+		focusedOutAt = undefined;
+		deferredAway.cancel();
+		idleTimer = clearTimer(idleTimer);
+		awayTimer = clearTimer(awayTimer);
+		postTurnTimer = clearTimer(postTurnTimer);
+		resumeTimer = clearTimer(resumeTimer);
+		cancelRequest(ctx);
 		focusDraftAfterAgent = false;
-		clearRecap(ctx);
+		pendingAwayAfterRequest = false;
+		if (config.lifecycle.clearOnInput) clearRecap(ctx);
 	});
-
 	pi.on("agent_start", async (_event, ctx) => {
+		reloadConfig(ctx);
+		resumeTimer = clearTimer(resumeTimer);
+		cancelRequest(ctx);
 		agentActive = true;
-		clearIdleTimer();
-		clearPostTurnTimer();
-		cancelActive();
-		clearRecap(ctx);
+		liveBuffer.reset();
+		liveState.start(Date.now());
+		idleTimer = clearTimer(idleTimer);
+		postTurnTimer = clearTimer(postTurnTimer);
+		if (config.lifecycle.clearOnAgentStart) clearRecap(ctx);
+		startLiveTimer(ctx);
 	});
-
 	pi.on("agent_end", async (_event, ctx) => {
 		agentActive = false;
+		stopLiveTimer();
+		liveState.stop();
+		let shouldScheduleAway = false;
+		if (config.lifecycle.liveWidgetOnAgentEnd === "clear") {
+			if (activeRequest?.reason === "live") {
+				cancelRequest(ctx);
+				const pendingAway = consumePendingAway(
+					pendingAwayAfterRequest,
+					focusedOutAt !== undefined,
+					config.enabled.automatic,
+					config.enabled.away,
+				);
+				pendingAwayAfterRequest = pendingAway.pending;
+				shouldScheduleAway = pendingAway.shouldSchedule;
+			}
+			clearRecap(ctx);
+		}
 		if (focusDraftAfterAgent) {
 			focusDraftAfterAgent = false;
-			tryAwayRecap(ctx);
+			shouldScheduleAway = true;
 		}
+		if (shouldScheduleAway) scheduleDeferredAway(ctx);
 	});
-
-	pi.on("session_shutdown", async () => {
-		agentActive = false;
-		focusDraftAfterAgent = false;
-		clearIdleTimer();
-		clearAwayTimer();
-		clearPostTurnTimer();
-		cancelActive();
-		detachFocusReporting();
-	});
-
-	// Session start: wire up focus reporting; on resume/fork, show a recap.
 	pi.on("session_start", async (event, ctx) => {
+		reloadConfig(ctx);
+		resumeTimer = clearTimer(resumeTimer);
 		attachFocusReporting(ctx);
-		if (isDisabled() || !ctx.hasUI) return;
+		if (!config.enabled.automatic || !config.enabled.resume || !ctx.hasUI) return;
 		if (event.reason === "resume" || event.reason === "fork") {
-			setTimeout(() => {
-				void generateAndShow(ctx, { reason: "resume" });
-			}, 300);
+			if (!config.lifecycle.persistWidgetAcrossResume) clearRecap(ctx);
+			resumeTimer = setTimeout(() => {
+				resumeTimer = undefined;
+				if (!config.enabled.automatic || !config.enabled.resume || !ctx.hasUI) return;
+				void startRecap(ctx, "resume");
+			}, config.timings.resumeDelayMs);
 		}
 	});
+	pi.on("session_shutdown", async (_event, ctx) => {
+		agentActive = false;
+		stopLiveTimer();
+		liveState.stop();
+		idleTimer = clearTimer(idleTimer);
+		awayTimer = clearTimer(awayTimer);
+		postTurnTimer = clearTimer(postTurnTimer);
+		resumeTimer = clearTimer(resumeTimer);
+		cancelRequest(ctx);
+		pendingAwayAfterRequest = false;
+		deferredAway.cancel();
+		detachFocusReporting();
+		if (config.lifecycle.clearOnSessionShutdown) clearRecap(ctx);
+	});
 
-	// Manual command.
 	pi.registerCommand("recap", {
 		description: "Generate a recap of recent session activity",
 		handler: async (_args, ctx) => {
-			await generateAndShow(ctx, { reason: "manual" });
+			reloadConfig(ctx);
+			if (!config.enabled.manual) return;
+			cancelRequest(ctx);
+			const { request } = liveState.beginManual();
+			await startRecap(ctx, "manual", { manual: true, liveRequest: request });
 		},
 	});
 }

--- a/session-recap/live-state.ts
+++ b/session-recap/live-state.ts
@@ -1,0 +1,341 @@
+export type PendingAwayDrain = {
+	pending: boolean;
+	shouldSchedule: boolean;
+};
+
+export function consumePendingAway(
+	pending: boolean,
+	focusedOut: boolean,
+	automaticEnabled: boolean,
+	awayEnabled: boolean,
+): PendingAwayDrain {
+	return {
+		pending: false,
+		shouldSchedule: pending && focusedOut && automaticEnabled && awayEnabled,
+	};
+}
+
+export type LiveRequest = {
+	id: number;
+	version: number;
+	kind: "live" | "manual";
+};
+
+export type LiveStateSnapshot = {
+	running: boolean;
+	startedAt: number;
+	activityVersion: number;
+	lastRequestedVersion: number;
+	lastLiveCompletedAt?: number;
+	inFlight?: LiveRequest;
+};
+
+/** Pure state machine. Timers and model calls stay in the extension adapter. */
+export class LiveRecapState {
+	private state: LiveStateSnapshot = {
+		running: false,
+		startedAt: 0,
+		activityVersion: 0,
+		lastRequestedVersion: 0,
+	};
+	private nextId = 1;
+
+	start(now: number): void {
+		this.state = {
+			running: true,
+			startedAt: now,
+			activityVersion: 0,
+			lastRequestedVersion: 0,
+		};
+	}
+
+	stop(): LiveRequest | undefined {
+		this.state.running = false;
+		return this.state.inFlight;
+	}
+
+	activity(): number {
+		if (!this.state.running) return this.state.activityVersion;
+		return ++this.state.activityVersion;
+	}
+
+	eligible(now: number, firstMs: number, minIntervalMs: number): boolean {
+		if (!this.state.running || this.state.inFlight) return false;
+		if (now - this.state.startedAt < firstMs) return false;
+		if (this.state.lastLiveCompletedAt !== undefined && now - this.state.lastLiveCompletedAt < minIntervalMs) return false;
+		return this.state.activityVersion > this.state.lastRequestedVersion;
+	}
+
+	beginLive(now: number, firstMs: number, minIntervalMs: number): LiveRequest | undefined {
+		if (!this.eligible(now, firstMs, minIntervalMs)) return undefined;
+		const request = { id: this.nextId++, version: this.state.activityVersion, kind: "live" as const };
+		this.state.inFlight = request;
+		this.state.lastRequestedVersion = request.version;
+		return request;
+	}
+
+	beginManual(): { request: LiveRequest; replaced?: LiveRequest } {
+		const replaced = this.state.inFlight;
+		const request = { id: this.nextId++, version: this.state.activityVersion, kind: "manual" as const };
+		this.state.inFlight = request;
+		return { request, replaced };
+	}
+
+	cancel(id?: number): LiveRequest | undefined {
+		const request = this.state.inFlight;
+		if (!request || (id !== undefined && request.id !== id)) return undefined;
+		this.state.inFlight = undefined;
+		return request;
+	}
+
+	complete(id: number, completedAt?: number, displayed = false): boolean {
+		const request = this.state.inFlight;
+		if (request?.id !== id) return false;
+		this.state.inFlight = undefined;
+		if (request.kind === "live" && displayed && completedAt !== undefined) {
+			this.state.lastLiveCompletedAt = completedAt;
+		}
+		return true;
+	}
+
+	snapshot(): Readonly<LiveStateSnapshot> {
+		return structuredClone(this.state);
+	}
+}
+
+export type LiveActivityOptions = {
+	assistantCharsPerVersion: number;
+	toolUpdateCharsPerVersion: number;
+	maxEvents: number;
+	maxEventChars: number;
+	maxRunningTools: number;
+	liveAssistantChars: number;
+};
+
+/** Invalidates superseded zero-delay work without coupling tests to real timers. */
+export class DeferredTriggerState {
+	private generation = 0;
+
+	arm(): number {
+		return ++this.generation;
+	}
+
+	cancel(): void {
+		this.generation++;
+	}
+
+	consume(generation: number): boolean {
+		if (generation !== this.generation) return false;
+		this.generation++;
+		return true;
+	}
+}
+
+type ToolActivity = {
+	name: string;
+	args: string;
+	result: string;
+	status: "running" | "done" | "error";
+	observedLength: number;
+	observedTail: string;
+	changedSinceDirty: number;
+	hasUpdate: boolean;
+};
+
+/** Captures streaming state that may not exist in SessionManager.getBranch(). */
+export class LiveActivityBuffer {
+	private assistant = "";
+	private assistantBucket = 0;
+	private tools = new Map<string, ToolActivity>();
+	private events: string[] = [];
+	private readonly options: LiveActivityOptions;
+
+	constructor(options: LiveActivityOptions) {
+		this.options = options;
+	}
+
+	reset(): void {
+		this.assistant = "";
+		this.assistantBucket = 0;
+		this.tools.clear();
+		this.events = [];
+	}
+
+	assistantUpdate(text: string): boolean {
+		this.assistant = boundedHeadTail(text, this.options.liveAssistantChars);
+		if (!text.trim()) return false;
+		const bucket = Math.floor(text.length / Math.max(1, this.options.assistantCharsPerVersion));
+		if (bucket <= this.assistantBucket && this.assistantBucket !== 0) return false;
+		this.assistantBucket = Math.max(1, bucket);
+		return true;
+	}
+
+	messageEnd(text: string): boolean {
+		if (text.trim()) this.push(`Assistant finalized: ${text}`);
+		this.assistant = "";
+		this.assistantBucket = 0;
+		return Boolean(text.trim());
+	}
+
+	toolStart(id: string, name: string, args: unknown): boolean {
+		const serialized = boundedHeadTail(safeStringify(args), this.options.maxEventChars);
+		this.setTool(id, {
+			name,
+			args: serialized,
+			result: "",
+			status: "running",
+			observedLength: 0,
+			observedTail: "",
+			changedSinceDirty: 0,
+			hasUpdate: false,
+		});
+		this.push(`Tool started: ${name}(${serialized})`);
+		return true;
+	}
+
+	toolUpdate(id: string, name: string, partialResult: unknown): boolean {
+		const fullText = activityText(partialResult);
+		const tail = fullText.slice(-this.options.maxEventChars);
+		const existing = this.tools.get(id) ?? emptyToolActivity(name);
+		existing.result = boundedHeadTail(fullText, this.options.maxEventChars);
+		this.setTool(id, existing);
+		if (!existing.hasUpdate) {
+			existing.hasUpdate = true;
+			existing.observedLength = fullText.length;
+			existing.observedTail = tail;
+			return true;
+		}
+		if (existing.observedLength === fullText.length && existing.observedTail === tail) return false;
+		existing.changedSinceDirty += changedContentSize(
+			existing.observedLength,
+			existing.observedTail,
+			fullText.length,
+			tail,
+		);
+		existing.observedLength = fullText.length;
+		existing.observedTail = tail;
+		if (existing.changedSinceDirty < this.options.toolUpdateCharsPerVersion) return false;
+		existing.changedSinceDirty %= this.options.toolUpdateCharsPerVersion;
+		return true;
+	}
+
+	toolEnd(id: string, name: string, result: unknown, isError: boolean): boolean {
+		const existing = this.tools.get(id) ?? emptyToolActivity(name);
+		existing.result = boundedHeadTail(activityText(result), this.options.maxEventChars);
+		existing.status = isError ? "error" : "done";
+		const prefix = `Tool ${existing.status}: ${name}${existing.result ? ": " : ""}`;
+		this.push(formatPrefixedEvidence(prefix, existing.result, this.options.maxEventChars));
+		this.tools.delete(id);
+		return true;
+	}
+
+	turnEnd(): boolean {
+		this.push("Turn finalized.");
+		return true;
+	}
+
+	runningToolCount(): number {
+		return this.tools.size;
+	}
+
+	lines(): string[] {
+		const lines = [...this.events];
+		if (this.assistant.trim()) {
+			lines.push(formatPrefixedEvidence("Assistant streaming: ", this.assistant, this.options.maxEventChars));
+		}
+		for (const tool of this.tools.values()) {
+			if (tool.status === "running") lines.push(formatRunningTool(tool, this.options.maxEventChars));
+		}
+		return lines.slice(-this.options.maxEvents).map((line) => boundedHeadTail(line, this.options.maxEventChars));
+	}
+
+	private setTool(id: string, tool: ToolActivity): void {
+		const maxRunningTools = this.options.maxRunningTools ?? Number.MAX_SAFE_INTEGER;
+		if (!this.tools.has(id) && this.tools.size >= maxRunningTools) {
+			const oldestId = this.tools.keys().next().value;
+			if (oldestId !== undefined) this.tools.delete(oldestId);
+		}
+		this.tools.set(id, tool);
+	}
+
+	private push(line: string): void {
+		this.events.push(boundedHeadTail(line, this.options.maxEventChars));
+		if (this.events.length > this.options.maxEvents) this.events.splice(0, this.events.length - this.options.maxEvents);
+	}
+}
+
+function boundedHeadTail(text: string, chars: number): string {
+	if (chars <= 0) return "";
+	if (text.length <= chars) return text;
+	const marker = " … ";
+	if (chars <= marker.length) return text.slice(-chars);
+	const contentChars = chars - marker.length;
+	const tailChars = Math.ceil(contentChars * 2 / 3);
+	return `${text.slice(0, contentChars - tailChars)}${marker}${text.slice(-tailChars)}`;
+}
+
+function formatPrefixedEvidence(prefix: string, evidence: string, chars: number): string {
+	if (!evidence) return boundedHeadTail(prefix, chars);
+	if (prefix.length >= chars) return boundedHeadTail(`${prefix}${evidence}`, chars);
+	return `${prefix}${boundedHeadTail(evidence, chars - prefix.length)}`;
+}
+
+function formatRunningTool(tool: ToolActivity, chars: number): string {
+	const prefix = `Tool running: ${tool.name}`;
+	if (!tool.result) return formatPrefixedEvidence(`${prefix}(`, `${tool.args})`, chars);
+	const latestPrefix = "; latest: ";
+	if (prefix.length + latestPrefix.length >= chars) {
+		return boundedHeadTail(`${prefix}${latestPrefix}${tool.result}`, chars);
+	}
+	const available = chars - prefix.length - latestPrefix.length;
+	const argsBudget = tool.args ? Math.floor(available / 3) : 0;
+	const args = argsBudget >= 3 ? `(${boundedHeadTail(tool.args, argsBudget - 2)})` : "";
+	const resultBudget = available - args.length;
+	return `${prefix}${args}${latestPrefix}${boundedHeadTail(tool.result, resultBudget)}`;
+}
+
+function emptyToolActivity(name: string): ToolActivity {
+	return {
+		name,
+		args: "",
+		result: "",
+		status: "running",
+		observedLength: 0,
+		observedTail: "",
+		changedSinceDirty: 0,
+		hasUpdate: false,
+	};
+}
+
+function changedContentSize(previousLength: number, previousTail: string, nextLength: number, nextTail: string): number {
+	if (previousLength !== nextLength) return Math.max(1, Math.abs(nextLength - previousLength));
+	let changed = 0;
+	const length = Math.max(previousTail.length, nextTail.length);
+	for (let index = 0; index < length; index++) {
+		if (previousTail[index] !== nextTail[index]) changed++;
+	}
+	return Math.max(1, changed);
+}
+
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return "[unserializable]";
+	}
+}
+
+function activityText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value && typeof value === "object") {
+		const content = (value as { content?: unknown }).content;
+		if (typeof content === "string") return content;
+		if (Array.isArray(content)) {
+			return content
+				.map((part) => (part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string" ? (part as { text: string }).text : ""))
+				.filter(Boolean)
+				.join("\n");
+		}
+	}
+	return safeStringify(value);
+}

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.2.2",
-  "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
+  "version": "0.3.0",
+  "type": "module",
+  "description": "Configurable live, away, idle, resume, and manual session recaps for Pi.",
   "license": "MIT",
   "author": "Thomas Mustier",
   "keywords": [
@@ -29,6 +30,6 @@
     "@earendil-works/pi-coding-agent": "^0.80.3"
   },
   "scripts": {
-    "test": "node tests/unknown-api-provider.test.mjs"
+    "test": "node --test tests/*.test.mjs"
   }
 }

--- a/session-recap/recap.ts
+++ b/session-recap/recap.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import type { RecapConfig, RecapReason } from "./config.ts";
+
+export type ContentBlock = {
+	type?: string;
+	text?: string;
+	name?: string;
+	arguments?: Record<string, unknown>;
+};
+
+export type Entry = {
+	id?: string;
+	type: string;
+	summary?: string;
+	message?: {
+		role?: string;
+		content?: unknown;
+		toolName?: string;
+	};
+};
+
+type Model = {
+	provider: string;
+	id: string;
+	[key: string]: unknown;
+};
+
+type AuthResult = {
+	ok: boolean;
+	apiKey?: string;
+	headers?: Record<string, string>;
+	env?: Record<string, string>;
+};
+
+export type RecapContext = {
+	model?: Model;
+	modelRegistry: {
+		find(provider: string, id: string): Model | undefined;
+		getApiKeyAndHeaders(model: Model): Promise<AuthResult>;
+	};
+};
+
+export type CompleteFunction = (
+	model: Model,
+	context: {
+		systemPrompt: string;
+		messages: Array<{ role: "user"; content: Array<{ type: "text"; text: string }>; timestamp: number }>;
+	},
+	options: {
+		apiKey?: string;
+		headers?: Record<string, string>;
+		env?: Record<string, string>;
+		signal?: AbortSignal;
+		reasoning: string;
+		cacheRetention: string;
+		maxTokens: number;
+	},
+) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+
+export function extractText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.filter((part): part is ContentBlock => Boolean(part) && typeof part === "object")
+		.filter((part) => part.type === "text" && typeof part.text === "string")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function extractToolCalls(content: unknown, chars: number): string[] {
+	if (!Array.isArray(content)) return [];
+	const output: string[] = [];
+	for (const part of content) {
+		if (!part || typeof part !== "object") continue;
+		const block = part as ContentBlock;
+		if (block.type !== "toolCall" || typeof block.name !== "string") continue;
+		output.push(`- ${block.name}(${JSON.stringify(block.arguments ?? {}).slice(0, chars)})`);
+	}
+	return output;
+}
+
+function boundedHeadTail(text: string, chars: number): string {
+	if (chars <= 0) return "";
+	if (text.length <= chars) return text;
+	const marker = " … ";
+	if (chars <= marker.length) return text.slice(-chars);
+	const contentChars = chars - marker.length;
+	const tailChars = Math.ceil(contentChars * 2 / 3);
+	return `${text.slice(0, contentChars - tailChars)}${marker}${text.slice(-tailChars)}`;
+}
+
+function fitNewestSection(heading: string, lines: string[], budget: number): string | undefined {
+	if (lines.length === 0 || budget <= 0) return undefined;
+	const fullLinesLength = lines.reduce((sum, line) => sum + line.length, Math.max(0, lines.length - 1));
+	const headingRemainder = budget - heading.length - 1;
+	const includeHeading = headingRemainder >= fullLinesLength;
+	let remaining = includeHeading ? headingRemainder : budget;
+	const selected: string[] = [];
+	for (let index = lines.length - 1; index >= 0 && remaining > 0; index--) {
+		const separator = selected.length > 0 ? 1 : 0;
+		if (remaining <= separator) break;
+		const line = boundedHeadTail(lines[index], remaining - separator);
+		if (!line) break;
+		selected.unshift(line);
+		remaining -= line.length + separator;
+	}
+	if (selected.length === 0) return undefined;
+	return includeHeading ? `${heading}\n${selected.join("\n")}` : selected.join("\n");
+}
+
+function proportionalAllocation(desired: number[], budget: number): number[] {
+	const allocation = desired.map(() => 0);
+	const active = desired.map((value, index) => ({ value, index })).filter(({ value }) => value > 0);
+	if (budget <= 0 || active.length === 0) return allocation;
+	if (budget < active.length) {
+		for (const { index } of active.slice(0, budget)) allocation[index] = 1;
+		return allocation;
+	}
+	const total = active.reduce((sum, { value }) => sum + value, 0);
+	if (total <= budget) return desired.slice();
+	for (const { value, index } of active) allocation[index] = Math.max(1, Math.floor(value / total * budget));
+	while (allocation.reduce((sum, value) => sum + value, 0) > budget) {
+		const index = allocation.reduce((largest, value, candidate) => value > allocation[largest] ? candidate : largest, 0);
+		if (allocation[index] <= 1) break;
+		allocation[index]--;
+	}
+	while (allocation.reduce((sum, value) => sum + value, 0) < budget) {
+		const next = active.find(({ value, index }) => allocation[index] < value);
+		if (!next) break;
+		allocation[next.index]++;
+	}
+	return allocation;
+}
+
+export function buildTranscript(entries: Entry[], config: RecapConfig, liveLines: string[] = []): string {
+	const limits = config.transcript;
+	const userIndexes: number[] = [];
+	for (let index = 0; index < entries.length; index++) {
+		if (entries[index].type === "message" && entries[index].message?.role === "user") userIndexes.push(index);
+	}
+	const lastUserIndex = userIndexes.at(-1) ?? -1;
+	const currentUser = lastUserIndex >= 0
+		? boundedHeadTail(extractText(entries[lastUserIndex].message?.content).trim(), limits.userChars)
+		: "";
+	const framing: string[] = [];
+
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if ((entry.type === "compaction" || entry.type === "branch_summary") && entry.summary?.trim()) {
+			framing.push(`Session summary so far: ${boundedHeadTail(entry.summary.trim(), limits.compactionSummaryChars)}`);
+			break;
+		}
+	}
+
+	const earlier = userIndexes.slice(0, -1).slice(-limits.earlierUserPrompts);
+	const earlierLines = earlier
+		.map((index) => boundedHeadTail(extractText(entries[index].message?.content).trim(), limits.earlierPromptChars))
+		.filter(Boolean)
+		.map((text) => `- ${text}`);
+	if (earlierLines.length) framing.push("Earlier user prompts:", ...earlierLines);
+
+	const recent = lastUserIndex >= 0 ? entries.slice(lastUserIndex + 1) : entries;
+	const detail: string[] = [];
+	for (const entry of recent) {
+		if (entry.type !== "message" || !entry.message?.role) continue;
+		const text = extractText(entry.message.content).trim();
+		if (entry.message.role === "assistant") {
+			if (text) detail.push(`Assistant: ${boundedHeadTail(text, limits.assistantChars)}`);
+			detail.push(...extractToolCalls(entry.message.content, limits.toolArgumentsChars));
+		}
+		if (entry.message.role === "toolResult" && text) {
+			detail.push(`Result(${entry.message.toolName ?? "tool"}): ${boundedHeadTail(text, limits.toolResultChars)}`);
+		}
+	}
+
+	const sections = [
+		{ order: 1, heading: "Current user request:", lines: currentUser ? [currentUser] : [], reserve: limits.currentUserReserveChars },
+		{ order: 2, heading: "Recent activity (since the user's last message):", lines: detail, reserve: limits.persistedReserveChars },
+		{ order: 3, heading: "Live in-memory activity (may not be persisted yet):", lines: liveLines, reserve: 0 },
+	];
+	const present = sections.filter(({ lines }) => lines.length > 0);
+	const full = present.map(({ heading, lines }) => fitNewestSection(heading, lines, limits.totalChars)?.length ?? 0);
+	const separatorChars = Math.max(0, present.length - 1);
+	const contentBudget = Math.max(0, limits.totalChars - separatorChars);
+
+	// Protect the current request and newest persisted evidence before live state can
+	// consume scarce space. Live state then outranks older framing, but remains capped.
+	const desiredReserves = present.map(({ order, reserve }, index) =>
+		order === 3 ? 0 : Math.min(reserve, full[index]));
+	const allocation = proportionalAllocation(desiredReserves, contentBudget);
+	let remaining = contentBudget - allocation.reduce((sum, value) => sum + value, 0);
+	const liveIndex = present.findIndex((section) => section.order === 3);
+	if (liveIndex >= 0 && remaining > 0) {
+		const liveAllocation = Math.min(full[liveIndex], limits.liveMaxChars, remaining);
+		allocation[liveIndex] = liveAllocation;
+		remaining -= liveAllocation;
+	}
+
+	for (const order of [2, 1]) {
+		const index = present.findIndex((section) => section.order === order);
+		if (index < 0 || remaining <= 0) continue;
+		const extra = Math.min(full[index] - allocation[index], remaining);
+		allocation[index] += extra;
+		remaining -= extra;
+	}
+
+	const selected = present
+		.map((section, index) => ({
+			order: section.order,
+			text: fitNewestSection(section.heading, section.lines, allocation[index]),
+		}))
+		.filter((section): section is { order: number; text: string } => Boolean(section.text));
+	const used = selected.reduce((sum, { text }) => sum + text.length, 0) + Math.max(0, selected.length - 1);
+	const framingSeparator = selected.length > 0 ? 1 : 0;
+	const framingText = fitNewestSection("Task framing:", framing, limits.totalChars - used - framingSeparator);
+	if (framingText) selected.push({ order: 0, text: framingText });
+	return selected.sort((left, right) => left.order - right.order).map(({ text }) => text).join("\n");
+}
+
+export function hasMeaningfulActivity(entries: Entry[], config: RecapConfig): boolean {
+	let lastUserIndex = -1;
+	for (let index = entries.length - 1; index >= 0; index--) {
+		if (entries[index].type === "message" && entries[index].message?.role === "user") {
+			lastUserIndex = index;
+			break;
+		}
+	}
+	let words = 0;
+	let tools = 0;
+	for (const entry of entries.slice(lastUserIndex + 1)) {
+		if (entry.type !== "message" || entry.message?.role !== "assistant") continue;
+		words += extractText(entry.message.content).split(/\s+/).filter(Boolean).length;
+		tools += extractToolCalls(entry.message.content, config.transcript.toolArgumentsChars).length;
+	}
+	return tools > 0 || words >= config.activity.assistantMinWords;
+}
+
+export function recapStateKey(transcript: string): string {
+	return createHash("sha256").update(transcript).digest("hex");
+}
+
+const TEMPLATE_TOKEN = /{{\s*([a-zA-Z][a-zA-Z0-9_]*)\s*}}/g;
+
+export function renderTextTemplate(template: string, values: Record<string, string>): string {
+	if (/{{{|}}}/.test(template)) throw new Error("template contains an invalid interpolation token");
+	const invalid = template.replace(TEMPLATE_TOKEN, "").match(/{{|}}/);
+	if (invalid) throw new Error("template contains an invalid interpolation token");
+	return template.replace(TEMPLATE_TOKEN, (_token, key: string) => {
+		if (!Object.hasOwn(values, key)) throw new Error(`template references unknown value: ${key}`);
+		return values[key];
+	});
+}
+
+function extractJsonObject(text: string): string | undefined {
+	const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
+	const source = fenced ?? text.trim();
+	let start = source.indexOf("{");
+	if (start < 0) return undefined;
+	let depth = 0;
+	let quoted = false;
+	let escaped = false;
+	for (let index = start; index < source.length; index++) {
+		const char = source[index];
+		if (quoted) {
+			if (escaped) escaped = false;
+			else if (char === "\\") escaped = true;
+			else if (char === '"') quoted = false;
+			continue;
+		}
+		if (char === '"') quoted = true;
+		else if (char === "{") depth++;
+		else if (char === "}" && --depth === 0) return source.slice(start, index + 1);
+	}
+	return undefined;
+}
+
+export function parseRecapResponse(text: string, reason: RecapReason, config: RecapConfig): string | undefined {
+	const compactPlain = (value: string) => value.replace(/[ \t]+/g, " ").replace(/\s*\n\s*/g, "\n").trim();
+	if (config.response.modes[reason] === "plain") {
+		const plain = compactPlain(text);
+		return plain ? plain.slice(0, config.response.maxChars) : undefined;
+	}
+	try {
+		const json = extractJsonObject(text);
+		if (!json) throw new Error("missing JSON object");
+		const parsed = JSON.parse(json) as Record<string, unknown>;
+		const values: Record<string, string> = {};
+		for (const field of config.response.fields) {
+			const value = parsed[field];
+			if (value !== undefined && typeof value !== "string") throw new Error(`${field} must be a string`);
+			values[field] = compactPlain(value ?? "") || config.response.emptyFieldFallback;
+		}
+		return renderTextTemplate(config.response.template, values).slice(0, config.response.maxChars);
+	} catch {
+		return config.response.malformedFallback.slice(0, config.response.maxChars);
+	}
+}
+
+function splitModel(spec: string): { provider: string; id: string } | undefined {
+	const separator = spec.indexOf("/");
+	if (separator <= 0 || separator === spec.length - 1) return undefined;
+	return { provider: spec.slice(0, separator), id: spec.slice(separator + 1) };
+}
+
+export function recapModelCandidates(ctx: RecapContext, config: RecapConfig): Model[] {
+	const candidates: Model[] = [];
+	for (const spec of config.model.candidates) {
+		const candidate = spec === "$active" ? ctx.model : (() => {
+			const parsed = splitModel(spec);
+			return parsed ? ctx.modelRegistry.find(parsed.provider, parsed.id) : undefined;
+		})();
+		if (candidate && !candidates.some((item) => item.provider === candidate.provider && item.id === candidate.id)) {
+			candidates.push(candidate);
+		}
+	}
+	return candidates;
+}
+
+export async function generateRecap(
+	transcript: string,
+	reason: RecapReason,
+	ctx: RecapContext,
+	config: RecapConfig,
+	signal: AbortSignal | undefined,
+	complete: CompleteFunction,
+): Promise<string | undefined> {
+	let prompt: string;
+	try {
+		prompt = renderTextTemplate(config.prompts[reason], { transcript });
+	} catch (error) {
+		console.error(`[session-recap] invalid ${reason} prompt template:`, error);
+		return undefined;
+	}
+	const candidates = recapModelCandidates(ctx, config);
+	for (let index = 0; index < candidates.length; index++) {
+		const model = candidates[index];
+		const hasFallback = index < candidates.length - 1;
+		let auth: AuthResult;
+		try {
+			auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+		} catch (error) {
+			if (hasFallback && config.model.fallbackOnAuthError) continue;
+			return undefined;
+		}
+		if (!auth.ok) {
+			if (hasFallback && config.model.fallbackOnAuthError) continue;
+			return undefined;
+		}
+		try {
+			const response = await complete(
+				model,
+				{
+					systemPrompt: config.prompts.system,
+					messages: [{ role: "user", content: [{ type: "text", text: prompt }], timestamp: Date.now() }],
+				},
+				{
+					apiKey: auth.apiKey,
+					headers: auth.headers,
+					env: auth.env,
+					signal,
+					reasoning: config.model.reasoning,
+					cacheRetention: config.model.cacheRetention,
+					maxTokens: config.model.maxTokens,
+				},
+			);
+			const text = response.content.filter((part) => part.type === "text").map((part) => part.text ?? "").join(" ");
+			const recap = parseRecapResponse(text, reason, config);
+			if (recap) return recap;
+		} catch (error) {
+			if (signal?.aborted) return undefined;
+			if (hasFallback && config.model.fallbackOnCompletionError) continue;
+			if (
+				config.model.silentUnsupportedApi &&
+				error instanceof Error &&
+				error.message.startsWith("No API provider registered for api:")
+			) return undefined;
+			throw error;
+		}
+	}
+	return undefined;
+}

--- a/session-recap/tests/config.test.mjs
+++ b/session-recap/tests/config.test.mjs
@@ -1,0 +1,335 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	applyDeprecatedFlagOverrides,
+	configPaths,
+	loadConfig,
+	MAX_TIMER_DELAY_MS,
+	shippedDefaults,
+} from "../config.ts";
+
+function fixture() {
+	const root = mkdtempSync(join(tmpdir(), "session-recap-config-"));
+	const agentDir = join(root, "agent");
+	const cwd = join(root, "project");
+	mkdirSync(join(cwd, ".pi"), { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	return { root, agentDir, cwd, projectTrusted: true };
+}
+
+function json(path, value) {
+	writeFileSync(path, JSON.stringify(value));
+}
+
+test("deep merges global, project, then explicit config", () => {
+	const { root, agentDir, cwd } = fixture();
+	const explicit = join(root, "explicit.json");
+	json(join(agentDir, "session-recap.json"), { timings: { awayMs: 1000 }, widget: { header: "global" } });
+	json(join(cwd, ".pi", "session-recap.json"), { timings: { awayMs: 2000 }, widget: { wrapWidth: 88 } });
+	json(explicit, { timings: { idleMs: 3000 }, widget: { header: "explicit" } });
+
+	const result = loadConfig({ cwd, agentDir, projectTrusted: true, explicitPath: explicit }, undefined);
+	assert.equal(result.valid, true);
+	assert.equal(result.config.timings.awayMs, 2000);
+	assert.equal(result.config.timings.idleMs, 3000);
+	assert.equal(result.config.widget.header, "explicit");
+	assert.equal(result.config.widget.wrapWidth, 88);
+	assert.equal(result.loadedFiles.length, 3);
+});
+
+test("environment and CLI config are separate layers with CLI per-key precedence", () => {
+	const { root, agentDir, cwd } = fixture();
+	const envPath = join(root, "env.json");
+	const cliPath = join(root, "cli.json");
+	json(envPath, { timings: { awayMs: 111, idleMs: 222 }, widget: { header: "env" } });
+	json(cliPath, { timings: { awayMs: 333 } });
+	const result = loadConfig({
+		cwd,
+		agentDir,
+		projectTrusted: true,
+		explicitPath: cliPath,
+		env: { PI_SESSION_RECAP_CONFIG: envPath },
+	}, undefined);
+	assert.equal(result.valid, true);
+	assert.equal(result.config.timings.awayMs, 333);
+	assert.equal(result.config.timings.idleMs, 222);
+	assert.equal(result.config.widget.header, "env");
+	assert.deepEqual(result.loadedFiles, [envPath, cliPath]);
+});
+
+test("identical environment and CLI config paths load once", () => {
+	const { root, agentDir, cwd } = fixture();
+	const path = join(root, "shared.json");
+	json(path, { timings: { awayMs: 321 } });
+	const options = { cwd, agentDir, projectTrusted: true, explicitPath: path, env: { PI_SESSION_RECAP_CONFIG: path } };
+	assert.equal(configPaths(options).filter((candidate) => candidate === path).length, 1);
+	assert.deepEqual(loadConfig(options, undefined).loadedFiles, [path]);
+});
+
+test("a deduplicated CLI path keeps its highest-precedence position", () => {
+	const { agentDir, cwd } = fixture();
+	const shared = join(agentDir, "session-recap.json");
+	json(shared, { timings: { awayMs: 999 } });
+	json(join(cwd, ".pi", "session-recap.json"), { timings: { awayMs: 111 } });
+	const result = loadConfig({ cwd, agentDir, projectTrusted: true, explicitPath: shared, env: {} }, undefined);
+	assert.equal(result.config.timings.awayMs, 999);
+	assert.equal(result.loadedFiles.filter((path) => path === shared).length, 1);
+});
+
+test("PI_CODING_AGENT_DIR selects the global config directory", () => {
+	const { root, cwd } = fixture();
+	assert.equal(
+		configPaths({ cwd, projectTrusted: false, env: { PI_CODING_AGENT_DIR: join(root, "custom-agent") } })[0],
+		join(root, "custom-agent", "session-recap.json"),
+	);
+});
+
+test("project config is loaded only for trusted projects", () => {
+	const { agentDir, cwd } = fixture();
+	const globalPath = join(agentDir, "session-recap.json");
+	const projectPath = join(cwd, ".pi", "session-recap.json");
+	json(globalPath, { widget: { header: "global" } });
+	json(projectPath, { widget: { header: "project" }, focus: { enableSequence: "untrusted-sequence" } });
+
+	const untrusted = loadConfig({ cwd, agentDir, projectTrusted: false }, undefined);
+	assert.equal(untrusted.config.widget.header, "global");
+	assert.equal(untrusted.config.focus.enableSequence, shippedDefaults().focus.enableSequence);
+	assert.deepEqual(untrusted.loadedFiles, [globalPath]);
+	assert.equal(configPaths({ cwd, agentDir, projectTrusted: false }).includes(projectPath), false);
+
+	const trusted = loadConfig({ cwd, agentDir, projectTrusted: true }, undefined);
+	assert.equal(trusted.config.widget.header, "project");
+	assert.equal(trusted.config.focus.enableSequence, "untrusted-sequence");
+	assert.deepEqual(trusted.loadedFiles, [globalPath, projectPath]);
+});
+
+test("explicit environment and CLI paths remain available for untrusted projects", () => {
+	const { root, agentDir, cwd } = fixture();
+	const envPath = join(root, "env.json");
+	const cliPath = join(root, "cli.json");
+	json(envPath, { widget: { header: "env" } });
+	json(cliPath, { widget: { header: "cli" } });
+	const result = loadConfig({
+		cwd,
+		agentDir,
+		projectTrusted: false,
+		explicitPath: cliPath,
+		env: { PI_SESSION_RECAP_CONFIG: envPath },
+	}, undefined);
+	assert.equal(result.config.widget.header, "cli");
+	assert.deepEqual(result.loadedFiles, [envPath, cliPath]);
+});
+
+test("a missing environment config reports the exact path and retains defaults", () => {
+	const { root, agentDir, cwd } = fixture();
+	const path = join(root, "missing-env.json");
+	const errors = [];
+	const result = loadConfig({
+		cwd,
+		agentDir,
+		projectTrusted: true,
+		env: { PI_SESSION_RECAP_CONFIG: path },
+	}, undefined, (message) => errors.push(message));
+	assert.equal(result.valid, false);
+	assert.equal(result.config.timings.liveFirstMs, 120000);
+	assert.ok(errors[0].includes(path));
+});
+
+test("a missing CLI config reports the exact path and retains defaults", () => {
+	const { root, agentDir, cwd } = fixture();
+	const path = join(root, "missing.json");
+	const errors = [];
+	const result = loadConfig({ cwd, agentDir, projectTrusted: true, explicitPath: path }, undefined, (message) => errors.push(message));
+	assert.equal(result.valid, false);
+	assert.equal(result.config.timings.liveFirstMs, 120000);
+	assert.ok(errors[0].includes(path));
+});
+
+test("unknown keys are rejected and the last valid config is retained", () => {
+	const { agentDir, cwd } = fixture();
+	const previous = shippedDefaults();
+	previous.widget.header = "last valid";
+	json(join(agentDir, "session-recap.json"), { widget: { surprise: true } });
+	const errors = [];
+
+	const result = loadConfig({ cwd, agentDir, projectTrusted: true }, previous, (message) => errors.push(message));
+	assert.equal(result.valid, false);
+	assert.equal(result.config.widget.header, "last valid");
+	assert.match(errors[0], /invalid config .*session-recap\.json: config\.widget\.surprise is unknown/);
+});
+
+test("unsafe template syntax is rejected during config validation", async (t) => {
+	for (const [name, template] of [
+		["expression", "{{#if transcript}}{{transcript}}{{/if}}"],
+		["nested opening delimiter", "{{{transcript}}}"],
+		["stray closing delimiter", "{{transcript}}}"],
+	]) {
+		await t.test(name, () => {
+			const { agentDir, cwd } = fixture();
+			const path = join(agentDir, "session-recap.json");
+			json(path, { prompts: { live: template } });
+			const errors = [];
+			const result = loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, (message) => errors.push(message));
+			assert.equal(result.valid, false);
+			assert.ok(errors[0].includes(path));
+			assert.match(errors[0], /invalid interpolation token/);
+		});
+	}
+});
+
+test("ordinary single braces remain valid in template prose", () => {
+	const { agentDir, cwd } = fixture();
+	json(join(agentDir, "session-recap.json"), { prompts: { live: "Object {shape}: {{transcript}}" } });
+	assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, true);
+});
+
+test("focus input sequences must be non-empty, non-overlapping, and fit the parser cap", async (t) => {
+	for (const [name, focus] of [
+		["empty in", { inSequence: "" }],
+		["empty out", { outSequence: "" }],
+		["identical", { inSequence: "same", outSequence: "same" }],
+		["undersized cap", { inSequence: "long", inputBufferCap: 2 }],
+		["in prefixes out", { inSequence: "A", outSequence: "AB" }],
+		["out prefixes in", { inSequence: "AB", outSequence: "A" }],
+	]) {
+		await t.test(name, () => {
+			const { agentDir, cwd } = fixture();
+			json(join(agentDir, "session-recap.json"), { focus });
+			assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, false);
+		});
+	}
+});
+
+test("model candidates allow nested IDs and reject malformed edges", async (t) => {
+	const { agentDir, cwd } = fixture();
+	json(join(agentDir, "session-recap.json"), {
+		model: { candidates: ["openrouter/anthropic/claude-sonnet"] },
+	});
+	assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, true);
+
+	for (const [name, candidates] of [
+		["empty list", []],
+		["slash only", ["/"]],
+		["missing provider", ["/model"]],
+		["missing model", ["provider/"]],
+		["whitespace provider", [" provider/model"]],
+		["whitespace model", ["provider/model "]],
+	]) {
+		await t.test(name, () => {
+			const { agentDir, cwd } = fixture();
+			json(join(agentDir, "session-recap.json"), { model: { candidates } });
+			assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, false);
+		});
+	}
+});
+
+test("model enums and live event names are strict", async (t) => {
+	for (const [name, override] of [
+		["unknown event", { activity: { liveEvents: ["message_update", "unknown"] } }],
+		["reasoning", { model: { reasoning: "turbo" } }],
+		["cache retention", { model: { cacheRetention: "forever" } }],
+	]) {
+		await t.test(name, () => {
+			const { agentDir, cwd } = fixture();
+			json(join(agentDir, "session-recap.json"), override);
+			assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, false);
+		});
+	}
+});
+
+test("required caps are positive integers and count fields are integral", async (t) => {
+	for (const [name, override] of [
+		["model tokens", { model: { maxTokens: 0 } }],
+		["widget width", { widget: { wrapWidth: 0 } }],
+		["widget lines", { widget: { maxBodyLines: 0 } }],
+		["focus cap", { focus: { inputBufferCap: 0 } }],
+		["response chars", { response: { maxChars: 0 } }],
+		["transcript total", { transcript: { totalChars: 0 } }],
+		["current user reserve", { transcript: { currentUserReserveChars: 0 } }],
+		["persisted reserve", { transcript: { persistedReserveChars: 0 } }],
+		["live transcript cap", { transcript: { liveMaxChars: 0 } }],
+		["live event cap", { activity: { maxLiveEvents: 0 } }],
+		["running tool cap", { activity: { maxRunningTools: 0 } }],
+		["activity threshold", { activity: { toolUpdateCharsPerLiveVersion: 0 } }],
+		["fractional count", { activity: { assistantMinWords: 1.5 } }],
+	]) {
+		await t.test(name, () => {
+			const { agentDir, cwd } = fixture();
+			json(join(agentDir, "session-recap.json"), override);
+			assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, false);
+		});
+	}
+});
+
+test("zero remains valid for documented immediate timing and disabled transcript components", () => {
+	const { agentDir, cwd } = fixture();
+	json(join(agentDir, "session-recap.json"), {
+		timings: { awayMs: 0, liveFirstMs: 0, liveMinIntervalMs: 0 },
+		transcript: { earlierUserPrompts: 0, earlierPromptChars: 0 },
+	});
+	assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, true);
+});
+
+test("timer values accept the Node boundary and reject values above it", async (t) => {
+	const timingNames = [
+		"awayMs",
+		"idleMs",
+		"postTurnDebounceMs",
+		"resumeDelayMs",
+		"liveFirstMs",
+		"liveMinIntervalMs",
+		"livePollMs",
+	];
+	const { agentDir, cwd } = fixture();
+	json(join(agentDir, "session-recap.json"), {
+		timings: Object.fromEntries(timingNames.map((name) => [name, MAX_TIMER_DELAY_MS])),
+	});
+	assert.equal(loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, () => {}).valid, true);
+
+	for (const name of timingNames) {
+		await t.test(`${name} above max`, () => {
+			const paths = fixture();
+			const errors = [];
+			json(join(paths.agentDir, "session-recap.json"), { timings: { [name]: MAX_TIMER_DELAY_MS + 1 } });
+			assert.equal(loadConfig(paths, undefined, (message) => errors.push(message)).valid, false);
+			assert.match(errors[0], new RegExp(`config\\.timings\\.${name} must be <= ${MAX_TIMER_DELAY_MS}`));
+		});
+	}
+});
+
+test("deprecated second flags cannot produce timer values above the Node maximum", () => {
+	const defaults = shippedDefaults();
+	const result = applyDeprecatedFlagOverrides(defaults, {
+		awaySeconds: String(MAX_TIMER_DELAY_MS / 1000 + 1),
+		idleSeconds: String(MAX_TIMER_DELAY_MS / 1000 + 1),
+	});
+	assert.equal(result.timings.awayMs, defaults.timings.awayMs);
+	assert.equal(result.timings.idleMs, defaults.timings.idleMs);
+});
+
+test("deprecated model override is derived from canonical config without duplicates after failed reload", () => {
+	const { agentDir, cwd } = fixture();
+	const canonical = shippedDefaults();
+	const once = applyDeprecatedFlagOverrides(canonical, { model: "openai-codex/gpt-5.6-luna" });
+	json(join(agentDir, "session-recap.json"), { model: { reasoning: "invalid" } });
+	const failed = loadConfig({ cwd, agentDir, projectTrusted: true }, canonical, () => {});
+	const twice = applyDeprecatedFlagOverrides(failed.config, { model: "openai-codex/gpt-5.6-luna" });
+	assert.equal(failed.valid, false);
+	assert.deepEqual(once.model.candidates, twice.model.candidates);
+	assert.equal(twice.model.candidates.filter((candidate) => candidate === "openai-codex/gpt-5.6-luna").length, 1);
+	assert.deepEqual(canonical.model.candidates, ["$active"]);
+});
+
+test("malformed JSON reports its exact path and keeps defaults", () => {
+	const { agentDir, cwd } = fixture();
+	const path = join(agentDir, "session-recap.json");
+	writeFileSync(path, "{");
+	const errors = [];
+	const result = loadConfig({ cwd, agentDir, projectTrusted: true }, undefined, (message) => errors.push(message));
+	assert.equal(result.valid, false);
+	assert.equal(result.config.timings.liveFirstMs, 120000);
+	assert.ok(errors[0].includes(path));
+});

--- a/session-recap/tests/focus-parser.test.mjs
+++ b/session-recap/tests/focus-parser.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FocusSequenceParser } from "../focus-parser.ts";
+
+test("focus parser recognizes sequences split across chunks", () => {
+	const parser = new FocusSequenceParser("\x1b[I", "\x1b[O", 64);
+	assert.deepEqual(parser.push("noise\x1b["), []);
+	assert.deepEqual(parser.push("I"), ["in"]);
+	assert.deepEqual(parser.push("\x1b"), []);
+	assert.deepEqual(parser.push("[O"), ["out"]);
+});
+
+test("focus parser handles mixed input and multiple events", () => {
+	const parser = new FocusSequenceParser("IN", "OUT", 16);
+	assert.deepEqual(parser.push("xINjunkOUTINy"), ["in", "out", "in"]);
+});
+
+test("shorter unrelated sequence is recognized without waiting for longer sequence", () => {
+	const parser = new FocusSequenceParser("I", "OUTSIDE", 16);
+	assert.deepEqual(parser.push("I"), ["in"]);
+	assert.deepEqual(parser.push("OUT"), []);
+	assert.deepEqual(parser.push("SIDE"), ["out"]);
+});
+
+test("focus parser rejects empty or identical sequences", () => {
+	assert.throws(() => new FocusSequenceParser("", "OUT", 16), /non-empty/);
+	assert.throws(() => new FocusSequenceParser("IN", "", 16), /non-empty/);
+	assert.throws(() => new FocusSequenceParser("SAME", "SAME", 16), /distinct/);
+	assert.throws(() => new FocusSequenceParser("A", "AB", 16), /prefix-overlapping/);
+	assert.throws(() => new FocusSequenceParser("AB", "A", 16), /prefix-overlapping/);
+	assert.throws(() => new FocusSequenceParser("IN", "LONG", 2), /cap/);
+});

--- a/session-recap/tests/live-state.test.mjs
+++ b/session-recap/tests/live-state.test.mjs
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { consumePendingAway, DeferredTriggerState, LiveActivityBuffer, LiveRecapState } from "../live-state.ts";
+
+const FIRST = 120_000;
+const INTERVAL = 90_000;
+
+test("pending away work drains once after its owning live request is cancelled", () => {
+	assert.deepEqual(consumePendingAway(true, true, true, true), {
+		pending: false,
+		shouldSchedule: true,
+	});
+	assert.equal(consumePendingAway(false, true, true, true).shouldSchedule, false, "consumed work does not duplicate");
+	assert.equal(consumePendingAway(true, false, true, true).shouldSchedule, false, "refocus suppresses work");
+	assert.equal(consumePendingAway(true, true, false, true).shouldSchedule, false, "automatic config is respected");
+	assert.equal(consumePendingAway(true, true, true, false).shouldSchedule, false, "away config is respected");
+});
+
+test("deferred triggers invalidate duplicates and cancellation prevents stale work", () => {
+	const state = new DeferredTriggerState();
+	const first = state.arm();
+	const second = state.arm();
+	assert.equal(state.consume(first), false, "new work invalidates the older callback");
+	assert.equal(state.consume(second), true);
+	assert.equal(state.consume(second), false, "one generation fires once");
+	const cancelled = state.arm();
+	state.cancel();
+	assert.equal(state.consume(cancelled), false);
+});
+
+test("first live snapshot waits 120 seconds and requires dirty activity", () => {
+	const state = new LiveRecapState();
+	state.start(1_000);
+	assert.equal(state.beginLive(121_000, FIRST, INTERVAL), undefined);
+	state.activity();
+	assert.equal(state.beginLive(120_999, FIRST, INTERVAL), undefined);
+	assert.equal(state.beginLive(121_000, FIRST, INTERVAL)?.version, 1);
+});
+
+test("live snapshots throttle, require new activity, and allow slightly stale completion", () => {
+	const state = new LiveRecapState();
+	state.start(0);
+	state.activity();
+	const first = state.beginLive(FIRST, FIRST, INTERVAL);
+	assert.ok(first);
+	state.activity();
+	assert.equal(state.complete(first.id, FIRST, true), true, "activity during generation does not invalidate its snapshot");
+	assert.equal(state.beginLive(FIRST + INTERVAL - 1, FIRST, INTERVAL), undefined);
+	const second = state.beginLive(FIRST + INTERVAL, FIRST, INTERVAL);
+	assert.equal(second.version, 2);
+	state.complete(second.id, FIRST + INTERVAL, true);
+	assert.equal(state.beginLive(FIRST + INTERVAL * 2, FIRST, INTERVAL), undefined, "clean state does not call again");
+});
+
+test("a slow request throttles from visible completion instead of request start", () => {
+	const state = new LiveRecapState();
+	state.start(0);
+	state.activity();
+	const first = state.beginLive(FIRST, FIRST, INTERVAL);
+	state.activity();
+	const slowCompletion = FIRST + INTERVAL + 10_000;
+	assert.equal(state.complete(first.id, slowCompletion, true), true);
+	assert.equal(state.beginLive(slowCompletion + 1, FIRST, INTERVAL), undefined);
+	assert.equal(state.beginLive(slowCompletion + INTERVAL - 1, FIRST, INTERVAL), undefined);
+	assert.ok(state.beginLive(slowCompletion + INTERVAL, FIRST, INTERVAL));
+});
+
+test("one long-running tool makes the first snapshot eligible", () => {
+	const state = new LiveRecapState();
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 80,
+		toolUpdateCharsPerVersion: 200,
+		maxEvents: 40,
+		maxEventChars: 1200,
+		liveAssistantChars: 2400,
+	});
+	state.start(0);
+	if (buffer.toolStart("one", "bash", { command: "long job" })) state.activity();
+	const request = state.beginLive(FIRST, FIRST, INTERVAL);
+	assert.ok(request);
+	assert.match(buffer.lines().join("\n"), /Tool running: bash/);
+});
+
+test("manual recap replaces an in-flight live request and old completion cannot win", () => {
+	const state = new LiveRecapState();
+	state.start(0);
+	state.activity();
+	const live = state.beginLive(FIRST, FIRST, INTERVAL);
+	const { request: manual, replaced } = state.beginManual();
+	assert.equal(replaced.id, live.id);
+	assert.equal(state.complete(live.id), false);
+	assert.equal(state.complete(manual.id), true);
+});
+
+test("stop prevents new live work while allowing the current snapshot to finish", () => {
+	const state = new LiveRecapState();
+	state.start(0);
+	state.activity();
+	const request = state.beginLive(FIRST, FIRST, INTERVAL);
+	state.stop();
+	assert.equal(state.beginLive(FIRST + INTERVAL, FIRST, INTERVAL), undefined);
+	assert.equal(state.complete(request.id), true);
+});
+
+test("empty or whitespace-only assistant updates do not dirty live state", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 2,
+		maxEventChars: 20,
+		liveAssistantChars: 10,
+	});
+	assert.equal(buffer.assistantUpdate(""), false);
+	assert.equal(buffer.assistantUpdate("   \n"), false);
+	assert.deepEqual(buffer.lines(), []);
+});
+
+test("stream and tool updates are capped and only cross configured dirty thresholds", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 2,
+		maxEventChars: 20,
+		liveAssistantChars: 10,
+	});
+	assert.equal(buffer.assistantUpdate("a"), true);
+	assert.equal(buffer.assistantUpdate("ab"), false);
+	assert.equal(buffer.assistantUpdate("abcdefgh"), true);
+	buffer.toolStart("t", "bash", {});
+	assert.equal(buffer.toolUpdate("t", "bash", "12"), true);
+	assert.equal(buffer.toolUpdate("t", "bash", "1234"), false);
+	assert.equal(buffer.toolUpdate("t", "bash", "1234567890"), true);
+	assert.ok(buffer.lines().length <= 4, "event cap plus active assistant/tool snapshots remains bounded");
+});
+
+test("completed and failed tools are removed from running snapshots", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 3,
+		maxEventChars: 80,
+		liveAssistantChars: 10,
+	});
+	for (let index = 0; index < 50; index++) {
+		const id = `tool-${index}`;
+		buffer.toolStart(id, "bash", { index });
+		buffer.toolEnd(id, "bash", `result-${index}`, index % 2 === 0);
+	}
+	assert.equal(buffer.runningToolCount(), 0);
+	assert.doesNotMatch(buffer.lines().join("\n"), /Tool running:/);
+});
+
+test("running tool records evict the oldest deterministically when end events are missing", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 10,
+		maxEventChars: 80,
+		maxRunningTools: 2,
+		liveAssistantChars: 10,
+	});
+	buffer.toolStart("one", "first", {});
+	buffer.toolStart("two", "second", {});
+	buffer.toolStart("three", "third", {});
+	assert.equal(buffer.runningToolCount(), 2);
+	let running = buffer.lines().filter((line) => line.startsWith("Tool running:"));
+	assert.deepEqual(running.map((line) => line.match(/^Tool running: (\w+)/)?.[1]), ["second", "third"]);
+
+	buffer.toolUpdate("four", "fourth", "progress without a start event");
+	assert.equal(buffer.runningToolCount(), 2);
+	running = buffer.lines().filter((line) => line.startsWith("Tool running:"));
+	assert.deepEqual(running.map((line) => line.match(/^Tool running: (\w+)/)?.[1]), ["third", "fourth"]);
+});
+
+test("streaming and finalized assistant lines preserve trailing evidence", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 4,
+		maxEventChars: 80,
+		liveAssistantChars: 60,
+	});
+	buffer.assistantUpdate(`STREAM_HEAD ${"middle ".repeat(30)} STREAM_TAIL`);
+	let lines = buffer.lines();
+	assert.match(lines.at(-1), /^Assistant streaming:/);
+	assert.match(lines.at(-1), /STREAM_TAIL/);
+	assert.ok(lines.every((line) => line.length <= 80));
+
+	buffer.messageEnd(`FINAL_HEAD ${"middle ".repeat(30)} FINAL_TAIL`);
+	lines = buffer.lines();
+	assert.match(lines.join("\n"), /Assistant finalized:/);
+	assert.match(lines.join("\n"), /FINAL_TAIL/);
+	assert.ok(lines.every((line) => line.length <= 80));
+});
+
+test("running tool formatting keeps latest progress visible after long arguments", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 4,
+		maxEventChars: 90,
+		liveAssistantChars: 60,
+	});
+	buffer.toolStart("t", "bash", { command: `build ${"argument ".repeat(40)}` });
+	buffer.toolUpdate("t", "bash", `${"old output ".repeat(30)}LATEST_PROGRESS`);
+	const running = buffer.lines().find((line) => line.startsWith("Tool running:"));
+	assert.match(running, /; latest: /);
+	assert.match(running, /LATEST_PROGRESS/);
+	assert.ok(running.length <= 90);
+});
+
+test("tool end and error lines preserve trailing result evidence", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 5,
+		maxEvents: 6,
+		maxEventChars: 80,
+		liveAssistantChars: 60,
+	});
+	buffer.toolEnd("done", "test", `${"passing ".repeat(40)}DONE_TAIL`, false);
+	buffer.toolEnd("failed", "test", `${"diagnostic ".repeat(40)}ERROR_TAIL`, true);
+	const lines = buffer.lines().join("\n");
+	assert.match(lines, /Tool done: test:/);
+	assert.match(lines, /DONE_TAIL/);
+	assert.match(lines, /Tool error: test:/);
+	assert.match(lines, /ERROR_TAIL/);
+	assert.ok(buffer.lines().every((line) => line.length <= 80));
+});
+
+test("same-length tool progress eventually dirties the run", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 3,
+		maxEvents: 4,
+		maxEventChars: 5,
+		liveAssistantChars: 10,
+	});
+	buffer.toolStart("t", "progress", {});
+	assert.equal(buffer.toolUpdate("t", "progress", "0%"), true);
+	assert.equal(buffer.toolUpdate("t", "progress", "1%"), false);
+	assert.equal(buffer.toolUpdate("t", "progress", "2%"), false);
+	assert.equal(buffer.toolUpdate("t", "progress", "3%"), true);
+});
+
+test("changed tool tails keep dirtying after visible output reaches its cap", () => {
+	const buffer = new LiveActivityBuffer({
+		assistantCharsPerVersion: 4,
+		toolUpdateCharsPerVersion: 4,
+		maxEvents: 4,
+		maxEventChars: 5,
+		liveAssistantChars: 10,
+	});
+	buffer.toolStart("t", "stream", {});
+	assert.equal(buffer.toolUpdate("t", "stream", "aaaaa"), true);
+	assert.equal(buffer.toolUpdate("t", "stream", "baaaa"), false);
+	assert.equal(buffer.toolUpdate("t", "stream", "bbaaa"), false);
+	assert.equal(buffer.toolUpdate("t", "stream", "bbbaa"), false);
+	assert.equal(buffer.toolUpdate("t", "stream", "bbbba"), true);
+});

--- a/session-recap/tests/ui-state.test.mjs
+++ b/session-recap/tests/ui-state.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { clearOwnedStatus } from "../ui-state.ts";
+
+test("cancellation clears the request-owned status key after config key changes", () => {
+	const cleared = [];
+	const rendered = clearOwnedStatus((key, value) => cleared.push([key, value]), "old-status", "new-status");
+	assert.deepEqual(cleared, [["old-status", undefined]]);
+	assert.equal(rendered, "new-status");
+});
+
+test("clearing the currently rendered owner resets tracked status state", () => {
+	const cleared = [];
+	const rendered = clearOwnedStatus((key, value) => cleared.push([key, value]), "session-recap", "session-recap");
+	assert.deepEqual(cleared, [["session-recap", undefined]]);
+	assert.equal(rendered, undefined);
+});

--- a/session-recap/tests/unknown-api-provider.test.mjs
+++ b/session-recap/tests/unknown-api-provider.test.mjs
@@ -1,82 +1,245 @@
 import assert from "node:assert/strict";
-import sessionRecap from "../index.ts";
+import test from "node:test";
+import { shippedDefaults } from "../config.ts";
+import { buildTranscript, generateRecap, parseRecapResponse, renderTextTemplate } from "../recap.ts";
 
-function makePi() {
-	const commands = new Map();
-	const flags = new Map();
+const model = (provider, id, api = "openai-codex-responses") => ({ provider, id, api });
+const response = (text) => ({ content: [{ type: "text", text }] });
+
+function recapContext({ active, models = [], auth = async () => ({ ok: true, apiKey: "test" }) }) {
 	return {
-		commands,
-		on() {},
-		registerCommand(name, command) {
-			commands.set(name, command);
-		},
-		registerFlag(name, options) {
-			flags.set(name, options.default);
-		},
-		getFlag(name) {
-			return flags.get(name);
+		model: active,
+		modelRegistry: {
+			find(provider, id) {
+				return models.find((candidate) => candidate.provider === provider && candidate.id === id);
+			},
+			getApiKeyAndHeaders: auth,
 		},
 	};
 }
 
-const pi = makePi();
-sessionRecap(pi);
+test("transcript cap preserves live and newest persisted evidence", () => {
+	const config = shippedDefaults();
+	config.transcript.totalChars = 210;
+	config.transcript.currentUserReserveChars = 45;
+	config.transcript.persistedReserveChars = 75;
+	const entries = [
+		{ type: "message", message: { role: "user", content: `old framing ${"x".repeat(500)}` } },
+		{ type: "message", message: { role: "assistant", content: `obsolete detail ${"y".repeat(500)}` } },
+		{ type: "message", message: { role: "assistant", content: "newest persisted result" } },
+	];
+	const transcript = buildTranscript(entries, config, [
+		"Assistant streaming: current implementation work",
+		"Tool running: test runner",
+	]);
+	assert.ok(transcript.length <= config.transcript.totalChars);
+	assert.match(transcript, /newest persisted result/);
+	assert.match(transcript, /entation work/);
+	assert.match(transcript, /Tool running: test runner/);
+	assert.doesNotMatch(transcript, /obsolete detail/);
+});
 
-const widgets = [];
-const ctx = {
-	hasUI: true,
-	model: {
-		id: "bridge-model",
-		name: "Bridge model",
-		api: "claude-bridge",
-		provider: "bridge",
-		baseUrl: "http://localhost.invalid",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 100_000,
-		maxTokens: 4096,
-	},
-	modelRegistry: {
-		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "unused" }),
-	},
-	sessionManager: {
-		getBranch: () => [
-			{ type: "message", message: { role: "user", content: "Please fix the bridge integration." } },
-			{
-				type: "message",
-				message: {
-					role: "assistant",
-					content: [{ type: "text", text: "I inspected the integration and prepared the next concrete change." }],
-				},
+test("small transcript caps reserve the current request, persisted detail, and live evidence", () => {
+	const config = shippedDefaults();
+	config.transcript.totalChars = 180;
+	config.transcript.currentUserReserveChars = 50;
+	config.transcript.persistedReserveChars = 70;
+	config.transcript.liveMaxChars = 60;
+	const transcript = buildTranscript([
+		{ type: "message", message: { role: "user", content: "CURRENT_REQUEST" } },
+		{ type: "message", message: { role: "assistant", content: "NEWEST_PERSISTED" } },
+	], config, [`${"live output ".repeat(80)}LIVE_PROGRESS`]);
+	assert.ok(transcript.length <= 180);
+	assert.match(transcript, /CURRENT_REQUEST/);
+	assert.match(transcript, /NEWEST_PERSISTED/);
+	assert.match(transcript, /LIVE_PROGRESS/);
+	assert.equal(transcript.match(/CURRENT_REQUEST/g)?.length, 1);
+});
+
+test("live evidence never exceeds liveMaxChars", () => {
+	const config = shippedDefaults();
+	config.transcript.totalChars = 500;
+	config.transcript.liveMaxChars = 30;
+	const transcript = buildTranscript([], config, [`${"old ".repeat(50)}LIVE_TAIL`]);
+	assert.ok(transcript.length <= 30);
+	assert.match(transcript, /LIVE_TAIL/);
+});
+
+test("scarce transcript budget protects current and persisted evidence before live and old framing", () => {
+	const config = shippedDefaults();
+	config.transcript.totalChars = 70;
+	config.transcript.currentUserReserveChars = 40;
+	config.transcript.persistedReserveChars = 40;
+	const transcript = buildTranscript([
+		{ type: "compaction", summary: "OLD_FRAMING" },
+		{ type: "message", message: { role: "user", content: "CURRENT_REQUEST" } },
+		{ type: "message", message: { role: "assistant", content: "NEWEST_PERSISTED" } },
+	], config, ["LIVE_EVIDENCE"]);
+	assert.ok(transcript.length <= 70);
+	assert.match(transcript, /CURRENT_REQUEST/);
+	assert.match(transcript, /NEWEST_PERSISTED/);
+	assert.doesNotMatch(transcript, /LIVE_EVIDENCE|OLD_FRAMING/);
+});
+
+test("long assistant and tool-result entries retain trailing errors and next steps", () => {
+	const config = shippedDefaults();
+	config.transcript.assistantChars = 90;
+	config.transcript.toolResultChars = 80;
+	const entries = [
+		{ type: "message", message: { role: "user", content: "Fix the release blocker without changing scope." } },
+		{
+			type: "message",
+			message: {
+				role: "assistant",
+				content: `Started investigation. ${"background ".repeat(30)}Next: rerun the focused package tests.`,
 			},
-		],
-	},
-	ui: {
-		setStatus() {},
-		setWidget(...args) {
-			widgets.push(args);
 		},
-		theme: {
-			fg(_name, text) {
-				return text;
-			},
-			bold(text) {
-				return text;
+		{
+			type: "message",
+			message: {
+				role: "toolResult",
+				toolName: "test",
+				content: `Test output ${"passing line ".repeat(30)}ERROR: timeout while closing the final handle.`,
 			},
 		},
-	},
-};
+	];
+	const transcript = buildTranscript(entries, config);
+	assert.match(transcript, /Fix the release blocker/);
+	assert.match(transcript, /Next: rerun the focused package tests\./);
+	assert.match(transcript, /ERROR: timeout while closing the final handle\./);
+	assert.ok(transcript.length <= config.transcript.totalChars);
+});
 
-const errors = [];
-const originalConsoleError = console.error;
-console.error = (...args) => errors.push(args);
-try {
-	await pi.commands.get("recap").handler("", ctx);
-} finally {
-	console.error = originalConsoleError;
-}
+test("the total transcript cap also preserves the tail of one oversized recent entry", () => {
+	const config = shippedDefaults();
+	config.transcript.assistantChars = 500;
+	config.transcript.totalChars = 100;
+	const transcript = buildTranscript([
+		{ type: "message", message: { role: "user", content: "Investigate the failure." } },
+		{
+			type: "message",
+			message: { role: "assistant", content: `${"progress ".repeat(80)}NEXT_STEP_SURVIVES` },
+		},
+	], config);
+	assert.ok(transcript.length <= config.transcript.totalChars);
+	assert.match(transcript, /NEXT_STEP_SURVIVES/);
+});
 
-assert.deepEqual(errors, [], "an unknown custom API provider should be skipped without logging an error");
-assert.deepEqual(widgets, [], "an unsupported provider should not render an empty recap widget");
-console.log("unknown API provider test passed");
+test("recap defaults to the active model with configured no-reasoning and cache policy", async () => {
+	const config = shippedDefaults();
+	const active = model("anthropic", "claude-sonnet");
+	const calls = [];
+	const recap = await generateRecap("User: continue", "away", recapContext({ active }), config, undefined,
+		async (selected, _context, options) => {
+			calls.push({ selected, options });
+			return response("Continue the task with the active model.");
+		});
+	assert.equal(recap, "Continue the task with the active model.");
+	assert.equal(calls[0].selected, active);
+	assert.equal(calls[0].options.reasoning, "off");
+	assert.equal(calls[0].options.cacheRetention, "none");
+	assert.equal(calls[0].options.maxTokens, 256);
+});
+
+test("active model follows an explicitly configured Luna auth failure", async () => {
+	const config = shippedDefaults();
+	config.model.candidates = ["openai-codex/gpt-5.6-luna", "$active"];
+	const active = model("anthropic", "claude-sonnet");
+	const luna = model("openai-codex", "gpt-5.6-luna");
+	const attempted = [];
+	const ctx = recapContext({
+		active,
+		models: [luna],
+		auth: async (selected) => {
+			attempted.push(selected);
+			return selected === luna ? { ok: false } : { ok: true, apiKey: "active" };
+		},
+	});
+	const recap = await generateRecap("User: continue", "away", ctx, config, undefined,
+		async (selected) => response(`Used ${selected.id}`));
+	assert.equal(recap, "Used claude-sonnet");
+	assert.deepEqual(attempted, [luna, active]);
+});
+
+test("active model follows an explicitly configured Luna completion failure", async () => {
+	const config = shippedDefaults();
+	config.model.candidates = ["openai-codex/gpt-5.6-luna", "$active"];
+	const active = model("anthropic", "claude-sonnet");
+	const luna = model("openai-codex", "gpt-5.6-luna");
+	const attempted = [];
+	const recap = await generateRecap("User: continue", "away", recapContext({ active, models: [luna] }), config, undefined,
+		async (selected) => {
+			attempted.push(selected);
+			if (selected === luna) throw new Error("Luna unavailable");
+			return response("Active fallback recap.");
+		});
+	assert.equal(recap, "Active fallback recap.");
+	assert.deepEqual(attempted, [luna, active]);
+});
+
+test("explicit configured model remains highest priority", async () => {
+	const config = shippedDefaults();
+	config.model.candidates = ["anthropic/claude-haiku", ...config.model.candidates];
+	const override = model("anthropic", "claude-haiku");
+	const selected = [];
+	await generateRecap("User: continue", "away", recapContext({
+		active: model("openai-codex", "gpt-5.6-sol"),
+		models: [override],
+	}), config, undefined, async (candidate) => {
+		selected.push(candidate);
+		return response("Override recap.");
+	});
+	assert.deepEqual(selected, [override]);
+});
+
+test("nested model IDs are resolved after the first slash", async () => {
+	const config = shippedDefaults();
+	config.model.candidates = ["openrouter/anthropic/claude-sonnet"];
+	const nested = model("openrouter", "anthropic/claude-sonnet");
+	const selected = [];
+	await generateRecap("User: continue", "away", recapContext({ models: [nested] }), config, undefined, async (candidate) => {
+		selected.push(candidate);
+		return response("Nested model recap.");
+	});
+	assert.deepEqual(selected, [nested]);
+});
+
+test("unsupported final custom API is skipped", async () => {
+	const config = shippedDefaults();
+	config.model.candidates = ["$active"];
+	const recap = await generateRecap("User: bridge", "away", recapContext({
+		active: model("bridge", "bridge-model", "claude-bridge"),
+	}), config, undefined, async () => {
+		throw new Error("No API provider registered for api: claude-bridge");
+	});
+	assert.equal(recap, undefined);
+});
+
+test("safe templates only interpolate named text values", () => {
+	assert.equal(renderTextTemplate("Done: {{done}}", { done: "read files" }), "Done: read files");
+	assert.throws(() => renderTextTemplate("{{constructor}}", { done: "x" }), /unknown value/);
+	assert.throws(() => renderTextTemplate("{{#if done}}boom{{/if}}", { done: "x" }), /invalid interpolation/);
+	assert.throws(() => renderTextTemplate("{{(() => process.exit())()}}", {}), /invalid interpolation/);
+	assert.throws(() => renderTextTemplate("{{{done}}}", { done: "x" }), /invalid interpolation/);
+	assert.throws(() => renderTextTemplate("{{done}}}", { done: "x" }), /invalid interpolation/);
+	assert.equal(renderTextTemplate("Object {done}: {{done}}", { done: "x" }), "Object {done}: x");
+});
+
+test("structured live response parses plain and fenced JSON", () => {
+	const config = shippedDefaults();
+	assert.equal(
+		parseRecapResponse('{"done":"tests added","current":"typecheck","next":"review"}', "live", config),
+		"Done: tests added\nNow: typecheck\nNext: review",
+	);
+	assert.equal(
+		parseRecapResponse('```json\n{"done":"A","current":"B","next":"C"}\n```', "live", config),
+		"Done: A\nNow: B\nNext: C",
+	);
+});
+
+test("malformed structured output uses configured fallback", () => {
+	const config = shippedDefaults();
+	config.response.malformedFallback = "safe fallback";
+	assert.equal(parseRecapResponse("not json", "live", config), "safe fallback");
+	assert.equal(parseRecapResponse('{"done":5}', "live", config), "safe fallback");
+});

--- a/session-recap/ui-state.ts
+++ b/session-recap/ui-state.ts
@@ -1,0 +1,9 @@
+export function clearOwnedStatus(
+	setStatus: (key: string, value: string | undefined) => void,
+	ownerKey: string | undefined,
+	renderedKey: string | undefined,
+): string | undefined {
+	if (!ownerKey) return renderedKey;
+	setStatus(ownerKey, undefined);
+	return renderedKey === ownerKey ? undefined : renderedKey;
+}


### PR DESCRIPTION
## Summary

- add rate-limited live recaps for long agent runs using persisted messages plus in-flight assistant and tool activity
- move timings, triggers, model selection, prompts, response templates, transcript budgets, focus handling, and widget behavior into layered JSON configuration
- harden focus parsing, timer bounds, cancellation, stale-request ownership, project-config trust, model fallback, and transcript freshness

The first live recap is eligible after 120 seconds. Later recaps wait at least 90 seconds after the previous visible completion and require meaningful new activity. The default model remains the active Pi model; cross-provider Luna use is an explicit config choice.

## Configuration

Configuration loads in this order:

1. shipped `defaults.json`
2. global `session-recap.json`
3. trusted project `.pi/session-recap.json`
4. `PI_SESSION_RECAP_CONFIG`
5. `--recap-config`

Objects deep-merge, arrays replace, unknown or invalid values reject the full reload, and templates support named text interpolation only.

## Validation

- `npm test --prefix session-recap`: 97 passed
- full TypeScript check against installed Pi declarations: passed
- `npm pack --dry-run --json ./session-recap`: 17 files
- `npm pack --dry-run --json .`: 192 files; no local agent artifacts or nested `node_modules`
- independent review: no blockers
