### PR TITLE
fix(usage): make dashboard views responsive

### DIFF
--- a/tests/usage-graph.test.mjs
+++ b/tests/usage-graph.test.mjs
@@ -274,6 +274,44 @@ test("renderChart emits height+1 lines within width and draws braille dots", () 
 	assert.ok(lines[CHART_OPTS.height].includes("2026-07-15"));
 });
 
+test("renderChart uses the full caller-provided width on wide terminals", () => {
+	const hourly = hourlyFrom([
+		[TODAY + 1 * HOUR, "a", "m", "", cell({ cost: 1 })],
+		[TODAY + 9 * HOUR, "a", "m", "", cell({ cost: 5 })],
+	]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+
+	const width = 200;
+	const lines = renderChart(model, { ...CHART_OPTS, width });
+	const widest = Math.max(...lines.map((line) => line.length));
+	assert.equal(widest, width, "chart should expand beyond the old 110-column cap");
+});
+
+test("renderChart stays within its requested width on very narrow terminals", () => {
+	const hourly = hourlyFrom([[TODAY + HOUR, "a", "m", "", cell({ cost: 5 })]]);
+	const model = buildGraphModel(hourly, {
+		period: "today",
+		metric: "cost",
+		groupBy: "total",
+		cumulative: true,
+		bounds: BOUNDS,
+	});
+
+	for (const width of [0, 1, 2, 5, 9, 10, 20, 30]) {
+		const lines = renderChart(model, { ...CHART_OPTS, width });
+		assert.equal(lines.length, CHART_OPTS.height + 1);
+		for (const line of lines) {
+			assert.ok(line.length <= width, `width=${width}: line too long (${line.length})`);
+		}
+	}
+});
+
 test("renderChart routes series text through the colorize callback with the series index", () => {
 	const hourly = hourlyFrom([[TODAY + HOUR, "a", "m", "", cell({ cost: 5 })]]);
 	const model = buildGraphModel(hourly, {

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Graphs, tables, and insights now expand to the full available terminal width instead of stopping at fixed content caps, while remaining safely bounded in very narrow terminals.
+
 ## [0.9.4] - 2026-07-22
 
 ### Changed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -61,11 +61,11 @@ In Pi, run:
 
 `/usage` has three view modes, shown as a tab strip in the title and cycled with `v`:
 
-- **Graphs** (default) — an interactive braille line-chart explorer for usage over time (screenshot at the top of this page, details below).
+- **Graphs** (default) - a responsive interactive braille line-chart explorer that expands to the available terminal width (screenshot at the top of this page, details below).
 - **Table** — per-provider / per-model stats with cost and token breakdown, with keyboard filtering (details below).
 - **Insights** — data-driven characteristics of your cost for the active time period (details below). Insights are **independent lenses**, not a breakdown, so they overlap and don't sum to 100%.
 
-Every view can export its current slice with `e` — see [Export](#export).
+Every view expands to the available terminal width and can export its current slice with `e` - see [Export](#export).
 
 ![Table view of /usage](screenshot.png)
 

--- a/usage-extension/graph.ts
+++ b/usage-extension/graph.ts
@@ -283,6 +283,10 @@ export interface ChartRenderOptions {
 	formatValue: (value: number) => string;
 	formatTime: (ms: number) => string;
 	colorize?: ChartColorize;
+	/** ANSI-aware display-width measurement supplied by the UI layer. */
+	measureWidth?: (text: string) => number;
+	/** ANSI-aware truncation supplied by the UI layer. */
+	truncate?: (text: string, width: number) => string;
 }
 
 const BRAILLE_BASE = 0x2800;
@@ -298,16 +302,22 @@ const DOT_BITS = [
  */
 export function renderChart(model: GraphModel, options: ChartRenderOptions): string[] {
 	const colorize: ChartColorize = options.colorize ?? ((_i, text) => text);
+	const measureWidth = options.measureWidth ?? ((text: string) => Array.from(text).length);
+	const truncate = options.truncate ?? ((text: string, width: number) => Array.from(text).slice(0, width).join(""));
+	const safeWidth = Math.max(0, Math.floor(options.width));
 	const plotHeightForLabels = Math.max(options.height, 4);
 	const midRowForLabels = Math.floor((plotHeightForLabels - 1) / 2);
 	const midValue = (model.yMax * (plotHeightForLabels - 1 - midRowForLabels)) / (plotHeightForLabels - 1);
-	const yLabelWidth = Math.max(
-		options.formatValue(model.yMax).length,
-		options.formatValue(midValue).length,
-		options.formatValue(0).length
+	const yLabelWidth = Math.min(
+		Math.max(
+			measureWidth(options.formatValue(model.yMax)),
+			measureWidth(options.formatValue(midValue)),
+			measureWidth(options.formatValue(0))
+		),
+		Math.max(safeWidth - 2, 0)
 	);
-	const axisWidth = yLabelWidth + 2; // label + " ┤" / " │"
-	const plotWidth = Math.max(options.width - axisWidth, 10);
+	const axisWidth = Math.min(yLabelWidth + 2, safeWidth); // label + " ┤" / " │"
+	const plotWidth = Math.max(safeWidth - axisWidth, 0);
 	const plotHeight = Math.max(options.height, 4);
 	const dotW = plotWidth * 2;
 	const dotH = plotHeight * 4;
@@ -371,7 +381,10 @@ export function renderChart(model: GraphModel, options: ChartRenderOptions): str
 		else if (row === midRow && plotHeight > 2) label = options.formatValue(midValue);
 		else if (row === plotHeight - 1) label = options.formatValue(0);
 		const axisChar = label ? "┤" : "│";
-		let line = colorize(-1, label.padStart(yLabelWidth) + " " + axisChar);
+		const fittedLabel = truncate(label, yLabelWidth);
+		const labelPadding = " ".repeat(Math.max(yLabelWidth - measureWidth(fittedLabel), 0));
+		const axisPrefix = axisWidth === 0 ? "" : axisWidth === 1 ? axisChar : labelPadding + fittedLabel + " " + axisChar;
+		let line = colorize(-1, axisPrefix);
 		// Batch consecutive cells with the same owning series into one colorize
 		// call to keep ANSI overhead proportional to color changes, not cells.
 		let runOwner = -2;
@@ -391,21 +404,26 @@ export function renderChart(model: GraphModel, options: ChartRenderOptions): str
 			runText += mask === 0 ? " " : String.fromCharCode(BRAILLE_BASE + mask);
 		}
 		flush();
-		lines.push(line);
+		lines.push(truncate(line, safeWidth));
 	}
 
 	// X-axis labels: start, optional middle, end.
 	const startLabel = options.formatTime(model.domainStartMs);
 	const endLabel = options.formatTime(model.domainEndMs);
-	const midLabel = plotWidth >= startLabel.length + endLabel.length + 14 ? options.formatTime(model.domainStartMs + (model.domainEndMs - model.domainStartMs) / 2) : "";
-	let axis = " ".repeat(yLabelWidth + 2) + startLabel;
+	const startLabelWidth = measureWidth(startLabel);
+	const endLabelWidth = measureWidth(endLabel);
+	const midLabel =
+		plotWidth >= startLabelWidth + endLabelWidth + 14
+			? options.formatTime(model.domainStartMs + (model.domainEndMs - model.domainStartMs) / 2)
+			: "";
+	let axis = " ".repeat(axisWidth) + startLabel;
 	if (midLabel) {
-		const midPos = yLabelWidth + 2 + Math.floor(plotWidth / 2 - midLabel.length / 2);
+		const midPos = axisWidth + Math.floor(plotWidth / 2 - measureWidth(midLabel) / 2);
 		axis = axis.padEnd(midPos) + midLabel;
 	}
-	const endPos = yLabelWidth + 2 + plotWidth - endLabel.length;
+	const endPos = axisWidth + plotWidth - endLabelWidth;
 	axis = axis.padEnd(Math.max(endPos, axis.length + 1)) + endLabel;
-	lines.push(colorize(-1, axis));
+	lines.push(truncate(colorize(-1, axis), safeWidth));
 
 	return lines;
 }

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -72,7 +72,7 @@ interface TableLayout {
 	compact: boolean;
 }
 
-const MAX_NAME_COL_WIDTH = 26;
+const FULL_TABLE_NAME_MIN_WIDTH = 26;
 
 const SESSIONS_COLUMN: DataColumn = {
 	label: "Sessions",
@@ -133,7 +133,7 @@ const FULL_DATA_COLUMNS: DataColumn[] = [
 ];
 
 const TABLE_LAYOUTS: TableLayoutCandidate[] = [
-	{ columns: FULL_DATA_COLUMNS, minNameWidth: MAX_NAME_COL_WIDTH },
+	{ columns: FULL_DATA_COLUMNS, minNameWidth: FULL_TABLE_NAME_MIN_WIDTH },
 	{ columns: [SESSIONS_COLUMN, MSGS_COLUMN, COST_COLUMN, TOKENS_COLUMN], minNameWidth: 14, compact: true },
 	{ columns: [SESSIONS_COLUMN, COST_COLUMN, TOKENS_COLUMN], minNameWidth: 12, compact: true },
 	{ columns: [COST_COLUMN, TOKENS_COLUMN], minNameWidth: 10, compact: true },
@@ -239,11 +239,11 @@ function pickFittingText(width: number, variants: string[]): string {
 }
 
 function getTableLayout(width: number): TableLayout {
-	const safeWidth = Math.max(width, 0);
+	const safeWidth = Math.max(Math.floor(width), 0);
 
 	for (const candidate of TABLE_LAYOUTS) {
 		const columnsWidth = sumColumnWidths(candidate.columns);
-		const nameWidth = Math.min(MAX_NAME_COL_WIDTH, Math.max(safeWidth - columnsWidth, 0));
+		const nameWidth = Math.max(safeWidth - columnsWidth, 0);
 		if (nameWidth >= candidate.minNameWidth) {
 			return {
 				columns: candidate.columns,
@@ -256,12 +256,20 @@ function getTableLayout(width: number): TableLayout {
 
 	const fallback = TABLE_LAYOUTS[TABLE_LAYOUTS.length - 1]!;
 	const fallbackColumnsWidth = sumColumnWidths(fallback.columns);
-	const fallbackNameWidth = Math.min(MAX_NAME_COL_WIDTH, Math.max(safeWidth - fallbackColumnsWidth, 0));
+	const fallbackNameWidth = Math.max(safeWidth - fallbackColumnsWidth, 0);
 	return {
 		columns: fallback.columns,
 		nameWidth: fallbackNameWidth,
 		tableWidth: fallbackNameWidth + fallbackColumnsWidth,
 		compact: fallback.compact ?? false,
+	};
+}
+
+function getInsightsLayout(width: number): { contentWidth: number; adviceWidth: number } {
+	const contentWidth = Math.max(Math.floor(width), 0);
+	return {
+		contentWidth,
+		adviceWidth: Math.max(contentWidth - 9, 1),
 	};
 }
 
@@ -640,10 +648,12 @@ class UsageComponent {
 
 		const chartHeight = 12;
 		const chart = renderChart(model, {
-			width: Math.max(Math.min(width, 110), 30),
+			width: Math.max(0, Math.floor(width)),
 			height: chartHeight,
 			formatValue,
 			formatTime,
+			measureWidth: visibleWidth,
+			truncate: (text, maxWidth) => truncateToWidth(text, maxWidth, ""),
 			colorize: (seriesIndex, text) => {
 				if (seriesIndex < 0) return th.fg("dim", text);
 				return seriesColor(seriesIndex) + text + COLOR_RESET;
@@ -681,12 +691,11 @@ class UsageComponent {
 		const hasCost = stats.totals.cost > 0;
 		const lines: string[] = [];
 
-		// Cap the content column so advice stays readable on very wide terminals.
-		const contentWidth = Math.max(Math.min(width, 100), 40);
+		const { contentWidth, adviceWidth } = getInsightsLayout(width);
 
 		lines.push(th.bold("What's contributing to your cost?"));
 		const subtitle = "Approximate, based on local sessions on this machine (these are independent and don't sum to 100%).";
-		for (const wrapped of wrapTextWithAnsi(subtitle, contentWidth)) {
+		for (const wrapped of wrapTextWithAnsi(subtitle, Math.max(contentWidth, 1))) {
 			lines.push(th.fg("dim", wrapped));
 		}
 		lines.push("");
@@ -707,12 +716,11 @@ class UsageComponent {
 			return lines;
 		}
 
-		// Columns: marker(2) + stat(6) + gap(1); advice aligns under the headline.
+		// Columns: marker(2) + stat(6) + gap(1); wrapped text aligns under the headline.
 		const indent = "         ";
-		const adviceWidth = Math.max(contentWidth - indent.length, 30);
 
 		const sectionHeader = (label: string, color: "warning" | "accent"): string => {
-			const rule = "─".repeat(Math.max(contentWidth - label.length - 1, 4));
+			const rule = "─".repeat(Math.max(contentWidth - visibleWidth(label) - 1, 0));
 			return `${th.fg(color, th.bold(label))} ${th.fg("border", rule)}`;
 		};
 
@@ -724,7 +732,9 @@ class UsageComponent {
 			// De-emphasise the trailing period-share parenthetical on alarm headlines.
 			const match = insight.headline.match(/^(.*?)\s*(\(\d[\d.,]*% of this period\))$/);
 			const headline = match ? `${match[1]} ${th.fg("dim", match[2]!)}` : insight.headline;
-			lines.push(`${marker}${stat} ${headline}`);
+			const headlineLines = wrapTextWithAnsi(headline, adviceWidth);
+			lines.push(`${marker}${stat} ${headlineLines[0] ?? ""}`);
+			for (const wrapped of headlineLines.slice(1)) lines.push(`${indent}${wrapped}`);
 			if (insight.advice) {
 				for (const wrapped of wrapTextWithAnsi(insight.advice, adviceWidth)) {
 					lines.push(`${indent}${th.fg("dim", wrapped)}`);


### PR DESCRIPTION
## Summary

- let the usage graph consume the full width supplied by Pi instead of capping it at 110 columns
- make graph rendering width-safe on very narrow terminals, including ANSI-aware measurement and truncation
- remove the 100-column Insights cap and wrap insight headlines and advice across the available width
- let the table's provider/model column grow so table rules and rows fill wide terminals
- document the responsive behavior and add wide/narrow graph regression coverage

## Verification

- `node --test tests/files-widget-utils.test.mjs tests/usage-data.test.mjs tests/usage-export.test.mjs tests/usage-graph.test.mjs`: 64 passed
- external Pi runtime verification: Pi v0.84.0 loaded the extension and registered `/usage`
- `git diff --check`
