### PR TITLE
Fix session recap wrapping at terminal width 

### DIFF
--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Let Pi wrap recap text at the terminal width instead of inserting breaks at 100 characters.
+
 ## [0.2.2] - 2026-07-21
 
 ### Fixed

--- a/session-recap/DESIGN.md
+++ b/session-recap/DESIGN.md
@@ -1,6 +1,5 @@
 # session-recap — design & plan
 
-> Status: **v0.2.1 — away-recap redesign + metadata-stable dedupe**  ·  Lives in `tmustier/pi-extensions/session-recap/`
 > v0.1 guessed at Claude Code's recap design; v0.2 is informed by the actual
 > implementation from the leaked Claude Code source (`tmustier/cc-inv`,
 > 2026-03-31): `src/services/awaySummary.ts` + `src/hooks/useAwaySummary.ts`.
@@ -61,7 +60,7 @@ mid-flight drafts.
 ## Display
 
 - `ctx.ui.setWidget("session-recap", [...], { placement: "aboveEditor" })`
-- Accent-bold `✦ recap` header + up to 4 dim wrapped lines (~100 cols).
+- Accent-bold `✦ recap` header + a dim body that the TUI reflows to the current terminal width.
 - Cleared on: user input, new turn start, session reload, session shutdown.
 - **No session persistence.** CC appends a transcript message instead; for pi
   a widget is idiomatic and avoids polluting the session file.
@@ -135,8 +134,7 @@ Rules:
 </transcript>
 ```
 
-Post-processing: whitespace collapsed to single spaces, capped at 600 chars,
-soft-wrapped into ≤4 widget lines.
+Post-processing: whitespace is collapsed to single spaces and capped at 600 characters.
 
 ## Edge cases
 
@@ -177,5 +175,3 @@ soft-wrapped into ≤4 widget lines.
 - [ ] Consider a provider-aware cheap-model default (e.g. Haiku when the
       active provider is Anthropic) once pi exposes a reliable "sibling small
       model" lookup.
-- [ ] Revisit widget wrap width — read the real terminal width from the TUI
-      instead of assuming ~100 cols.

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -91,10 +91,6 @@ const COMPACTION_SUMMARY_CHARS = 600;
 // not spend another recap call.
 const TRANSCRIPT_CHAR_CAP = 12000;
 
-// Widget body wrapping.
-const WRAP_WIDTH = 100;
-const MAX_BODY_LINES = 4;
-
 // DECSET 1004 focus reporting — https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 const FOCUS_ENABLE = "\x1b[?1004h";
 const FOCUS_DISABLE = "\x1b[?1004l";
@@ -243,27 +239,6 @@ function hasMeaningfulActivity(entries: Entry[]): boolean {
 	return toolCalls > 0 || assistantWords >= 30;
 }
 
-function wrapText(text: string, width: number, maxLines: number): string[] {
-	const words = text.split(/\s+/).filter(Boolean);
-	const lines: string[] = [];
-	let cur = "";
-	for (const w of words) {
-		if (cur && cur.length + 1 + w.length > width) {
-			lines.push(cur);
-			cur = w;
-		} else {
-			cur = cur ? `${cur} ${w}` : w;
-		}
-	}
-	if (cur) lines.push(cur);
-	if (lines.length > maxLines) {
-		const kept = lines.slice(0, maxLines);
-		kept[maxLines - 1] += " …";
-		return kept;
-	}
-	return lines;
-}
-
 async function generateRecap(
 	transcript: string,
 	ctx: ExtensionContext,
@@ -361,8 +336,7 @@ function showRecap(ctx: ExtensionContext, recap: string) {
 	if (!ctx.hasUI) return;
 	const theme = ctx.ui.theme;
 	const header = theme.fg("accent", theme.bold("✦ recap"));
-	const body = wrapText(recap, WRAP_WIDTH, MAX_BODY_LINES).map((l) => theme.fg("dim", l));
-	ctx.ui.setWidget(WIDGET_KEY, [header, ...body], { placement: "aboveEditor" });
+	ctx.ui.setWidget(WIDGET_KEY, [header, theme.fg("dim", recap)], { placement: "aboveEditor" });
 }
 
 function clearRecap(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary
- remove the fixed 100-column wrapping code
- pass recap text directly to Pi so it reflows at the live terminal width
- remove stale fixed-width design notes

## Verification
- `npm test --prefix session-recap`
- `node --test tests/*.test.mjs`
- TypeScript check for `session-recap/index.ts`
- visual check at 40, 80, and 120 columns