### PR TITLE
Prefer cheaper models for session recaps

### DIFF
--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Let Pi wrap recap text at the terminal width instead of inserting breaks at 100 characters.
 
+### Changed
+- Prefer Claude Haiku 4.5 for Anthropic sessions, or GPT-5.6 Luna when the active model is GPT and its provider offers Luna. Fall back to the active model; `--recap-model` still takes precedence.
+
 ## [0.2.2] - 2026-07-21
 
 ### Fixed

--- a/session-recap/DESIGN.md
+++ b/session-recap/DESIGN.md
@@ -25,8 +25,8 @@ line 142.
 | Trigger | Blur → 5-min timer → generate while still away. Refocus cancels timer + in-flight. Timer fires mid-turn → pending bit, generate at turn end if still blurred. | Same shape, but 90s default + an extra trigger: turn ends while blurred (debounced 3s). Multi-tab agent workflows context-switch faster than CC's 5 min assumes. |
 | Idle fallback | None — focus state `unknown` (no DECSET 1004) = feature off. | Kept, but only armed when the terminal has *not* demonstrated focus support (no `ESC[I`/`ESC[O` seen this session). |
 | Output | Persistent dim `※` transcript system message (`away_summary` subtype), excluded from API context. | Transient widget above the editor (pi-idiomatic, non-polluting), cleared on next input. |
-| Model | `getSmallFastModel()` — Haiku or `ANTHROPIC_SMALL_FAST_MODEL`. Never the active model. | Active model (no auth surprises across custom providers) + `--recap-model` override. See trade-off below. |
-| Context | Last **30 raw messages** + session memory, instruction appended as a user message, `skipCacheWrite: true`. | Two-tier compact text transcript (~12k char cap). 30 raw messages is only affordable at Haiku pricing; on the active model it could be 30–80k tokens per throwaway hint. |
+| Model | `getSmallFastModel()` — Haiku or `ANTHROPIC_SMALL_FAST_MODEL`. Never the active model. | Anthropic Haiku 4.5, or GPT-5.6 Luna when the active model is GPT and its provider offers Luna; otherwise the active model. `--recap-model` overrides this. |
+| Context | Last **30 raw messages** + session memory, instruction appended as a user message, `skipCacheWrite: true`. | Two-tier compact text transcript (~12k char cap) to avoid paying for old assistant text and tool results that add little orientation. |
 | Prompt | "Write exactly 1-3 short sentences. Start by stating the high-level task — what they are building or debugging, not implementation details. Next: the concrete next step. **Skip status reports and commit recaps.**" | Adopted near-verbatim. This was v0.1's biggest miss — our old prompt asked for a status report, which is exactly what CC bans. |
 | Dedupe | Max one summary per user turn (`hasSummarySinceLastUserTurn`). | Recap-prompt fingerprinting (same prompt = no new model call, even if Pi appends metadata entries). |
 | In-flight abort on refocus | Yes — summary appended to transcript late would be weird. | No — a widget landing moments after return is exactly when it helps. |
@@ -65,28 +65,25 @@ mid-flight drafts.
 - **No session persistence.** CC appends a transcript message instead; for pi
   a widget is idiomatic and avoids polluting the session file.
 
-## Model selection — decision (unchanged from v0.1)
+## Model selection
 
-Default must not surprise users with auth/login issues.
+Selection order:
 
-**Decision:** default to the **currently active model**, invoked as a tiny
-throwaway completion: no tools, reasoning disabled, `cacheRetention: "none"`,
-`maxTokens: 256`. Any OAuth / env-var / custom-provider credential the user
-already has just works. No active model / failed auth resolution → skip
-silently.
+1. Explicit `--recap-model "<provider>/<id>"` override.
+2. `anthropic/claude-haiku-4-5` when Anthropic is the active provider.
+3. GPT-5.6 Luna when the active model is GPT and its provider offers Luna.
+4. The active model.
 
-- CC uses Haiku here. We deliberately diverge: pi sessions run against
-  arbitrary providers and there is no universally-available cheap model we can
-  assume auth for. The cost envelope is protected by the transcript cap
-  (~3k input tokens) rather than by the model choice.
-- `apiKey` may legitimately be absent when `ok: true` (env/ambient-auth
-  providers such as Bedrock) — only bail when auth resolution itself fails,
-  and pass `env` through to `completeSimple`.
-- Escape hatch: `--recap-model "<provider>/<id>"`.
+Haiku is deliberately Anthropic-only. Luna is limited to GPT sessions and stays
+on the active provider. Automatic choices use only available models.
+Calls use no tools or reasoning, `cacheRetention: "none"`, and `maxTokens: 256`.
+No model or failed auth resolution skips the recap silently.
 
