### PR TITLE
Improve session recap context and prompt

### DIFF
--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Replace the flattened 12,000-character transcript with a 30-message native conversation window, the initial request, and the latest compaction or branch summary. Long initial requests and tool results retain their beginning and end.
+- Use Claude Code's recap instruction verbatim, removing the extra file/error rules and the 600-character output truncation.
+
 ## [0.3.0] - 2026-08-06
 
 ### Fixed

--- a/session-recap/DESIGN.md
+++ b/session-recap/DESIGN.md
@@ -26,8 +26,8 @@ line 142.
 | Idle fallback | None — focus state `unknown` (no DECSET 1004) = feature off. | Kept, but only armed when the terminal has *not* demonstrated focus support (no `ESC[I`/`ESC[O` seen this session). |
 | Output | Persistent dim `※` transcript system message (`away_summary` subtype), excluded from API context. | Transient widget above the editor (pi-idiomatic, non-polluting), cleared on next input. |
 | Model | `getSmallFastModel()` — Haiku or `ANTHROPIC_SMALL_FAST_MODEL`. Never the active model. | Anthropic Haiku 4.5, or GPT-5.6 Luna when the active model is GPT and its provider offers Luna; otherwise the active model. `--recap-model` overrides this. |
-| Context | Last **30 raw messages** + session memory, instruction appended as a user message, `skipCacheWrite: true`. | Two-tier compact text transcript (~12k char cap) to avoid paying for old assistant text and tool results that add little orientation. |
-| Prompt | "Write exactly 1-3 short sentences. Start by stating the high-level task — what they are building or debugging, not implementation details. Next: the concrete next step. **Skip status reports and commit recaps.**" | Adopted near-verbatim. This was v0.1's biggest miss — our old prompt asked for a status report, which is exactly what CC bans. |
+| Context | Last **30 raw messages** + session memory, instruction appended as a user message, `skipCacheWrite: true`. | A **30-message LLM-ready window** in native roles + the initial request and latest compaction or branch summary as broader context. |
+| Prompt | "Write exactly 1-3 short sentences. Start by stating the high-level task — what they are building or debugging, not implementation details. Next: the concrete next step. **Skip status reports and commit recaps.**" | Adopted verbatim, with no custom system prompt. |
 | Dedupe | Max one summary per user turn (`hasSummarySinceLastUserTurn`). | Recap-prompt fingerprinting (same prompt = no new model call, even if Pi appends metadata entries). |
 | In-flight abort on refocus | Yes — summary appended to transcript late would be weird. | No — a widget landing moments after return is exactly when it helps. |
 
@@ -76,7 +76,8 @@ Selection order:
 
 Haiku is deliberately Anthropic-only. Luna is limited to GPT sessions and stays
 on the active provider. Automatic choices use only available models.
-Calls use no tools or reasoning, `cacheRetention: "none"`, and `maxTokens: 256`.
+Calls use no tools and request no reasoning level, with
+`cacheRetention: "none"` and `maxTokens: 256`.
 No model or failed auth resolution skips the recap silently.
 
 `apiKey` may legitimately be absent when auth succeeds for env or ambient-auth
@@ -85,64 +86,45 @@ providers. The resolved headers and environment are passed to `completeSimple`.
 > **Import note:** as of pi 0.80.x, `completeSimple` lives in
 > `@earendil-works/pi-ai/compat`; the root export dropped it.
 
-## Context fed to the model — two-tier transcript
+## Context fed to the model
 
-CC's insight: the recap's job is task re-orientation, and the task framing
-lives in the *conversation*, not in the last tool call. CC affords the last 30
-raw messages because it pays Haiku prices; we get the same orientation for
-~500 extra tokens by being selective:
+The recap call follows Claude Code's structure: a 30-message recent window is
+converted through Pi's normal LLM-context path and kept in its native user,
+assistant, and tool-result roles, followed by the recap instruction as a user
+message. When available, the initial request and latest compaction or branch
+summary are prepended to that final instruction as broader context. Initial
+requests longer than 8,000 characters keep their first and last 4,000.
 
