### PR TITLE
Release session recap 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.3.0] - 2026-08-06
 
 ### Fixed
 - Let Pi wrap recap text at the terminal width instead of inserting breaks at 100 characters.

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Release
- publish `@tmustier/pi-session-recap@0.3.0`
- publish `pi-extensions@0.1.62`
- include responsive recap wrapping and cheaper provider-aware model selection

## Verification
- session recap: 8 tests passed
- repository: 62 tests passed
- TypeScript check passed
- inspected both npm tarballs; no nested `node_modules`