-> **Import note:** as of pi 0.80.x, `completeSimple`/`getModel` live in
-> `@earendil-works/pi-ai/compat` — the root export dropped them, which
-> silently broke v0.1.3 at runtime.
+`apiKey` may legitimately be absent when auth succeeds for env or ambient-auth
+providers. The resolved headers and environment are passed to `completeSimple`.
+
+> **Import note:** as of pi 0.80.x, `completeSimple` lives in
+> `@earendil-works/pi-ai/compat`; the root export dropped it.
 
 ## Context fed to the model — two-tier transcript
 
@@ -165,13 +162,9 @@ Post-processing: whitespace is collapsed to single spaces and capped at 600 char
 - Session persistence of recap history (CC does persist; see Display).
 - Multi-recap / rolling summary across many focus cycles.
 - Recap UI beyond the widget (no modal, no notifications).
-- Matching CC's small-fast-model choice (see Model selection).
 
 ## Follow-ups (v0.3+)
 
 - [ ] Optional e2e harness driving fake focus sequences + `turn_end` events
       and asserting widget state transitions (manual tmux testing works but is
       tedious).
-- [ ] Consider a provider-aware cheap-model default (e.g. Haiku when the
-      active provider is Anthropic) once pi exposes a reliable "sibling small
-      model" lookup.

