### PR TITLE
Release session recap 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.4.1] - 2026-08-06
 
 ### Changed
 - Simplified the extension implementation and documentation without changing recap behaviour.

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",


### PR DESCRIPTION
## Release
- bump `@tmustier/pi-session-recap` to 0.4.1
- bump `pi-extensions` to 0.1.64
- finalize the 0.4.1 changelog

## Verification
- session recap tests: 12 passed
- TypeScript check passed
- packed extension: 8 files, no nested `node_modules`
- packed root package: 183 files, no nested `node_modules`
