### PR TITLE
Release session recap 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.4.0] - 2026-08-06
 
 ### Changed
 - Replace the flattened 12,000-character transcript with a 30-message native conversation window, the initial request, and the latest compaction or branch summary. Long initial requests and tool results retain their beginning and end.

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Release
- bump `@tmustier/pi-session-recap` to 0.4.0
- bump `pi-extensions` to 0.1.63
- finalize the 0.4.0 changelog

## Verification
- session recap tests: 12 passed
- TypeScript check passed
- packed extension: 9 files, no nested `node_modules`
- packed root package: 184 files, no nested `node_modules`
