### PR TITLE
session-recap: force reasoning off for Codex recap models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.65] - 2026-08-10
+
+### Fixed
+- `session-recap` 0.4.2: force reasoning off for Codex recap models. `completeSimple` cannot express "off", and openai-codex-responses sends no reasoning field when none is requested, so recaps inherited the server-side default effort. Those models now go through `complete` with an explicit `reasoningEffort: "none"`; every other API keeps disabling thinking by omission.
+
 ## [0.1.61] - 2026-07-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "license": "MIT",
   "private": false,
   "keywords": [

--- a/session-recap/README.md
+++ b/session-recap/README.md
@@ -40,7 +40,9 @@ The recap reuses the active provider's authentication and chooses a cheaper mode
 3. GPT-5.6 Luna when the active model is GPT and its provider offers Luna.
 4. The currently active model otherwise.
 
-The recap sends no tools or Agent Skills. It uses a 30-message window in native roles, plus the initial request and latest compaction or branch summary. Large initial requests and tool results retain their beginning and end.
+The recap sends no system prompt, no tools and no Agent Skills, and never writes to the prompt cache. Reasoning is always off: most APIs disable thinking when no reasoning level is requested, and Codex models are sent an explicit `reasoningEffort: "none"` because they would otherwise fall back to the server-side default.
+
+It uses a 30-message window in native roles, plus the initial request and latest compaction or branch summary. Large initial requests and tool results retain their beginning and end.
 
 Custom providers work when they use a built-in pi-ai API type. Pi-only custom handlers are skipped because the standalone compatibility layer cannot route them; use `--recap-model "<provider>/<id>"` to select a supported model.
 

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Message } from "@earendil-works/pi-ai";
-import { completeSimple } from "@earendil-works/pi-ai/compat";
+import { complete, completeSimple } from "@earendil-works/pi-ai/compat";
 import {
 	convertToLlm,
 	sessionEntryToContextMessages,
@@ -33,6 +33,13 @@ const LUNA_RECAP_MODEL = /(?:^|\/)gpt-5[.-]6-luna(?:$|[@:])/;
 // Debounce after a turn ends while blurred, so mid-loop turn_ends (which are
 // immediately followed by the next turn_start) don't trigger drafts.
 const POST_TURN_DEBOUNCE_MS = 3000;
+
+// `completeSimple` cannot express "reasoning off": its `reasoning` option only
+// accepts real thinking levels. Omitting it disables thinking on every API we
+// use except openai-codex-responses, which sends no reasoning field at all and
+// so inherits the server-side default. Those models go through `complete` with
+// an explicit `reasoningEffort: "none"` instead.
+const NEEDS_EXPLICIT_REASONING_OFF = new Set(["openai-codex-responses"]);
 
 const RECENT_MESSAGE_WINDOW = 30;
 const MIN_ASSISTANT_WORDS = 30;
@@ -188,30 +195,32 @@ async function generateRecap(
 		"Start by stating the high-level task — what they are building or debugging, not " +
 		"implementation details. Next: the concrete next step. Skip status reports and commit recaps.";
 
+	const context = {
+		systemPrompt: "",
+		messages: [
+			...recapContext.messages,
+			{
+				role: "user" as const,
+				content: [{ type: "text" as const, text: prompt }],
+				timestamp: Date.now(),
+			},
+		],
+	};
+	const options = {
+		apiKey: auth.apiKey,
+		headers: auth.headers,
+		env: auth.env,
+		signal,
+		cacheRetention: "none" as const,
+		maxTokens: 256,
+	};
+
 	let response;
 	try {
-		response = await completeSimple(
-			model,
-			{
-				systemPrompt: "",
-				messages: [
-					...recapContext.messages,
-					{
-						role: "user",
-						content: [{ type: "text", text: prompt }],
-						timestamp: Date.now(),
-					},
-				],
-			},
-			{
-				apiKey: auth.apiKey,
-				headers: auth.headers,
-				env: auth.env,
-				signal,
-				cacheRetention: "none",
-				maxTokens: 256,
-			},
-		);
+		// Recaps never need reasoning; skipping it keeps each away-timer fire cheap.
+		response = NEEDS_EXPLICIT_REASONING_OFF.has(model.api)
+			? await complete(model, context, { ...options, reasoningEffort: "none" })
+			: await completeSimple(model, context, options);
 	} catch (err) {
 		// completeSimple cannot route custom handlers registered only inside Pi.
 		if (err instanceof Error && err.message.startsWith("No API provider registered for api:")) {

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/session-recap/tests/reasoning-off.test.mjs
+++ b/session-recap/tests/reasoning-off.test.mjs
@@ -1,0 +1,123 @@
+// Recaps must never spend reasoning tokens. `completeSimple` disables thinking
+// for every API by omitting `reasoning`, except openai-codex-responses, which
+// then inherits the server-side default — that api must get an explicit
+// `reasoningEffort: "none"` through `complete`.
+import assert from "node:assert/strict";
+import { registerApiProvider } from "@earendil-works/pi-ai/compat";
+import sessionRecap from "../index.ts";
+
+const calls = [];
+
+function stubStream(kind, api) {
+	return (_model, _context, options) => {
+		calls.push({ kind, api, options });
+		return {
+			result: async () => ({
+				role: "assistant",
+				content: [{ type: "text", text: "Recap text." }],
+			}),
+		};
+	};
+}
+
+for (const api of ["openai-codex-responses", "anthropic-messages"]) {
+	registerApiProvider({
+		api,
+		stream: stubStream("stream", api),
+		streamSimple: stubStream("streamSimple", api),
+	});
+}
+
+function makePi() {
+	const commands = new Map();
+	const flags = new Map();
+	return {
+		commands,
+		on() {},
+		registerCommand(name, command) {
+			commands.set(name, command);
+		},
+		registerFlag(name, options) {
+			flags.set(name, options.default);
+		},
+		getFlag(name) {
+			return flags.get(name);
+		},
+	};
+}
+
+const branch = [
+	{ type: "message", message: { role: "user", content: "Please fix the bridge integration." } },
+	{
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "I inspected the integration and prepared the next change." }],
+		},
+	},
+];
+
+function makeCtx(model) {
+	return {
+		hasUI: true,
+		model,
+		modelRegistry: {
+			find: () => undefined,
+			getAvailable: () => [],
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "unused" }),
+		},
+		sessionManager: {
+			getBranch: () => branch,
+			buildContextEntries: () => branch,
+		},
+		ui: {
+			setStatus() {},
+			setWidget() {},
+			theme: { fg: (_n, t) => t, bold: (t) => t },
+		},
+	};
+}
+
+function makeModel(api, id) {
+	return {
+		id,
+		name: id,
+		api,
+		provider: api === "anthropic-messages" ? "anthropic" : "openai-codex",
+		baseUrl: "http://localhost.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	};
+}
+
+const pi = makePi();
+sessionRecap(pi);
+const recap = pi.commands.get("recap").handler;
+
+await recap("", makeCtx(makeModel("openai-codex-responses", "gpt-5.6-luna")));
+await recap("", makeCtx(makeModel("anthropic-messages", "claude-haiku-4-5")));
+
+const codex = calls.find((c) => c.api === "openai-codex-responses");
+const anthropic = calls.find((c) => c.api === "anthropic-messages");
+
+assert.ok(codex, "codex recap should have issued a request");
+assert.equal(codex.kind, "stream", "codex recaps must use complete(), not completeSimple()");
+assert.equal(codex.options.reasoningEffort, "none", "codex recaps must disable reasoning explicitly");
+
+assert.ok(anthropic, "anthropic recap should have issued a request");
+assert.equal(anthropic.kind, "streamSimple", "other apis keep using completeSimple()");
+assert.equal(
+	anthropic.options.reasoning,
+	undefined,
+	"omitting `reasoning` is what disables thinking on non-codex apis",
+);
+assert.equal(
+	anthropic.options.reasoningEffort,
+	undefined,
+	"completeSimple has no reasoningEffort option — it would be silently dropped",
+);
+
+console.log("reasoning-off test passed");


### PR DESCRIPTION
`completeSimple`'s `reasoning` option only accepts real thinking levels, so it cannot express "off". Omitting it disables thinking on anthropic-messages, openai-responses and openai-completions — but `openai-codex-responses` sends no reasoning field at all in that case, so the recap inherited the server-side default effort and paid for reasoning tokens on every away-timer fire.

Codex models now go through `complete()` with an explicit `reasoningEffort: "none"` (which maps through `thinkingLevelMap.off`). Everything else is unchanged and still uses `completeSimple`.

Also confirms in docs what the recap does *not* send: no system prompt, no tools, no skills, no cache writes.

New test `session-recap/tests/reasoning-off.test.mjs` registers stub API providers and asserts the routing per api. It fails without the fix. All 13 session-recap tests pass.