-**Tier 1 — task framing (cheap):**
-- Most recent compaction or branch-summary entry, trimmed to 600 chars —
-  already-distilled task context (pi's analog of CC's session memory).
-- Up to 4 user prompts *before* the latest one, trimmed to 300 chars each.
-  Old assistant text and tool results add cost, not orientation.
-
-**Tier 2 — recent detail (since the last user message, inclusive):**
-- User text (≤1200 chars), assistant text (≤1200 chars)
-- Tool calls as `- <name>(<JSON args, ≤280 chars>)`
-- Tool results as `Result(<name>): <text, ≤400 chars>`
-
-Whole transcript capped at 12,000 chars (~3k tokens), so worst-case cost is
-unchanged from v0.1. The same builder serves resume/fork recaps (v0.1 passed
-the whole branch for resume; tier 1 now covers that need).
+Compaction and branch summaries are supplied once rather than duplicated in
+the recent message window. Tool results keep their first and last 2,000
+characters. A window boundary that falls inside a group of tool results
+expands to include their assistant tool call; an assistant-led window gets a
+short synthetic user boundary for provider compatibility.
 
 ## Prompt
 
-One user message plus a terse system prompt (some providers require a
-non-empty instruction string). Philosophy from CC: orient, don't report.
+The instruction is appended after the recent messages, following Claude Code
+verbatim. No custom system prompt is added.
 
 ```
-The user stepped away from this coding-agent session and is coming back.
-Write a short recap so they can re-enter flow.
-
-Rules:
-- Write 1-3 short sentences of plain text. No preamble, no markdown, no bullets.
-- Start by stating the high-level task — what the user is building, fixing, or
-  debugging — not implementation minutiae.
-- End with the concrete next step, if there is one.
-- Skip status reports and commit recaps; orient the reader instead.
-- If the last turn was aborted or errored, say so explicitly (e.g. "aborted
-  during X", "errored at Y").
-- Use file/function names where they matter. Max ~400 characters.
-
-<transcript>
-…
-</transcript>
+The user stepped away and is coming back. Write exactly 1-3 short sentences.
+Start by stating the high-level task — what they are building or debugging,
+not implementation details. Next: the concrete next step. Skip status reports
+and commit recaps.
 ```
 
-Post-processing: whitespace is collapsed to single spaces and capped at 600 characters.
+Post-processing only collapses whitespace; `maxTokens: 256` bounds the response.
 
 ## Edge cases
 
 1. **Turn still running when a trigger fires** — deferred to `agent_end` via
    the pending bit (CC-equivalent). `--recap-during-active` opts out.
 2. **Repeated blur/refocus with no new activity** — recap-prompt fingerprinting skips
-   regeneration. The fingerprint is derived from the capped transcript sent to
-   the model, not from the raw session leaf, so metadata-only entries do not
+   regeneration. The fingerprint is derived from the exact recap context sent
+   to the model, not from the raw session leaf, so metadata-only entries do not
    spend another call.
 3. **Errored/aborted turns** — triggers arm on `turn_end`, which fires
-   regardless of outcome; the prompt asks the model to say so explicitly.
+   regardless of outcome.
 4. **Terminal without DECSET `?1004`** — idle fallback covers it, and only
    runs there: the first real focus event disarms the idle path for the
    session. Caveat: on a supporting terminal where the user never switches

--- a/session-recap/README.md
+++ b/session-recap/README.md
@@ -42,8 +42,8 @@ The recap reuses the active provider's authentication and chooses a cheaper mode
 
 Custom providers registered through `pi.registerProvider` work when they use one of pi-ai's built-in API types. Providers that register a custom API handler only inside Pi's runtime are skipped silently because pi-ai's standalone compatibility layer cannot route the recap call; use `--recap-model` to select a supported provider if you still want recaps in those sessions.
 
-- No tools or Agent Skills are loaded into the recap call — only a compact two-tier transcript is sent (recent activity in detail, plus your earlier prompts and any compaction summary for task framing), capped at ~12k chars.
-- Reasoning/thinking is disabled for the recap call.
+- No tools or Agent Skills are loaded into the recap call. It receives a 30-message recent window in native roles, expanded only to keep tool calls with their results, plus the initial request and latest compaction or branch summary for broader context. Long initial requests keep their first and last 4,000 characters; long tool results keep their first and last 2,000.
+- No reasoning/thinking level is requested for the recap call.
 - Prompt cache writes/reads are disabled with `cacheRetention: "none"`.
 - Output is capped with `maxTokens: 256`.
 - No active model, failed auth resolution, or an unsupported custom API handler → the recap is skipped silently.
