### PR TITLE
feat(usage): remember selected tabs

### DIFF
--- a/tests/usage-preferences.test.mjs
+++ b/tests/usage-preferences.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	getUsageStatePath,
+	loadUsagePreferences,
+	loadUsageSelectionState,
+	parseUsagePreferences,
+	parseUsageSelectionState,
+	resolveUsageSelection,
+	saveUsageSelectionState,
+} from "../usage-extension/preferences.ts";
+
+test("parseUsagePreferences enables view and period memory independently", () => {
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":true}}'), {
+		rememberView: true,
+		rememberPeriod: false,
+	});
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberPeriod":true}}'), {
+		rememberView: false,
+		rememberPeriod: true,
+	});
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":true,"rememberPeriod":true}}'), {
+		rememberView: true,
+		rememberPeriod: true,
+	});
+});
+
+test("parseUsagePreferences uses strict booleans and safe defaults", () => {
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":"true","rememberPeriod":1}}'), {
+		rememberView: false,
+		rememberPeriod: false,
+	});
+	assert.deepEqual(parseUsagePreferences("not json"), { rememberView: false, rememberPeriod: false });
+});
+
+test("resolveUsageSelection restores each enabled dimension independently", () => {
+	const remembered = { view: "insights", period: "lastWeek" };
+	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: false }, remembered), {
+		view: "insights",
+		period: "allTime",
+	});
+	assert.deepEqual(resolveUsageSelection({ rememberView: false, rememberPeriod: true }, remembered), {
+		view: "graph",
+		period: "lastWeek",
+	});
+	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: true }, {}), {
+		view: "graph",
+		period: "allTime",
+	});
+});
+
+test("parseUsageSelectionState ignores unknown or malformed selections", () => {
+	assert.deepEqual(parseUsageSelectionState('{"view":"table","period":"lastWeek"}'), {
+		view: "table",
+		period: "lastWeek",
+	});
+	assert.deepEqual(parseUsageSelectionState('{"view":"calendar","period":"yesterday"}'), {});
+	assert.deepEqual(parseUsageSelectionState("not json"), {});
+});
+
+test("selection state persists only enabled dimensions and loads defensively", () => {
+	const dir = mkdtempSync(join(tmpdir(), "usage-preferences-"));
+	try {
+		writeFileSync(
+			join(dir, "settings.json"),
+			'{"usage-extension":{"rememberView":true,"rememberPeriod":false}}',
+			"utf8",
+		);
+		const preferences = loadUsagePreferences(dir);
+		assert.deepEqual(preferences, { rememberView: true, rememberPeriod: false });
+
+		saveUsageSelectionState(dir, { view: "insights", period: "last30Days" }, preferences);
+		assert.deepEqual(loadUsageSelectionState(dir), { view: "insights" });
+		assert.deepEqual(JSON.parse(readFileSync(getUsageStatePath(dir), "utf8")), { view: "insights" });
+
+		writeFileSync(getUsageStatePath(dir), '{"view":"broken","period":"today"}', "utf8");
+		assert.deepEqual(loadUsageSelectionState(dir), { period: "today" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("disabled selection memory clears stale state and does not create a new file", () => {
+	const dir = mkdtempSync(join(tmpdir(), "usage-preferences-disabled-"));
+	try {
+		writeFileSync(getUsageStatePath(dir), '{"view":"table","period":"today"}', "utf8");
+		saveUsageSelectionState(
+			dir,
+			{ view: "table", period: "today" },
+			{ rememberView: false, rememberPeriod: false },
+		);
+		assert.throws(() => readFileSync(getUsageStatePath(dir), "utf8"), { code: "ENOENT" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Optional independent `rememberView` and `rememberPeriod` settings restore the last selected dashboard view and/or time period. Runtime selections are persisted in a separate extension-owned state file rather than modifying `settings.json`.
+
 ## [0.9.4] - 2026-07-22
 
 ### Changed

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -67,6 +67,24 @@ In Pi, run:
 
 Every view can export its current slice with `e` — see [Export](#export).
 
+### Remembering the selected tabs
+
+By default, `/usage` opens on **Graphs** and **All Time**. You can independently remember the last selected view, the last selected time period, or both:
+
+```json
+{
+	"usage-extension": {
+		"rememberView": true,
+		"rememberPeriod": true
+	}
+}
+```
+
+- `rememberView` restores the last **Graphs / Table / Insights** selection.
+- `rememberPeriod` restores the last **Today / This Week / Last Week / Last 30 Days / All Time** selection.
+
+Both settings are optional and default to `false`. The selections are stored separately in `<agentDir>/usage-extension-state.json`; the extension never writes runtime state back into `settings.json`.
+
 ![Table view of /usage](screenshot.png)
 
 ### Filtering the table

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -37,8 +37,13 @@ import {
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-
-type ViewMode = "table" | "insights" | "graph";
+import {
+	loadUsagePreferences,
+	loadUsageSelectionState,
+	resolveUsageSelection,
+	saveUsageSelectionState,
+} from "./preferences";
+import type { UsageSelection, ViewMode } from "./preferences";
 
 const VIEW_CYCLE: ViewMode[] = ["graph", "table", "insights"];
 
@@ -287,6 +292,7 @@ class UsageComponent {
 	private theme: Theme;
 	private requestRender: () => void;
 	private done: () => void;
+	private selectionChanged: (state: UsageSelection) => void;
 
 	// Graph explorer state.
 	private graphMetric: GraphMetric = "cost";
@@ -299,12 +305,26 @@ class UsageComponent {
 	private graphHidden = new Set<string>();
 	private graphLegendIndex = 0;
 
-	constructor(theme: Theme, data: UsageData, requestRender: () => void, done: () => void) {
+	constructor(
+		theme: Theme,
+		data: UsageData,
+		requestRender: () => void,
+		done: () => void,
+		initial: UsageSelection,
+		selectionChanged: (state: UsageSelection) => void,
+	) {
 		this.theme = theme;
 		this.requestRender = requestRender;
 		this.done = done;
 		this.data = data;
+		this.viewMode = initial.view;
+		this.activeTab = initial.period;
+		this.selectionChanged = selectionChanged;
 		this.updateProviderOrder();
+	}
+
+	private notifySelectionChanged(): void {
+		this.selectionChanged({ view: this.viewMode, period: this.activeTab });
 	}
 
 	private updateProviderOrder(): void {
@@ -409,6 +429,7 @@ class UsageComponent {
 			const idx = VIEW_CYCLE.indexOf(this.viewMode);
 			this.viewMode = VIEW_CYCLE[(idx + 1) % VIEW_CYCLE.length]!;
 			this.exportNote = null;
+			this.notifySelectionChanged();
 			this.requestRender();
 			return;
 		}
@@ -428,12 +449,14 @@ class UsageComponent {
 			this.activeTab = TAB_ORDER[(idx + 1) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
 			this.exportNote = null;
+			this.notifySelectionChanged();
 			this.requestRender();
 		} else if (matchesKey(data, "shift+tab") || matchesKey(data, "left")) {
 			const idx = TAB_ORDER.indexOf(this.activeTab);
 			this.activeTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
 			this.exportNote = null;
+			this.notifySelectionChanged();
 			this.requestRender();
 		} else if (this.viewMode === "graph") {
 			// Graph-specific keys were handled above; swallow table-only keys.
@@ -977,6 +1000,21 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
+			const agentDir = getAgentDir();
+			const preferences = loadUsagePreferences(agentDir);
+			const remembered = loadUsageSelectionState(agentDir);
+			const initial = resolveUsageSelection(preferences, remembered);
+			const persistSelection = (state: UsageSelection): void => {
+				try {
+					saveUsageSelectionState(agentDir, state, preferences);
+				} catch {
+					// Remembering the selection is best-effort and must not break the dashboard.
+				}
+			};
+			// Canonicalize stale state immediately, including removing selections whose
+			// corresponding remember flag is disabled.
+			persistSelection(initial);
+
 			await ctx.ui.custom<void>((tui, theme, _kb, done) => {
 				const container = new Container();
 
@@ -985,7 +1023,7 @@ export default function (pi: ExtensionAPI) {
 				container.addChild(new DynamicBorder((s: string) => theme.fg("border", s)));
 				container.addChild(new Spacer(1));
 
-				const usage = new UsageComponent(theme, data, () => tui.requestRender(), () => done());
+				const usage = new UsageComponent(theme, data, () => tui.requestRender(), () => done(), initial, persistSelection);
 
 				return {
 					render: (w: number) => {

--- a/usage-extension/preferences.ts
+++ b/usage-extension/preferences.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { TabName } from "./data.ts";
+
+export type ViewMode = "table" | "insights" | "graph";
+
+export interface UsagePreferences {
+	rememberView: boolean;
+	rememberPeriod: boolean;
+}
+
+export interface UsageSelection {
+	view: ViewMode;
+	period: TabName;
+}
+
+export interface UsageSelectionState {
+	view?: ViewMode;
+	period?: TabName;
+}
+
+const DEFAULT_PREFERENCES: UsagePreferences = {
+	rememberView: false,
+	rememberPeriod: false,
+};
+
+const VIEW_MODES = new Set<ViewMode>(["graph", "table", "insights"]);
+const PERIODS = new Set<TabName>(["today", "thisWeek", "lastWeek", "last30Days", "allTime"]);
+
+export function parseUsagePreferences(settingsJson: string): UsagePreferences {
+	try {
+		const parsed = JSON.parse(settingsJson) as {
+			"usage-extension"?: { rememberView?: unknown; rememberPeriod?: unknown };
+		};
+		const settings = parsed["usage-extension"];
+		return {
+			rememberView: settings?.rememberView === true,
+			rememberPeriod: settings?.rememberPeriod === true,
+		};
+	} catch {
+		return { ...DEFAULT_PREFERENCES };
+	}
+}
+
+export function parseUsageSelectionState(stateJson: string): UsageSelectionState {
+	try {
+		const parsed = JSON.parse(stateJson) as { view?: unknown; period?: unknown };
+		return {
+			...(typeof parsed.view === "string" && VIEW_MODES.has(parsed.view as ViewMode)
+				? { view: parsed.view as ViewMode }
+				: {}),
+			...(typeof parsed.period === "string" && PERIODS.has(parsed.period as TabName)
+				? { period: parsed.period as TabName }
+				: {}),
+		};
+	} catch {
+		return {};
+	}
+}
+
+export function resolveUsageSelection(
+	preferences: UsagePreferences,
+	remembered: UsageSelectionState,
+): UsageSelection {
+	return {
+		view: preferences.rememberView ? remembered.view ?? "graph" : "graph",
+		period: preferences.rememberPeriod ? remembered.period ?? "allTime" : "allTime",
+	};
+}
+
+export function getUsageStatePath(agentDir: string): string {
+	return join(agentDir, "usage-extension-state.json");
+}
+
+export function loadUsagePreferences(agentDir: string): UsagePreferences {
+	try {
+		return parseUsagePreferences(readFileSync(join(agentDir, "settings.json"), "utf8"));
+	} catch {
+		return { ...DEFAULT_PREFERENCES };
+	}
+}
+
+export function loadUsageSelectionState(agentDir: string): UsageSelectionState {
+	try {
+		return parseUsageSelectionState(readFileSync(getUsageStatePath(agentDir), "utf8"));
+	} catch {
+		return {};
+	}
+}
+
+export function saveUsageSelectionState(
+	agentDir: string,
+	state: UsageSelection,
+	preferences: UsagePreferences,
+): void {
+	const statePath = getUsageStatePath(agentDir);
+	if (!preferences.rememberView && !preferences.rememberPeriod) {
+		try {
+			unlinkSync(statePath);
+		} catch {
+			// No remembered state to clear.
+		}
+		return;
+	}
+
+	const saved: UsageSelectionState = {
+		...(preferences.rememberView ? { view: state.view } : {}),
+		...(preferences.rememberPeriod ? { period: state.period } : {}),
+	};
+	const tmpPath = join(agentDir, `.usage-state-${process.pid}-${Date.now()}.tmp`);
+	mkdirSync(agentDir, { recursive: true });
+	try {
+		writeFileSync(tmpPath, JSON.stringify(saved, null, "\t") + "\n", "utf8");
+		renameSync(tmpPath, statePath);
+	} catch (error) {
+		try {
+			unlinkSync(tmpPath);
+		} catch {
+			// The temporary file may not have been created or may already be gone.
+		}
+		throw error;
+	}
+}


### PR DESCRIPTION
## Summary

- add independent `rememberView` and `rememberPeriod` settings for `/usage`
- restore the selected dashboard view and/or time period on the next open
- persist runtime selections atomically in `<agentDir>/usage-extension-state.json` without modifying `settings.json`
- validate malformed settings and state defensively, and clear disabled dimensions
- document the settings and add focused preference/state tests

## Configuration

```json
{
  "usage-extension": {
    "rememberView": true,
    "rememberPeriod": true
  }
}
```

Both options are independent and default to `false`.

## Verification

- `npx --yes --package tsx tsx --test tests/files-widget-utils.test.mjs tests/usage-data.test.mjs tests/usage-export.test.mjs tests/usage-graph.test.mjs tests/usage-preferences.test.mjs`: 68 passed
- `pi_verify` typecheck and runtime verification passed with Pi 0.84.1; `/usage` registered and invoked through Pi RPC
