### PR TITLE
feat(usage): make slash command configurable

### DIFF
--- a/tests/usage-preferences.test.mjs
+++ b/tests/usage-preferences.test.mjs
@@ -18,14 +18,17 @@ test("parseUsagePreferences enables view and period memory independently", () =>
 	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":true}}'), {
 		rememberView: true,
 		rememberPeriod: false,
+		commandName: "usage",
 	});
 	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberPeriod":true}}'), {
 		rememberView: false,
 		rememberPeriod: true,
+		commandName: "usage",
 	});
 	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":true,"rememberPeriod":true}}'), {
 		rememberView: true,
 		rememberPeriod: true,
+		commandName: "usage",
 	});
 });
 
@@ -33,21 +36,49 @@ test("parseUsagePreferences uses strict booleans and safe defaults", () => {
 	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":"true","rememberPeriod":1}}'), {
 		rememberView: false,
 		rememberPeriod: false,
+		commandName: "usage",
 	});
-	assert.deepEqual(parseUsagePreferences("not json"), { rememberView: false, rememberPeriod: false });
+	assert.deepEqual(parseUsagePreferences("not json"), {
+		rememberView: false,
+		rememberPeriod: false,
+		commandName: "usage",
+	});
+});
+
+test("parseUsagePreferences accepts a safe custom command name", () => {
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"commandName":"us-stats_2"}}'), {
+		rememberView: false,
+		rememberPeriod: false,
+		commandName: "us-stats_2",
+	});
+});
+
+test("parseUsagePreferences rejects slash-prefixed and malformed command names", () => {
+	for (const commandName of ["/us", "Usage", "2usage", "usage stats", "usage:2", "", true]) {
+		assert.equal(
+			parseUsagePreferences(JSON.stringify({ "usage-extension": { commandName } })).commandName,
+			"usage",
+		);
+	}
 });
 
 test("resolveUsageSelection restores each enabled dimension independently", () => {
 	const remembered = { view: "insights", period: "lastWeek" };
-	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: false }, remembered), {
-		view: "insights",
-		period: "allTime",
-	});
-	assert.deepEqual(resolveUsageSelection({ rememberView: false, rememberPeriod: true }, remembered), {
-		view: "graph",
-		period: "lastWeek",
-	});
-	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: true }, {}), {
+	assert.deepEqual(
+		resolveUsageSelection({ rememberView: true, rememberPeriod: false, commandName: "usage" }, remembered),
+		{
+			view: "insights",
+			period: "allTime",
+		},
+	);
+	assert.deepEqual(
+		resolveUsageSelection({ rememberView: false, rememberPeriod: true, commandName: "usage" }, remembered),
+		{
+			view: "graph",
+			period: "lastWeek",
+		},
+	);
+	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: true, commandName: "usage" }, {}), {
 		view: "graph",
 		period: "allTime",
 	});