--- a/session-recap/README.md
+++ b/session-recap/README.md
@@ -33,7 +33,14 @@ If focus events cause any weirdness in your terminal, run with `--recap-disable-
 
 ## Model
 
-Defaults to the **currently active model** in your Pi session, but with recap-specific low-cost settings. This piggybacks on the auth you already have configured, so there are no extra login prompts. Custom providers registered through `pi.registerProvider` work when they use one of pi-ai's built-in API types. Providers that register a custom API handler only inside Pi's runtime are skipped silently because pi-ai's standalone compatibility layer cannot route the recap call; use `--recap-model` to select a supported provider if you still want recaps in those sessions.
+The recap reuses the active provider's authentication and chooses a cheaper model when available:
+
+1. `--recap-model` when set.
+2. `anthropic/claude-haiku-4-5` for Anthropic sessions.
+3. GPT-5.6 Luna when the active model is GPT and its provider offers Luna.
+4. The currently active model otherwise.
+
+Custom providers registered through `pi.registerProvider` work when they use one of pi-ai's built-in API types. Providers that register a custom API handler only inside Pi's runtime are skipped silently because pi-ai's standalone compatibility layer cannot route the recap call; use `--recap-model` to select a supported provider if you still want recaps in those sessions.
 
 - No tools or Agent Skills are loaded into the recap call — only a compact two-tier transcript is sent (recent activity in detail, plus your earlier prompts and any compaction summary for task framing), capped at ~12k chars.
 - Reasoning/thinking is disabled for the recap call.
@@ -83,7 +90,7 @@ Filter to just this extension in `~/.pi/agent/settings.json`:
 | `--recap-disable-focus` | `false` | Disable DECSET `?1004` focus reporting. Idle fallback still runs. |
 | `--recap-during-active` | `false` | Allow away recaps while an agent turn is still running, instead of deferring to the end of the turn. |
 | `--recap-disable` | `false` | Disable the automatic recap entirely. `/recap` still works. |
-| `--recap-model "<p/id>"` | (active model) | Override the default, e.g. `anthropic/claude-sonnet-4-6`. |
+| `--recap-model "<p/id>"` | automatic | Override model selection, e.g. `anthropic/claude-sonnet-4-6`. |
 
 > v0.1's `--recap-focus-min-seconds` was removed: recaps are no longer drafted on every focus-out, so there is no quick-glance suppression to tune.
 

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -27,10 +27,9 @@
  * Skip status reports — the last assistant message is already on screen; what
  * the user has lost is the task thread.
  *
- * Model: defaults to the user's currently active model with reasoning/thinking
- * disabled and cache writes disabled. This piggybacks on the user's configured
- * auth. Custom providers using a built-in pi-ai API work normally; providers
- * with a custom API handler are skipped silently. Override explicitly with
+ * Model: uses Claude Haiku 4.5 for Anthropic sessions, or GPT-5.6 Luna when
+ * the active model is GPT and its provider offers Luna. Otherwise it keeps
+ * the active model. Reasoning and cache writes are disabled. Override with
  * `--recap-model "<provider>/<id>"`.
  *
  * Flags:
@@ -39,14 +38,14 @@
  *   --recap-disable-focus      Disable DECSET ?1004 focus reporting
  *   --recap-during-active      Allow away recaps while an agent turn is running
  *   --recap-disable            Disable the automatic recap entirely
- *   --recap-model <p/id>       Override the default (active) model
+ *   --recap-model <p/id>       Override automatic model selection
  *
  * Command:
  *   /recap                     Force-generate a recap right now
  */
 
 import { createHash } from "node:crypto";
-import { completeSimple, getModel } from "@earendil-works/pi-ai/compat";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 type ContentBlock = {
@@ -76,6 +75,9 @@ const STATUS_KEY = "session-recap";
 
 const DEFAULT_AWAY_SECONDS = 90;
 const DEFAULT_IDLE_SECONDS = 120;
+const ANTHROPIC_RECAP_MODEL = "claude-haiku-4-5";
+const GPT_MODEL_ID = /(?:^|\/)gpt-/;
+const LUNA_RECAP_MODEL = /(?:^|\/)gpt-5[.-]6-luna(?:$|[@:])/;
 
 // Debounce after a turn ends while blurred, so mid-loop turn_ends (which are
 // immediately followed by the next turn_start) don't trigger drafts.
@@ -98,12 +100,6 @@ const FOCUS_IN_SEQ = "\x1b[I";
 const FOCUS_OUT_SEQ = "\x1b[O";
 
 // --- helpers -----------------------------------------------------------------
-
-function splitModel(spec: string): { provider: string; id: string } | undefined {
-	const idx = spec.indexOf("/");
-	if (idx <= 0) return undefined;
-	return { provider: spec.slice(0, idx), id: spec.slice(idx + 1) };
-}
 
 function extractText(content: unknown): string {
 	if (typeof content === "string") return content;
@@ -137,10 +133,9 @@ function extractToolCalls(content: unknown): string[] {
  *   Tier 1 — task framing (cheap): the most recent compaction/branch summary
  *   if present, plus the last few *user* prompts before the latest one,
  *   trimmed hard. This is what lets the model state the high-level task
- *   instead of parroting the last tool call. (Claude Code feeds the last 30
- *   raw messages to Haiku for this; we're on the active model, so we keep the
- *   framing to user prompts only — old tool results add cost, not
- *   orientation.)
+ *   instead of parroting the last tool call. Claude Code feeds the last 30
+ *   raw messages to Haiku; user prompts preserve the framing without paying
+ *   for old tool results.
  *
  *   Tier 2 — recent detail: everything since the last user message, with the
  *   same per-item trimming as before (assistant text, tool calls, results).
@@ -239,24 +234,35 @@ function hasMeaningfulActivity(entries: Entry[]): boolean {
 	return toolCalls > 0 || assistantWords >= 30;
 }
 
+export function selectRecapModel(
+	activeModel: Model | undefined,
+	overrideSpec: string | undefined,
+	registry: Pick<ExtensionContext["modelRegistry"], "find" | "getAvailable">,
+): Model | undefined {
+	if (overrideSpec) {
+		const slash = overrideSpec.indexOf("/");
+		if (slash <= 0) return activeModel;
+		return registry.find(overrideSpec.slice(0, slash), overrideSpec.slice(slash + 1)) ?? activeModel;
+	}
+	if (!activeModel) return undefined;
+
+	const available = registry
+		.getAvailable()
+		.filter((model) => model.provider === activeModel.provider);
+	if (activeModel.provider === "anthropic") {
+		return available.find((model) => model.id === ANTHROPIC_RECAP_MODEL) ?? activeModel;
+	}
+	if (!GPT_MODEL_ID.test(activeModel.id)) return activeModel;
+	return available.find((model) => LUNA_RECAP_MODEL.test(model.id)) ?? activeModel;
+}
+
 async function generateRecap(
 	transcript: string,
 	ctx: ExtensionContext,
 	overrideSpec: string | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<string | undefined> {
-	// Prefer explicit override flag; otherwise use the active model.
-	let model: Model | undefined = ctx.model;
-	if (overrideSpec) {
-		const parsed = splitModel(overrideSpec);
-		if (parsed) {
-			const found = (getModel as (provider: string, id: string) => Model | undefined)(
-				parsed.provider,
-				parsed.id,
-			);
-			if (found) model = found;
-		}
-	}
+	const model = selectRecapModel(ctx.model, overrideSpec, ctx.modelRegistry);
 	if (!model) return undefined;
 
 	// Note: apiKey may legitimately be absent for env/ambient-auth providers —
@@ -375,7 +381,7 @@ export default function (pi: ExtensionAPI) {
 		default: false,
 	});
 	pi.registerFlag("recap-model", {
-		description: "Override the default (active) model, e.g. anthropic/claude-sonnet-4-6",
+		description: "Override automatic model selection, e.g. anthropic/claude-sonnet-4-6",
 		type: "string",
 		default: "",
 	});

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -29,6 +29,6 @@
     "@earendil-works/pi-coding-agent": "^0.80.3"
   },
   "scripts": {
-    "test": "node tests/unknown-api-provider.test.mjs"
+    "test": "node --test tests/*.test.mjs"
   }
 }

--- a/session-recap/tests/model-selection.test.mjs
+++ b/session-recap/tests/model-selection.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectRecapModel } from "../index.ts";
+
+const model = (provider, id) => ({ provider, id });
+const select = (active, available, override) =>
+	selectRecapModel(active, override, {
+		find: (provider, id) =>
+			available.find((candidate) => candidate.provider === provider && candidate.id === id),
+		getAvailable: () => available,
+	});
+
+test("an explicit recap model wins", () => {
+	const active = model("anthropic", "claude-opus-4-6");
+	const override = model("openrouter", "google/gemini-3-flash");
+	assert.equal(select(active, [override], "openrouter/google/gemini-3-flash"), override);
+	assert.equal(select(active, [], "openrouter/missing-model"), active);
+});
+
+test("Anthropic sessions use Claude Haiku 4.5", () => {
+	const active = model("anthropic", "claude-opus-4-6");
+	const haiku = model("anthropic", "claude-haiku-4-5");
+	assert.equal(select(active, [haiku]), haiku);
+});
+
+for (const [provider, activeId, lunaId] of [
+	["openai-codex", "gpt-5.6-sol", "gpt-5.6-luna"],
+	["openrouter", "openai/gpt-5.6-sol", "openai/gpt-5.6-luna"],
+	["cursor", "gpt-5-6-sol@1m", "gpt-5-6-luna@1m"],
+]) {
+	test(`${provider} GPT sessions use GPT-5.6 Luna`, () => {
+		const active = model(provider, activeId);
+		const luna = model(provider, lunaId);
+		assert.equal(select(active, [luna]), luna);
+	});
+}
+
+test("non-GPT sessions keep the active model outside Anthropic", () => {
+	const active = model("openrouter", "anthropic/claude-opus-4.6");
+	const haiku = model("openrouter", "anthropic/claude-haiku-4.5");
+	const luna = model("openrouter", "openai/gpt-5.6-luna");
+	assert.equal(select(active, [haiku, luna]), active);
+});
+
+test("an unavailable cheaper model falls back to the active model", () => {
+	const active = model("openai-codex", "gpt-5.6-sol");
+	assert.equal(select(active, []), active);
+});

--- a/session-recap/tests/unknown-api-provider.test.mjs
+++ b/session-recap/tests/unknown-api-provider.test.mjs
@@ -38,6 +38,9 @@ const ctx = {
 		maxTokens: 4096,
 	},
 	modelRegistry: {
+		getAvailable() {
+			return [];
+		},
 		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "unused" }),
 	},
 	sessionManager: {


### PR DESCRIPTION
## Summary
- use `anthropic/claude-haiku-4-5` when Anthropic is active
- when the active model is GPT, use an available GPT-5.6 Luna from the same provider
- preserve explicit `--recap-model` overrides and otherwise keep the active model

## Verification
- `npm test --prefix session-recap` (8 tests)
- TypeScript check for `session-recap/index.ts`
- `node --test tests/*.test.mjs` (62 tests)
- verified current Luna, Sol and Haiku model IDs with `pi --list-models`