@@ -102,7 +102,7 @@ Filter to just this extension in `~/.pi/agent/settings.json`:
 
 ## Behaviour notes
 
-- **Uses `turn_end`, not `agent_end`**, to arm triggers, so a turn that errors or is aborted still gets recapped — and the prompt asks the model to say so explicitly.
+- **Uses `turn_end`, not `agent_end`**, to arm triggers, so a turn that errors or is aborted can still be recapped.
 - **No duplicate drafts**: the last-drafted recap prompt is fingerprinted; blur/refocus churn or session metadata-only changes reuse the recap rather than regenerating.
 - **Defers during active work by default**: if a trigger fires while a turn is still loading, the draft waits for the agent to finish, matching Claude Code's away-summary pending behaviour. Use `--recap-during-active` to allow mid-flight recaps.
 - **Aborts on new input**: any in-flight recap request is cancelled when you start typing or a new turn begins.

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -29,8 +29,8 @@
  *
  * Model: uses Claude Haiku 4.5 for Anthropic sessions, or GPT-5.6 Luna when
  * the active model is GPT and its provider offers Luna. Otherwise it keeps
- * the active model. Reasoning and cache writes are disabled. Override with
- * `--recap-model "<provider>/<id>"`.
+ * the active model. No reasoning level is requested; cache writes are
+ * disabled. Override with `--recap-model "<provider>/<id>"`.
  *
  * Flags:
  *   --recap-away-seconds <n>   Continuous blur before an away recap (default 90)
@@ -45,8 +45,15 @@
  */
 
 import { createHash } from "node:crypto";