@@ -71,7 +102,7 @@ test("selection state persists only enabled dimensions and loads defensively", (
 			"utf8",
 		);
 		const preferences = loadUsagePreferences(dir);
-		assert.deepEqual(preferences, { rememberView: true, rememberPeriod: false });
+		assert.deepEqual(preferences, { rememberView: true, rememberPeriod: false, commandName: "usage" });
 
 		saveUsageSelectionState(dir, { view: "insights", period: "last30Days" }, preferences);
 		assert.deepEqual(loadUsageSelectionState(dir), { view: "insights" });
@@ -91,7 +122,7 @@ test("disabled selection memory clears stale state and does not create a new fil
 		saveUsageSelectionState(
 			dir,
 			{ view: "table", period: "today" },
-			{ rememberView: false, rememberPeriod: false },
+			{ rememberView: false, rememberPeriod: false, commandName: "usage" },
 		);
 		assert.throws(() => readFileSync(getUsageStatePath(dir), "utf8"), { code: "ENOENT" });
 	} finally {

--- a/tests/usage-preferences.test.mjs
+++ b/tests/usage-preferences.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	getUsageStatePath,
+	loadUsagePreferences,
+	loadUsageSelectionState,
+	parseUsagePreferences,
+	parseUsageSelectionState,
+	resolveUsageSelection,
+	saveUsageSelectionState,
+} from "../usage-extension/preferences.ts";
+
+test("parseUsagePreferences enables view and period memory independently", () => {
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":true}}'), {
+		rememberView: true,
+		rememberPeriod: false,
+	});
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberPeriod":true}}'), {
+		rememberView: false,
+		rememberPeriod: true,
+	});
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":true,"rememberPeriod":true}}'), {
+		rememberView: true,
+		rememberPeriod: true,
+	});
+});
+
+test("parseUsagePreferences uses strict booleans and safe defaults", () => {
+	assert.deepEqual(parseUsagePreferences('{"usage-extension":{"rememberView":"true","rememberPeriod":1}}'), {
+		rememberView: false,
+		rememberPeriod: false,
+	});
+	assert.deepEqual(parseUsagePreferences("not json"), { rememberView: false, rememberPeriod: false });
+});
+
+test("resolveUsageSelection restores each enabled dimension independently", () => {
+	const remembered = { view: "insights", period: "lastWeek" };
+	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: false }, remembered), {
+		view: "insights",
+		period: "allTime",
+	});
+	assert.deepEqual(resolveUsageSelection({ rememberView: false, rememberPeriod: true }, remembered), {
+		view: "graph",
+		period: "lastWeek",
+	});
+	assert.deepEqual(resolveUsageSelection({ rememberView: true, rememberPeriod: true }, {}), {
+		view: "graph",
+		period: "allTime",
+	});
+});
+
+test("parseUsageSelectionState ignores unknown or malformed selections", () => {
+	assert.deepEqual(parseUsageSelectionState('{"view":"table","period":"lastWeek"}'), {
+		view: "table",
+		period: "lastWeek",
+	});
+	assert.deepEqual(parseUsageSelectionState('{"view":"calendar","period":"yesterday"}'), {});
+	assert.deepEqual(parseUsageSelectionState("not json"), {});
+});
+
+test("selection state persists only enabled dimensions and loads defensively", () => {
+	const dir = mkdtempSync(join(tmpdir(), "usage-preferences-"));
+	try {
+		writeFileSync(
+			join(dir, "settings.json"),
+			'{"usage-extension":{"rememberView":true,"rememberPeriod":false}}',
+			"utf8",
+		);
+		const preferences = loadUsagePreferences(dir);
+		assert.deepEqual(preferences, { rememberView: true, rememberPeriod: false });
+
+		saveUsageSelectionState(dir, { view: "insights", period: "last30Days" }, preferences);
+		assert.deepEqual(loadUsageSelectionState(dir), { view: "insights" });
+		assert.deepEqual(JSON.parse(readFileSync(getUsageStatePath(dir), "utf8")), { view: "insights" });
+
+		writeFileSync(getUsageStatePath(dir), '{"view":"broken","period":"today"}', "utf8");
+		assert.deepEqual(loadUsageSelectionState(dir), { period: "today" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("disabled selection memory clears stale state and does not create a new file", () => {
+	const dir = mkdtempSync(join(tmpdir(), "usage-preferences-disabled-"));
+	try {
+		writeFileSync(getUsageStatePath(dir), '{"view":"table","period":"today"}', "utf8");
+		saveUsageSelectionState(
+			dir,
+			{ view: "table", period: "today" },
+			{ rememberView: false, rememberPeriod: false },
+		);
+		assert.throws(() => readFileSync(getUsageStatePath(dir), "utf8"), { code: "ENOENT" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Optional independent `rememberView` and `rememberPeriod` settings restore the last selected dashboard view and/or time period. Runtime selections are persisted in a separate extension-owned state file rather than modifying `settings.json`.
+
 ## [0.9.4] - 2026-07-22
 
 ### Changed

--- a/usage-extension/CHANGELOG.md
+++ b/usage-extension/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Optional `commandName` setting overrides the registered `/usage` slash command, avoiding collisions with commands from other extensions. Changing it requires `/reload`; invalid values fall back to `usage`.
 - Optional independent `rememberView` and `rememberPeriod` settings restore the last selected dashboard view and/or time period. Runtime selections are persisted in a separate extension-owned state file rather than modifying `settings.json`.
 
 ## [0.9.4] - 2026-07-22

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -67,6 +67,24 @@ In Pi, run:
 
 Every view can export its current slice with `e` — see [Export](#export).
 
+### Remembering the selected tabs
+
+By default, `/usage` opens on **Graphs** and **All Time**. You can independently remember the last selected view, the last selected time period, or both:
+
+```json
+{
+	"usage-extension": {
+		"rememberView": true,
+		"rememberPeriod": true
+	}
+}
+```
+
+- `rememberView` restores the last **Graphs / Table / Insights** selection.
+- `rememberPeriod` restores the last **Today / This Week / Last Week / Last 30 Days / All Time** selection.
+
+Both settings are optional and default to `false`. The selections are stored separately in `<agentDir>/usage-extension-state.json`; the extension never writes runtime state back into `settings.json`.
+
 ![Table view of /usage](screenshot.png)
 
 ### Filtering the table

--- a/usage-extension/README.md
+++ b/usage-extension/README.md
@@ -55,6 +55,18 @@ In Pi, run:
 /usage
 ```
 
+To avoid a slash-command name collision, override the command name in the global `~/.pi/agent/settings.json`:
+
+```json
+{
+	"usage-extension": {
+		"commandName": "us"
+	}
+}
+```
+
+After changing `commandName`, run `/reload`. The value must be a bare lowercase command name without the leading `/`; letters, digits, `_`, and `-` are supported. Invalid values fall back to `usage`.
+
 ## Features
 
 ### Views

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -37,8 +37,13 @@ import {
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-
-type ViewMode = "table" | "insights" | "graph";
+import {
+	loadUsagePreferences,
+	loadUsageSelectionState,
+	resolveUsageSelection,
+	saveUsageSelectionState,
+} from "./preferences";
+import type { UsageSelection, ViewMode } from "./preferences";
 
 const VIEW_CYCLE: ViewMode[] = ["graph", "table", "insights"];
 
@@ -287,6 +292,7 @@ class UsageComponent {
 	private theme: Theme;
 	private requestRender: () => void;
 	private done: () => void;
+	private selectionChanged: (state: UsageSelection) => void;
 
 	// Graph explorer state.
 	private graphMetric: GraphMetric = "cost";
@@ -299,12 +305,26 @@ class UsageComponent {
 	private graphHidden = new Set<string>();
 	private graphLegendIndex = 0;
 
-	constructor(theme: Theme, data: UsageData, requestRender: () => void, done: () => void) {
+	constructor(
+		theme: Theme,
+		data: UsageData,
+		requestRender: () => void,
+		done: () => void,
+		initial: UsageSelection,
+		selectionChanged: (state: UsageSelection) => void,
+	) {
 		this.theme = theme;
 		this.requestRender = requestRender;
 		this.done = done;
 		this.data = data;
+		this.viewMode = initial.view;
+		this.activeTab = initial.period;
+		this.selectionChanged = selectionChanged;
 		this.updateProviderOrder();
+	}
+
+	private notifySelectionChanged(): void {
+		this.selectionChanged({ view: this.viewMode, period: this.activeTab });
 	}
 
 	private updateProviderOrder(): void {
@@ -409,6 +429,7 @@ class UsageComponent {
 			const idx = VIEW_CYCLE.indexOf(this.viewMode);
 			this.viewMode = VIEW_CYCLE[(idx + 1) % VIEW_CYCLE.length]!;
 			this.exportNote = null;
+			this.notifySelectionChanged();
 			this.requestRender();
 			return;
 		}
@@ -428,12 +449,14 @@ class UsageComponent {
 			this.activeTab = TAB_ORDER[(idx + 1) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
 			this.exportNote = null;
+			this.notifySelectionChanged();
 			this.requestRender();
 		} else if (matchesKey(data, "shift+tab") || matchesKey(data, "left")) {
 			const idx = TAB_ORDER.indexOf(this.activeTab);
 			this.activeTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length]!;
 			this.updateProviderOrder();
 			this.exportNote = null;
+			this.notifySelectionChanged();
 			this.requestRender();
 		} else if (this.viewMode === "graph") {
 			// Graph-specific keys were handled above; swallow table-only keys.
@@ -977,6 +1000,21 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
+			const agentDir = getAgentDir();
+			const preferences = loadUsagePreferences(agentDir);
+			const remembered = loadUsageSelectionState(agentDir);
+			const initial = resolveUsageSelection(preferences, remembered);
+			const persistSelection = (state: UsageSelection): void => {
+				try {
+					saveUsageSelectionState(agentDir, state, preferences);
+				} catch {
+					// Remembering the selection is best-effort and must not break the dashboard.
+				}
+			};
+			// Canonicalize stale state immediately, including removing selections whose
+			// corresponding remember flag is disabled.
+			persistSelection(initial);
+
 			await ctx.ui.custom<void>((tui, theme, _kb, done) => {
 				const container = new Container();
 
@@ -985,7 +1023,7 @@ export default function (pi: ExtensionAPI) {
 				container.addChild(new DynamicBorder((s: string) => theme.fg("border", s)));
 				container.addChild(new Spacer(1));
 
-				const usage = new UsageComponent(theme, data, () => tui.requestRender(), () => done());
+				const usage = new UsageComponent(theme, data, () => tui.requestRender(), () => done(), initial, persistSelection);
 
 				return {
 					render: (w: number) => {

--- a/usage-extension/index.ts
+++ b/usage-extension/index.ts
@@ -952,7 +952,9 @@ class UsageComponent {
 // =============================================================================
 
 export default function (pi: ExtensionAPI) {
-	pi.registerCommand("usage", {
+	const commandName = loadUsagePreferences(getAgentDir()).commandName;
+
+	pi.registerCommand(commandName, {
 		description: "Show usage statistics dashboard",
 		handler: async (_args: string, ctx: ExtensionCommandContext) => {
 			if (!ctx.hasUI) {

--- a/usage-extension/preferences.ts
+++ b/usage-extension/preferences.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { TabName } from "./data.ts";
+
+export type ViewMode = "table" | "insights" | "graph";
+
+export interface UsagePreferences {
+	rememberView: boolean;
+	rememberPeriod: boolean;
+}
+
+export interface UsageSelection {
+	view: ViewMode;
+	period: TabName;
+}
+
+export interface UsageSelectionState {
+	view?: ViewMode;
+	period?: TabName;
+}
+
+const DEFAULT_PREFERENCES: UsagePreferences = {
+	rememberView: false,
+	rememberPeriod: false,
+};
+
+const VIEW_MODES = new Set<ViewMode>(["graph", "table", "insights"]);
+const PERIODS = new Set<TabName>(["today", "thisWeek", "lastWeek", "last30Days", "allTime"]);
+
+export function parseUsagePreferences(settingsJson: string): UsagePreferences {
+	try {
+		const parsed = JSON.parse(settingsJson) as {
+			"usage-extension"?: { rememberView?: unknown; rememberPeriod?: unknown };
+		};
+		const settings = parsed["usage-extension"];
+		return {
+			rememberView: settings?.rememberView === true,
+			rememberPeriod: settings?.rememberPeriod === true,
+		};
+	} catch {
+		return { ...DEFAULT_PREFERENCES };
+	}
+}
+
+export function parseUsageSelectionState(stateJson: string): UsageSelectionState {
+	try {
+		const parsed = JSON.parse(stateJson) as { view?: unknown; period?: unknown };
+		return {
+			...(typeof parsed.view === "string" && VIEW_MODES.has(parsed.view as ViewMode)
+				? { view: parsed.view as ViewMode }
+				: {}),
+			...(typeof parsed.period === "string" && PERIODS.has(parsed.period as TabName)
+				? { period: parsed.period as TabName }
+				: {}),
+		};
+	} catch {
+		return {};
+	}
+}
+
+export function resolveUsageSelection(
+	preferences: UsagePreferences,
+	remembered: UsageSelectionState,
+): UsageSelection {
+	return {
+		view: preferences.rememberView ? remembered.view ?? "graph" : "graph",
+		period: preferences.rememberPeriod ? remembered.period ?? "allTime" : "allTime",
+	};
+}
+
+export function getUsageStatePath(agentDir: string): string {
+	return join(agentDir, "usage-extension-state.json");
+}
+
+export function loadUsagePreferences(agentDir: string): UsagePreferences {
+	try {
+		return parseUsagePreferences(readFileSync(join(agentDir, "settings.json"), "utf8"));
+	} catch {
+		return { ...DEFAULT_PREFERENCES };
+	}
+}
+
+export function loadUsageSelectionState(agentDir: string): UsageSelectionState {
+	try {
+		return parseUsageSelectionState(readFileSync(getUsageStatePath(agentDir), "utf8"));
+	} catch {
+		return {};
+	}
+}
+
+export function saveUsageSelectionState(
+	agentDir: string,
+	state: UsageSelection,
+	preferences: UsagePreferences,
+): void {
+	const statePath = getUsageStatePath(agentDir);
+	if (!preferences.rememberView && !preferences.rememberPeriod) {
+		try {
+			unlinkSync(statePath);
+		} catch {
+			// No remembered state to clear.
+		}
+		return;
+	}
+
+	const saved: UsageSelectionState = {
+		...(preferences.rememberView ? { view: state.view } : {}),
+		...(preferences.rememberPeriod ? { period: state.period } : {}),
+	};
+	const tmpPath = join(agentDir, `.usage-state-${process.pid}-${Date.now()}.tmp`);
+	mkdirSync(agentDir, { recursive: true });
+	try {
+		writeFileSync(tmpPath, JSON.stringify(saved, null, "\t") + "\n", "utf8");
+		renameSync(tmpPath, statePath);
+	} catch (error) {
+		try {
+			unlinkSync(tmpPath);
+		} catch {
+			// The temporary file may not have been created or may already be gone.
+		}
+		throw error;
+	}
+}

--- a/usage-extension/preferences.ts
+++ b/usage-extension/preferences.ts
@@ -8,6 +8,7 @@ export type ViewMode = "table" | "insights" | "graph";
 export interface UsagePreferences {
 	rememberView: boolean;
 	rememberPeriod: boolean;
+	commandName: string;
 }
 
 export interface UsageSelection {
@@ -23,20 +24,33 @@ export interface UsageSelectionState {
 const DEFAULT_PREFERENCES: UsagePreferences = {
 	rememberView: false,
 	rememberPeriod: false,
+	commandName: "usage",
 };
 
 const VIEW_MODES = new Set<ViewMode>(["graph", "table", "insights"]);
 const PERIODS = new Set<TabName>(["today", "thisWeek", "lastWeek", "last30Days", "allTime"]);
+const COMMAND_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+
+function parseCommandName(value: unknown): string {
+	return typeof value === "string" && COMMAND_NAME_PATTERN.test(value)
+		? value
+		: DEFAULT_PREFERENCES.commandName;
+}
 
 export function parseUsagePreferences(settingsJson: string): UsagePreferences {
 	try {
 		const parsed = JSON.parse(settingsJson) as {
-			"usage-extension"?: { rememberView?: unknown; rememberPeriod?: unknown };
+			"usage-extension"?: {
+				rememberView?: unknown;
+				rememberPeriod?: unknown;
+				commandName?: unknown;
+			};
 		};
 		const settings = parsed["usage-extension"];
 		return {
 			rememberView: settings?.rememberView === true,
 			rememberPeriod: settings?.rememberPeriod === true,
+			commandName: parseCommandName(settings?.commandName),
 		};
 	} catch {
 		return { ...DEFAULT_PREFERENCES };


### PR DESCRIPTION
## Why

The usage extension currently always registers `/usage`. When another installed package exposes the same command, Pi keeps both registrations and presents suffixed entries such as `/usage:1` and `/usage:2`. That makes autocomplete ambiguous and forces users to remember which numbered command belongs to this dashboard.

Allowing the command name to be configured gives users a deterministic, collision-free alias such as `/us` without requiring changes to either package.

## What changed

- add `usage-extension.commandName` to the global `~/.pi/agent/settings.json` configuration
- register the dashboard command using the configured name during extension initialization
- validate command names as lowercase bare command tokens and fall back safely to `usage`
- document the setting and the required `/reload`
- add parser coverage for valid, malformed, and slash-prefixed values

Example:

```json
{
  "usage-extension": {
    "commandName": "us"
  }
}
```

After `/reload`, the extension registers `/us` instead of `/usage`.

## Validation

- `npx --yes --package tsx tsx --test tests/files-widget-utils.test.mjs tests/usage-data.test.mjs tests/usage-export.test.mjs tests/usage-graph.test.mjs tests/usage-preferences.test.mjs`: 70 tests passed
- `pi_verify` typecheck: passed
- `pi_verify` runtime load: passed; default `/usage` command registered

## Dependency

This is a stacked PR based on #99 because it extends the settings parser introduced there. Once #99 is merged, this PR will contain only the configurable-command commit.