+import type { Message } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	convertToLlm,
+	sessionEntryToContextMessages,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type SessionEntry,
+} from "@earendil-works/pi-coding-agent";
 
 type ContentBlock = {
 	type?: string;
@@ -55,18 +62,12 @@ type ContentBlock = {
 	arguments?: Record<string, unknown>;
 };
 
-type Entry = {
-	id?: string;
-	type: string;
-	summary?: string; // compaction / branch_summary entries
-	message?: {
-		role?: string;
-		content?: unknown;
-		toolName?: string;
-	};
-};
-
 type Model = Parameters<typeof completeSimple>[0];
+
+type RecapContext = {
+	messages: Message[];
+	broaderContext?: string;
+};
 
 type RecapReason = "idle" | "manual" | "resume" | "focus";
 
@@ -83,15 +84,10 @@ const LUNA_RECAP_MODEL = /(?:^|\/)gpt-5[.-]6-luna(?:$|[@:])/;
 // immediately followed by the next turn_start) don't trigger drafts.
 const POST_TURN_DEBOUNCE_MS = 3000;
 
-// Task-framing context limits (tier 1 of the transcript).
-const EARLIER_USER_PROMPTS = 4;
-const EARLIER_PROMPT_CHARS = 300;
-const COMPACTION_SUMMARY_CHARS = 600;
-
-// Model input cap. The dedupe fingerprint hashes exactly this capped prompt
-// payload, so irrelevant session metadata or over-cap transcript changes do
-// not spend another recap call.
-const TRANSCRIPT_CHAR_CAP = 12000;
+const RECENT_MESSAGE_WINDOW = 30;
+const INITIAL_TASK_EDGE_CHARS = 4000;
+const TOOL_RESULT_EDGE_CHARS = 2000;
+const EARLIER_CONTEXT_MARKER = "(Earlier conversation omitted.)";
 
 // DECSET 1004 focus reporting — https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 const FOCUS_ENABLE = "\x1b[?1004h";
@@ -127,95 +123,92 @@ function extractToolCalls(content: unknown): string[] {
 	return out;
 }
 
-/**
- * Two-tier transcript:
- *
- *   Tier 1 — task framing (cheap): the most recent compaction/branch summary
- *   if present, plus the last few *user* prompts before the latest one,
- *   trimmed hard. This is what lets the model state the high-level task
- *   instead of parroting the last tool call. Claude Code feeds the last 30
- *   raw messages to Haiku; user prompts preserve the framing without paying
- *   for old tool results.
- *
- *   Tier 2 — recent detail: everything since the last user message, with the
- *   same per-item trimming as before (assistant text, tool calls, results).
- */
-function buildTranscript(entries: Entry[]): string {
-	const userIdxs: number[] = [];
-	for (let i = 0; i < entries.length; i++) {
-		const e = entries[i];
-		if (e.type === "message" && e.message?.role === "user") userIdxs.push(i);
-	}
-	const lastUserIdx = userIdxs.length > 0 ? userIdxs[userIdxs.length - 1] : -1;
-
-	const lines: string[] = [];
-
-	// Tier 1a: most recent compaction / branch summary — already-distilled task context.
-	for (let i = entries.length - 1; i >= 0; i--) {
-		const e = entries[i];
-		if (
-			(e.type === "compaction" || e.type === "branch_summary") &&
-			typeof e.summary === "string" &&
-			e.summary.trim()
-		) {
-			lines.push(`Session summary so far: ${e.summary.trim().slice(0, COMPACTION_SUMMARY_CHARS)}`);
+export function buildRecapContext(
+	contextEntries: SessionEntry[],
+	branchEntries: SessionEntry[],
+): RecapContext {
+	let summary: string | undefined;
+	for (let i = contextEntries.length - 1; i >= 0; i--) {
+		const entry = contextEntries[i];
+		const candidate =
+			entry.type === "compaction" || entry.type === "branch_summary" ? entry.summary?.trim() : undefined;
+		if (candidate) {
+			summary = candidate;
 			break;
 		}
 	}
 
-	// Tier 1b: earlier user prompts (task framing), oldest → newest.
-	const earlier = userIdxs.slice(0, -1).slice(-EARLIER_USER_PROMPTS);
-	const earlierLines: string[] = [];
-	for (const i of earlier) {
-		const t = extractText(entries[i].message?.content).trim();
-		if (t) earlierLines.push(`- ${t.slice(0, EARLIER_PROMPT_CHARS)}`);
-	}
-	if (earlierLines.length > 0) {
-		lines.push("Earlier user prompts (task framing):");
-		lines.push(...earlierLines);
+	let initialTask: string | undefined;
+	for (const entry of branchEntries) {
+		if (entry.type !== "message" || entry.message.role !== "user") continue;
+		initialTask = extractText(entry.message.content).trim() || undefined;
+		break;
 	}
 
-	// Tier 2: full compact detail since the last user message (inclusive).
-	const slice = lastUserIdx >= 0 ? entries.slice(lastUserIdx) : entries;
-	const detail: string[] = [];
-	for (const e of slice) {
-		if (e.type !== "message" || !e.message?.role) continue;
-		const role = e.message.role;
-		if (role === "user") {
-			const t = extractText(e.message.content).trim();
-			if (t) detail.push(`User: ${t.slice(0, 1200)}`);
-		} else if (role === "assistant") {
-			const t = extractText(e.message.content).trim();
-			if (t) detail.push(`Assistant: ${t.slice(0, 1200)}`);
-			const calls = extractToolCalls(e.message.content);
-			if (calls.length) detail.push(...calls);
-		} else if (role === "toolResult") {
-			const t = extractText(e.message.content).trim();
-			const name = e.message.toolName ?? "tool";
-			if (t) detail.push(`Result(${name}): ${t.slice(0, 400)}`);
-		}
-	}
-	if (detail.length > 0) {
-		lines.push("Recent activity (since the user's last message):");
-		lines.push(...detail);
+	const messages = convertToLlm(
+		contextEntries
+			.filter((entry) => entry.type !== "compaction" && entry.type !== "branch_summary")
+			.flatMap(sessionEntryToContextMessages),
+	).map((message) => {
+		if (message.role !== "toolResult") return message;
+		return {
+			...message,
+			content: message.content.map((block) => {
+				if (block.type !== "text" || block.text.length <= TOOL_RESULT_EDGE_CHARS * 2) return block;
+				return {
+					...block,
+					text: `${block.text.slice(0, TOOL_RESULT_EDGE_CHARS)}\n… [tool result truncated for recap] …\n${block.text.slice(-TOOL_RESULT_EDGE_CHARS)}`,
+				};
+			}),
+		};
+	});
+	let start = Math.max(0, messages.length - RECENT_MESSAGE_WINDOW);
+	while (start > 0 && messages[start]?.role === "toolResult") start--;
+	let recentMessages = messages.slice(start);
+	while (recentMessages[0]?.role === "toolResult") recentMessages = recentMessages.slice(1);
+	if (recentMessages[0]?.role === "assistant") {
+		recentMessages = [
+			{
+				role: "user",
+				content: EARLIER_CONTEXT_MARKER,
+				timestamp: recentMessages[0].timestamp,
+			},
+			...recentMessages,
+		];
 	}
 
-	return lines.join("\n");
+	const broader: string[] = [];
+	const initialTaskInRecent = recentMessages.some(
+		(message) => message.role === "user" && extractText(message.content).trim() === initialTask,
+	);
+	if (initialTask && !initialTaskInRecent) {
+		const framedInitialTask =
+			initialTask.length <= INITIAL_TASK_EDGE_CHARS * 2
+				? initialTask
+				: `${initialTask.slice(0, INITIAL_TASK_EDGE_CHARS)}\n… [middle of initial request omitted for recap] …\n${initialTask.slice(-INITIAL_TASK_EDGE_CHARS)}`;
+		broader.push(`Initial user request:\n${framedInitialTask}`);
+	}
+	if (summary) broader.push(`Session summary:\n${summary}`);
+
+	return {
+		messages: recentMessages,
+		broaderContext: broader.length > 0 ? broader.join("\n\n") : undefined,
+	};
 }
 
-function recapStateKey(transcript: string): string {
-	return createHash("sha256").update(transcript.slice(0, TRANSCRIPT_CHAR_CAP)).digest("hex");
+function recapStateKey(context: RecapContext): string {
+	return createHash("sha256").update(JSON.stringify(context)).digest("hex");
 }
 
 /**
  * Only draft a recap if there has been real agent activity since the last user
  * message: at least one tool call, or ~30+ words of assistant text.
  */
-function hasMeaningfulActivity(entries: Entry[]): boolean {
+function hasMeaningfulActivity(entries: SessionEntry[]): boolean {
 	let lastUserIdx = -1;
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const e = entries[i];
-		if (e.type === "message" && e.message?.role === "user") {
+		if (e.type === "message" && e.message.role === "user") {
 			lastUserIdx = i;
 			break;
 		}
@@ -225,7 +218,7 @@ function hasMeaningfulActivity(entries: Entry[]): boolean {
 	let toolCalls = 0;
 	for (const e of tail) {
 		if (e.type !== "message") continue;
-		if (e.message?.role === "assistant") {
+		if (e.message.role === "assistant") {
 			const t = extractText(e.message.content);
 			assistantWords += t.split(/\s+/).filter(Boolean).length;
 			toolCalls += extractToolCalls(e.message.content).length;
@@ -257,7 +250,7 @@ export function selectRecapModel(
 }
 
 async function generateRecap(
-	transcript: string,
+	recapContext: RecapContext,
 	ctx: ExtensionContext,
 	overrideSpec: string | undefined,
 	signal: AbortSignal | undefined,
@@ -270,34 +263,22 @@ async function generateRecap(
 	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	if (!auth?.ok) return undefined;
 
-	// Prompt philosophy mirrors Claude Code's away-summary: orient the user in
-	// the high-level task, don't produce a status report — the last assistant
-	// message is already visible in scrollback.
 	const prompt =
-		"The user stepped away from this coding-agent session and is coming back. " +
-		"Write a short recap so they can re-enter flow.\n\n" +
-		"Rules:\n" +
-		"- Write 1-3 short sentences of plain text. No preamble, no markdown, no bullets.\n" +
-		"- Start by stating the high-level task — what the user is building, fixing, or " +
-		"debugging — not implementation minutiae.\n" +
-		"- End with the concrete next step, if there is one.\n" +
-		"- Skip status reports and commit recaps; orient the reader instead.\n" +
-		"- If the last turn was aborted or errored, say so explicitly " +
-		'(e.g. "aborted during X", "errored at Y").\n' +
-		"- Use file/function names where they matter. Max ~400 characters.\n\n" +
-		"<transcript>\n" +
-		transcript.slice(0, TRANSCRIPT_CHAR_CAP) +
-		"\n</transcript>";
+		(recapContext.broaderContext
+			? `Broader session context:\n${recapContext.broaderContext}\n\n`
+			: "") +
+		"The user stepped away and is coming back. Write exactly 1-3 short sentences. " +
+		"Start by stating the high-level task — what they are building or debugging, not " +
+		"implementation details. Next: the concrete next step. Skip status reports and commit recaps.";
 
 	let response;
 	try {
 		response = await completeSimple(
 			model,
 			{
-				// Some providers (notably openai-codex-responses) require a non-empty
-				// top-level instruction string even for simple one-shot completions.
-				systemPrompt: "You write terse, concrete session recaps for a coding agent UI.",
+				systemPrompt: "",
 				messages: [
+					...recapContext.messages,
 					{
 						role: "user",
 						content: [{ type: "text", text: prompt }],
@@ -310,9 +291,6 @@ async function generateRecap(
 				headers: auth.headers,
 				env: auth.env,
 				signal,
-				// Recaps are tiny, throwaway UI hints. Do not pay to create/read prompt
-				// cache entries, and do not spend reasoning tokens. Claude Code's away
-				// summary path likewise disables thinking for this job.
 				cacheRetention: "none",
 				maxTokens: 256,
 			},
@@ -335,7 +313,7 @@ async function generateRecap(
 		.replace(/\s+/g, " ")
 		.trim();
 
-	return text ? text.slice(0, 600) : undefined;
+	return text || undefined;
 }
 
 function showRecap(ctx: ExtensionContext, recap: string) {
@@ -463,16 +441,16 @@ export default function (pi: ExtensionAPI) {
 		!focusEnabled || isFocusDisabled() || !focusEventsSeen;
 
 	const generateAndShow = async (ctx: ExtensionContext, opts: { reason: RecapReason }) => {
-		const entries = ctx.sessionManager.getBranch() as Entry[];
+		const entries = ctx.sessionManager.getBranch();
 		if (!hasMeaningfulActivity(entries) && opts.reason !== "manual") return;
 
-		const transcript = buildTranscript(entries);
-		if (!transcript.trim()) return;
+		const recapContext = buildRecapContext(ctx.sessionManager.buildContextEntries(), entries);
+		if (recapContext.messages.length === 0 && !recapContext.broaderContext) return;
 
 		// Snapshot the exact recap prompt we're summarising BEFORE we await. If
 		// recap-relevant content changes while the model call is in flight, discard
 		// the stale draft; metadata-only leaf changes should not invalidate it.
-		const startStateKey = recapStateKey(transcript);
+		const startStateKey = recapStateKey(recapContext);
 		if (opts.reason !== "manual" && lastDraftedStateKey === startStateKey) return;
 
 		// Take ownership of the active-request slot. Any prior request is
@@ -488,13 +466,16 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", "✦ drafting recap…"));
 
 		try {
-			const recap = await generateRecap(transcript, ctx, modelOverride(), controller.signal);
+			const recap = await generateRecap(recapContext, ctx, modelOverride(), controller.signal);
 			if (!recap || controller.signal.aborted) return;
 			// Discard the recap if the recap prompt changed while we were drafting.
 			// If only session metadata changed, the prompt key stays the same and the
 			// draft remains valid.
-			const currentTranscript = buildTranscript(ctx.sessionManager.getBranch() as Entry[]);
-			if (recapStateKey(currentTranscript) !== startStateKey) return;
+			const currentContext = buildRecapContext(
+				ctx.sessionManager.buildContextEntries(),
+				ctx.sessionManager.getBranch(),
+			);
+			if (recapStateKey(currentContext) !== startStateKey) return;
 
 			// Stamp the prompt we actually summarised, not the live branch leaf.
 			lastDraftedStateKey = startStateKey;

--- a/session-recap/tests/context.test.mjs
+++ b/session-recap/tests/context.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildRecapContext } from "../index.ts";
+
+const initialTask = `Build a session recap that preserves the user's task framing. ${"context ".repeat(100)}`.trim();
+const summary = `The recap extension now works, but its output lacks the original task context. ${"detail ".repeat(120)}`.trim();
+const toolResult = `The implementation still flattens and truncates the conversation. ${"output ".repeat(1000)}`;
+
+const initialEntry = {
+	type: "message",
+	message: { role: "user", content: initialTask, timestamp: 1 },
+};
+const currentEntries = [
+	{
+		type: "compaction",
+		summary,
+	},
+	{
+		type: "message",
+		message: { role: "user", content: "Make it match Claude Code more closely.", timestamp: 2 },
+	},
+	{
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [
+				{ type: "text", text: "I am comparing the two implementations." },
+				{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "src/services/awaySummary.ts" } },
+			],
+			timestamp: 3,
+		},
+	},
+	{
+		type: "message",
+		message: {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [{ type: "text", text: toolResult }],
+			isError: false,
+			timestamp: 4,
+		},
+	},
+];
+
+test("recap context keeps broad task framing and recent native messages", () => {
+	const context = buildRecapContext(currentEntries, [initialEntry, ...currentEntries]);
+
+	assert.equal(context.broaderContext, `Initial user request:\n${initialTask}\n\nSession summary:\n${summary}`);
+	assert.deepEqual(context.messages.map((message) => message.role), ["user", "assistant", "toolResult"]);
+	assert.equal(
+		context.messages[2].content[0].text,
+		`${toolResult.slice(0, 2000)}\n… [tool result truncated for recap] …\n${toolResult.slice(-2000)}`,
+	);
+});
+
+test("recap context uses a 30-message recent window and bounds initial framing", () => {
+	const initialRequest = `Start of request. ${"detail ".repeat(1500)}End of request.`;
+	const branch = [];
+	for (let i = 1; i <= 16; i++) {
+		branch.push(
+			{ type: "message", message: { role: "user", content: i === 1 ? initialRequest : `User request ${i}` } },
+			{ type: "message", message: { role: "assistant", content: [{ type: "text", text: `Response ${i}` }] } },
+		);
+	}
+
+	const context = buildRecapContext(branch, branch);
+	assert.equal(context.messages.length, 30);
+	assert.equal(context.messages[0].content, "User request 2");
+	assert.ok(context.broaderContext.startsWith("Initial user request:\nStart of request."));
+	assert.match(context.broaderContext, /\[middle of initial request omitted for recap\]/);
+	assert.ok(context.broaderContext.endsWith("End of request."));
+});
+
+test("recap context adds a user boundary before an assistant-led window", () => {
+	const branch = [{ type: "message", message: { role: "user", content: "Investigate the failing build." } }];
+	for (let i = 1; i <= 16; i++) {
+		branch.push(
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: `call-${i}`, name: "read", arguments: { path: `file-${i}` } }],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolCallId: `call-${i}`,
+					toolName: "read",
+					content: [{ type: "text", text: `file ${i} contents` }],
+				},
+			},
+		);
+	}
+
+	const context = buildRecapContext(branch, branch);
+	assert.equal(context.messages[0].role, "user");
+	assert.equal(context.messages[0].content, "(Earlier conversation omitted.)");
+	assert.equal(context.messages[1].role, "assistant");
+});
+
+test("recap context does not repeat a recent initial request", () => {
+	const context = buildRecapContext([initialEntry], [initialEntry]);
+	assert.equal(context.broaderContext, undefined);
+});

--- a/session-recap/tests/unknown-api-provider.test.mjs
+++ b/session-recap/tests/unknown-api-provider.test.mjs
@@ -22,6 +22,17 @@ function makePi() {
 const pi = makePi();
 sessionRecap(pi);
 
+const branch = [
+	{ type: "message", message: { role: "user", content: "Please fix the bridge integration." } },
+	{
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "I inspected the integration and prepared the next concrete change." }],
+		},
+	},
+];
+
 const widgets = [];
 const ctx = {
 	hasUI: true,
@@ -44,16 +55,8 @@ const ctx = {
 		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "unused" }),
 	},
 	sessionManager: {
-		getBranch: () => [
-			{ type: "message", message: { role: "user", content: "Please fix the bridge integration." } },
-			{
-				type: "message",
-				message: {
-					role: "assistant",
-					content: [{ type: "text", text: "I inspected the integration and prepared the next concrete change." }],
-				},
-			},
-		],
+		getBranch: () => branch,
+		buildContextEntries: () => branch,
 	},
 	ui: {
 		setStatus() {},


### PR DESCRIPTION
## Summary
- replace the flattened transcript with a 30-message native context window
- include bounded initial-task framing and the latest compaction or branch summary
- use Claude Code's concise away-summary instruction and retain provider-safe tool-call boundaries
- bound long tool results while keeping their beginning and end

## Verification
- `npm test --prefix session-recap`
- `npm exec --prefix session-recap --package=typescript -- tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck index.ts`
- `node --test tests/*.test.mjs`
- npm pack dry runs for root and `session-recap` (no nested `node_modules`)
