### PR TITLE
session-recap: render fullscreen recaps in transcript

### DIFF
--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Show recaps as temporary content at the end of the scrollable transcript in fullscreen mode, rather than as a fixed widget above the editor. Regular mode keeps the existing widget placement.
+
 ## [0.4.1] - 2026-08-06
 
 ### Changed

--- a/session-recap/README.md
+++ b/session-recap/README.md
@@ -1,6 +1,6 @@
 # session-recap
 
-"While you were away" recap for Pi, modelled on Claude Code's away-summary. When you've genuinely been away from a Pi session, a short recap is drafted while you're gone and parked above the editor so it's waiting when you return.
+"While you were away" recap for Pi, modelled on Claude Code's away-summary. When you've genuinely been away from a Pi session, a short recap is drafted while you're gone and parked at the end of the scrollable transcript so it's waiting when you return. In Pi's regular TUI it stays above the editor.
 
 ![session-recap widget in a live Pi session](./assets/recap.png)
 
@@ -16,7 +16,7 @@ The recap orients rather than reports: it states the high-level task first (what
 
 Also fires automatically on `/resume` and `/fork` so you know where the prior session left off.
 
-The widget clears when you type or new agent work begins.
+The recap disappears when you submit a message or new agent work begins. It is temporary UI: it is not saved in session history or sent to the model.
 
 Quick alt-tabs cost nothing: no model call is made until you've actually been away for the full threshold. If you return while a recap is still drafting, it's allowed to finish — it lands moments after you're back, which is exactly when it helps.
 

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -12,6 +12,7 @@ import {
 	type ExtensionContext,
 	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
+import { Container, Text, type Component, type TUI } from "@earendil-works/pi-tui";
 
 type Model = Parameters<typeof completeSimple>[0];
 
@@ -23,6 +24,112 @@ type RecapContext = {
 type RecapReason = "idle" | "manual" | "resume" | "focus";
 
 const RECAP_KEY = "session-recap";
+const TUI_CAPTURE_KEY = `${RECAP_KEY}:capture`;
+
+const EMPTY_COMPONENT: Component = {
+	render: () => [],
+	invalidate: () => {},
+};
+
+type ComponentContainer = Component & {
+	children: Component[];
+	addChild(component: Component): void;
+	removeChild(component: Component): void;
+};
+
+function isComponentContainer(component: unknown): component is ComponentContainer {
+	if (!component || typeof component !== "object") return false;
+	const candidate = component as Partial<ComponentContainer>;
+	return (
+		Array.isArray(candidate.children) &&
+		typeof candidate.addChild === "function" &&
+		typeof candidate.removeChild === "function"
+	);
+}
+
+class FullscreenOnlyComponent implements Component {
+	private readonly tui: Pick<TUI, "mode">;
+	private readonly content: Component;
+
+	constructor(tui: Pick<TUI, "mode">, content: Component) {
+		this.tui = tui;
+		this.content = content;
+	}
+
+	render(width: number): string[] {
+		return this.tui.mode === "fullscreen" ? this.content.render(width) : [];
+	}
+
+	invalidate(): void {
+		this.content.invalidate();
+	}
+}
+
+class TranscriptRecapBridge implements Component {
+	private disposed = false;
+	private readonly tui: Pick<TUI, "requestRender">;
+	private readonly document: ComponentContainer;
+	private readonly recap: Component;
+
+	constructor(
+		tui: Pick<TUI, "requestRender">,
+		document: ComponentContainer,
+		recap: Component,
+	) {
+		this.tui = tui;
+		this.document = document;
+		this.recap = recap;
+	}
+
+	render(): string[] {
+		return [];
+	}
+
+	invalidate(): void {
+		this.recap.invalidate();
+	}
+
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.document.removeChild(this.recap);
+		this.tui.requestRender();
+	}
+}
+
+/**
+ * Mount temporary recap content after Pi's chat container in fullscreen mode.
+ *
+ * Pi does not expose a transcript-insertion API, but its TUI component tree is
+ * public. Validate the current document shape and fail closed so a future Pi
+ * layout change falls back to the normal above-editor widget.
+ */
+export function mountFullscreenRecap(tui: TUI, content: Component): TranscriptRecapBridge | undefined {
+	if (tui.mode !== "fullscreen") return undefined;
+
+	const document = tui.children[0];
+	if (!isComponentContainer(document) || document.children.length < 3) return undefined;
+	if (!document.children.slice(0, 3).every(isComponentContainer)) return undefined;
+
+	const recap = new FullscreenOnlyComponent(tui, content);
+	document.addChild(recap);
+	tui.requestRender();
+	return new TranscriptRecapBridge(tui, document, recap);
+}
+
+function captureTui(ctx: ExtensionContext): TUI | undefined {
+	let tui: TUI | undefined;
+	ctx.ui.setWidget(
+		TUI_CAPTURE_KEY,
+		(candidate) => {
+			tui = candidate;
+			return EMPTY_COMPONENT;
+		},
+		{ placement: "belowEditor" },
+	);
+	ctx.ui.setWidget(TUI_CAPTURE_KEY, undefined);
+	return tui;
+}
 
 const DEFAULT_AWAY_SECONDS = 90;
 const DEFAULT_IDLE_SECONDS = 120;
@@ -242,7 +349,30 @@ async function generateRecap(
 function clearRecap(ctx: ExtensionContext) {
 	if (!ctx.hasUI) return;
 	ctx.ui.setWidget(RECAP_KEY, undefined);
+	ctx.ui.setWidget(TUI_CAPTURE_KEY, undefined);
 	ctx.ui.setStatus(RECAP_KEY, undefined);
+}
+
+function showRecap(ctx: ExtensionContext, recap: string) {
+	const theme = ctx.ui.theme;
+	const header = theme.fg("accent", theme.bold("✦ recap"));
+	const content = new Container();
+	content.addChild(new Text(header, 1, 0));
+	content.addChild(new Text(theme.fg("dim", recap), 1, 0));
+
+	const tui = captureTui(ctx);
+	const bridge = tui ? mountFullscreenRecap(tui, content) : undefined;
+	if (bridge) {
+		try {
+			ctx.ui.setWidget(RECAP_KEY, () => bridge, { placement: "belowEditor" });
+		} catch (error) {
+			bridge.dispose();
+			throw error;
+		}
+		return;
+	}
+
+	ctx.ui.setWidget(RECAP_KEY, [header, theme.fg("dim", recap)], { placement: "aboveEditor" });
 }
 
 export default function (pi: ExtensionAPI) {
@@ -352,9 +482,7 @@ export default function (pi: ExtensionAPI) {
 			clearIdleTimer();
 			clearPostTurnTimer();
 
-			const theme = ctx.ui.theme;
-			const header = theme.fg("accent", theme.bold("✦ recap"));
-			ctx.ui.setWidget(RECAP_KEY, [header, theme.fg("dim", recap)], { placement: "aboveEditor" });
+			showRecap(ctx, recap);
 		} catch (err) {
 			if (!controller.signal.aborted) console.error("[session-recap] failed:", err);
 		} finally {
@@ -497,13 +625,14 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", () => {
+	pi.on("session_shutdown", (_event, ctx) => {
 		agentActive = false;
 		awayRecapPending = false;
 		clearIdleTimer();
 		clearAwayTimer();
 		clearPostTurnTimer();
 		cancelActive();
+		clearRecap(ctx);
 		detachFocusReporting();
 	});
 

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -24,112 +24,6 @@ type RecapContext = {
 type RecapReason = "idle" | "manual" | "resume" | "focus";
 
 const RECAP_KEY = "session-recap";
-const TUI_CAPTURE_KEY = `${RECAP_KEY}:capture`;
-
-const EMPTY_COMPONENT: Component = {
-	render: () => [],
-	invalidate: () => {},
-};
-
-type ComponentContainer = Component & {
-	children: Component[];
-	addChild(component: Component): void;
-	removeChild(component: Component): void;
-};
-
-function isComponentContainer(component: unknown): component is ComponentContainer {
-	if (!component || typeof component !== "object") return false;
-	const candidate = component as Partial<ComponentContainer>;
-	return (
-		Array.isArray(candidate.children) &&
-		typeof candidate.addChild === "function" &&
-		typeof candidate.removeChild === "function"
-	);
-}
-
-class FullscreenOnlyComponent implements Component {
-	private readonly tui: Pick<TUI, "mode">;
-	private readonly content: Component;
-
-	constructor(tui: Pick<TUI, "mode">, content: Component) {
-		this.tui = tui;
-		this.content = content;
-	}
-
-	render(width: number): string[] {
-		return this.tui.mode === "fullscreen" ? this.content.render(width) : [];
-	}
-
-	invalidate(): void {
-		this.content.invalidate();
-	}
-}
-
-class TranscriptRecapBridge implements Component {
-	private disposed = false;
-	private readonly tui: Pick<TUI, "requestRender">;
-	private readonly document: ComponentContainer;
-	private readonly recap: Component;
-
-	constructor(
-		tui: Pick<TUI, "requestRender">,
-		document: ComponentContainer,
-		recap: Component,
-	) {
-		this.tui = tui;
-		this.document = document;
-		this.recap = recap;
-	}
-
-	render(): string[] {
-		return [];
-	}
-
-	invalidate(): void {
-		this.recap.invalidate();
-	}
-
-	dispose(): void {
-		if (this.disposed) return;
-		this.disposed = true;
-		this.document.removeChild(this.recap);
-		this.tui.requestRender();
-	}
-}
-
-/**
- * Mount temporary recap content after Pi's chat container in fullscreen mode.
- *
- * Pi does not expose a transcript-insertion API, but its TUI component tree is
- * public. Validate the current document shape and fail closed so a future Pi
- * layout change falls back to the normal above-editor widget.
- */
-export function mountFullscreenRecap(tui: TUI, content: Component): TranscriptRecapBridge | undefined {
-	if (tui.mode !== "fullscreen") return undefined;
-
-	const document = tui.children[0];
-	if (!isComponentContainer(document) || document.children.length < 3) return undefined;
-	if (!document.children.slice(0, 3).every(isComponentContainer)) return undefined;
-
-	const recap = new FullscreenOnlyComponent(tui, content);
-	document.addChild(recap);
-	tui.requestRender();
-	return new TranscriptRecapBridge(tui, document, recap);
-}
-
-function captureTui(ctx: ExtensionContext): TUI | undefined {
-	let tui: TUI | undefined;
-	ctx.ui.setWidget(
-		TUI_CAPTURE_KEY,
-		(candidate) => {
-			tui = candidate;
-			return EMPTY_COMPONENT;
-		},
-		{ placement: "belowEditor" },
-	);
-	ctx.ui.setWidget(TUI_CAPTURE_KEY, undefined);
-	return tui;
-}
 
 const DEFAULT_AWAY_SECONDS = 90;
 const DEFAULT_IDLE_SECONDS = 120;
@@ -349,30 +243,48 @@ async function generateRecap(
 function clearRecap(ctx: ExtensionContext) {
 	if (!ctx.hasUI) return;
 	ctx.ui.setWidget(RECAP_KEY, undefined);
-	ctx.ui.setWidget(TUI_CAPTURE_KEY, undefined);
 	ctx.ui.setStatus(RECAP_KEY, undefined);
 }
 
-function showRecap(ctx: ExtensionContext, recap: string) {
+export function showRecap(ctx: ExtensionContext, recap: string) {
 	const theme = ctx.ui.theme;
 	const header = theme.fg("accent", theme.bold("✦ recap"));
-	const content = new Container();
-	content.addChild(new Text(header, 1, 0));
-	content.addChild(new Text(theme.fg("dim", recap), 1, 0));
+	const body = theme.fg("dim", recap);
+	let tui!: TUI;
+	ctx.ui.setWidget(
+		RECAP_KEY,
+		(candidate) => {
+			tui = candidate;
+			return new Container();
+		},
+		{ placement: "belowEditor" },
+	);
 
-	const tui = captureTui(ctx);
-	const bridge = tui ? mountFullscreenRecap(tui, content) : undefined;
-	if (bridge) {
-		try {
-			ctx.ui.setWidget(RECAP_KEY, () => bridge, { placement: "belowEditor" });
-		} catch (error) {
-			bridge.dispose();
-			throw error;
-		}
+	// Pi mounts the scrollable document as its first TUI child.
+	const document = tui.children[0];
+	if (tui.mode !== "fullscreen" || !(document instanceof Container)) {
+		ctx.ui.setWidget(RECAP_KEY, [header, body], { placement: "aboveEditor" });
 		return;
 	}
 
-	ctx.ui.setWidget(RECAP_KEY, [header, theme.fg("dim", recap)], { placement: "aboveEditor" });
+	const content = new Container();
+	content.addChild(new Text(header, 1, 0));
+	content.addChild(new Text(body, 1, 0));
+	const transcriptRecap: Component = {
+		render: (width) => (tui.mode === "fullscreen" ? content.render(width) : []),
+		invalidate: () => content.invalidate(),
+	};
+	document.addChild(transcriptRecap);
+
+	ctx.ui.setWidget(
+		RECAP_KEY,
+		() => ({
+			render: () => [],
+			invalidate: () => {},
+			dispose: () => document.removeChild(transcriptRecap),
+		}),
+		{ placement: "belowEditor" },
+	);
 }
 
 export default function (pi: ExtensionAPI) {
@@ -625,14 +537,13 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
+	pi.on("session_shutdown", () => {
 		agentActive = false;
 		awayRecapPending = false;
 		clearIdleTimer();
 		clearAwayTimer();
 		clearPostTurnTimer();
 		cancelActive();
-		clearRecap(ctx);
 		detachFocusReporting();
 	});
 

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tmustier/pi-session-recap",
   "version": "0.4.2",
-  "description": "While-you-were-away recap above the editor when you return to a Pi session. Keeps you in flow when multi-agenting.",
+  "description": "While-you-were-away recap at the end of the transcript when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",
   "keywords": [
@@ -22,11 +22,13 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.3"
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs"

--- a/session-recap/tests/reasoning-off.test.mjs
+++ b/session-recap/tests/reasoning-off.test.mjs
@@ -72,7 +72,9 @@ function makeCtx(model) {
 		},
 		ui: {
 			setStatus() {},
-			setWidget() {},
+			setWidget(_key, content) {
+				if (typeof content === "function") content({ mode: "regular", children: [] }, this.theme);
+			},
 			theme: { fg: (_n, t) => t, bold: (t) => t },
 		},
 	};

--- a/session-recap/tests/transcript-recap.test.mjs
+++ b/session-recap/tests/transcript-recap.test.mjs
@@ -1,83 +1,45 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mountFullscreenRecap } from "../index.ts";
+import { Container } from "@earendil-works/pi-tui";
+import { showRecap } from "../index.ts";
 
-function container(children = []) {
-	return {
-		children: [...children],
-		addChild(component) {
-			this.children.push(component);
-		},
-		removeChild(component) {
-			const index = this.children.indexOf(component);
-			if (index >= 0) this.children.splice(index, 1);
-		},
-		render(width) {
-			return this.children.flatMap((child) => child.render(width));
-		},
-		invalidate() {
-			for (const child of this.children) child.invalidate();
+function createUi(mode) {
+	const document = new Container();
+	for (let i = 0; i < 3; i++) document.addChild(new Container());
+	const tui = { mode, children: [document] };
+	const theme = { fg: (_name, text) => text, bold: (text) => text };
+	const widgets = new Map();
+	const ui = {
+		theme,
+		setWidget(key, content, options) {
+			widgets.get(key)?.component?.dispose?.();
+			widgets.delete(key);
+			if (content === undefined) return;
+			const component = typeof content === "function" ? content(tui, theme) : undefined;
+			widgets.set(key, { content, component, options });
 		},
 	};
+	return { ctx: { ui }, document, widgets };
 }
 
-const emptyContainer = () => container();
-const textComponent = (text) => ({
-	render: () => [text],
-	invalidate() {},
-});
+test("fullscreen recap is temporary transcript content", () => {
+	const { ctx, document, widgets } = createUi("fullscreen");
+	showRecap(ctx, "Temporary recap text.");
 
-test("mounts a temporary recap after the fullscreen transcript and removes it on dispose", () => {
-	const document = container([emptyContainer(), emptyContainer(), emptyContainer()]);
-	let renders = 0;
-	const tui = {
-		mode: "fullscreen",
-		children: [document],
-		requestRender() {
-			renders++;
-		},
-	};
-
-	const bridge = mountFullscreenRecap(tui, textComponent("recap text"));
-	assert.ok(bridge);
 	assert.equal(document.children.length, 4);
-	assert.deepEqual(document.children[3].render(80), ["recap text"]);
-	assert.deepEqual(bridge.render(80), [], "the bridge must consume no fixed dock rows");
-	assert.equal(renders, 1);
+	assert.match(document.children[3].render(80).join("\n"), /Temporary recap text/);
+	assert.equal(widgets.get("session-recap").options.placement, "belowEditor");
+	assert.deepEqual(widgets.get("session-recap").component.render(80), []);
 
-	tui.mode = "regular";
-	assert.deepEqual(document.children[3].render(80), [], "the recap must not leak into regular scrollback");
-
-	bridge.dispose();
-	bridge.dispose();
+	ctx.ui.setWidget("session-recap", undefined);
 	assert.equal(document.children.length, 3);
-	assert.equal(renders, 2, "disposal should be idempotent and request one repaint");
 });
 
-test("fails closed when Pi's transcript layout is not recognised", () => {
-	const document = container([emptyContainer(), emptyContainer()]);
-	const tui = {
-		mode: "fullscreen",
-		children: [document],
-		requestRender() {
-			throw new Error("should not render");
-		},
-	};
+test("regular mode keeps the above-editor recap", () => {
+	const { ctx, document, widgets } = createUi("regular");
+	showRecap(ctx, "Temporary recap text.");
 
-	assert.equal(mountFullscreenRecap(tui, textComponent("recap text")), undefined);
-	assert.equal(document.children.length, 2);
-});
-
-test("does not mount transcript content in regular mode", () => {
-	const document = container([emptyContainer(), emptyContainer(), emptyContainer()]);
-	const tui = {
-		mode: "regular",
-		children: [document],
-		requestRender() {
-			throw new Error("should not render");
-		},
-	};
-
-	assert.equal(mountFullscreenRecap(tui, textComponent("recap text")), undefined);
 	assert.equal(document.children.length, 3);
+	assert.equal(widgets.get("session-recap").options.placement, "aboveEditor");
+	assert.deepEqual(widgets.get("session-recap").content, ["✦ recap", "Temporary recap text."]);
 });

--- a/session-recap/tests/transcript-recap.test.mjs
+++ b/session-recap/tests/transcript-recap.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mountFullscreenRecap } from "../index.ts";
+
+function container(children = []) {
+	return {
+		children: [...children],
+		addChild(component) {
+			this.children.push(component);
+		},
+		removeChild(component) {
+			const index = this.children.indexOf(component);
+			if (index >= 0) this.children.splice(index, 1);
+		},
+		render(width) {
+			return this.children.flatMap((child) => child.render(width));
+		},
+		invalidate() {
+			for (const child of this.children) child.invalidate();
+		},
+	};
+}
+
+const emptyContainer = () => container();
+const textComponent = (text) => ({
+	render: () => [text],
+	invalidate() {},
+});
+
+test("mounts a temporary recap after the fullscreen transcript and removes it on dispose", () => {
+	const document = container([emptyContainer(), emptyContainer(), emptyContainer()]);
+	let renders = 0;
+	const tui = {
+		mode: "fullscreen",
+		children: [document],
+		requestRender() {
+			renders++;
+		},
+	};
+
+	const bridge = mountFullscreenRecap(tui, textComponent("recap text"));
+	assert.ok(bridge);
+	assert.equal(document.children.length, 4);
+	assert.deepEqual(document.children[3].render(80), ["recap text"]);
+	assert.deepEqual(bridge.render(80), [], "the bridge must consume no fixed dock rows");
+	assert.equal(renders, 1);
+
+	tui.mode = "regular";
+	assert.deepEqual(document.children[3].render(80), [], "the recap must not leak into regular scrollback");
+
+	bridge.dispose();
+	bridge.dispose();
+	assert.equal(document.children.length, 3);
+	assert.equal(renders, 2, "disposal should be idempotent and request one repaint");
+});
+
+test("fails closed when Pi's transcript layout is not recognised", () => {
+	const document = container([emptyContainer(), emptyContainer()]);
+	const tui = {
+		mode: "fullscreen",
+		children: [document],
+		requestRender() {
+			throw new Error("should not render");
+		},
+	};
+
+	assert.equal(mountFullscreenRecap(tui, textComponent("recap text")), undefined);
+	assert.equal(document.children.length, 2);
+});
+
+test("does not mount transcript content in regular mode", () => {
+	const document = container([emptyContainer(), emptyContainer(), emptyContainer()]);
+	const tui = {
+		mode: "regular",
+		children: [document],
+		requestRender() {
+			throw new Error("should not render");
+		},
+	};
+
+	assert.equal(mountFullscreenRecap(tui, textComponent("recap text")), undefined);
+	assert.equal(document.children.length, 3);
+});


### PR DESCRIPTION
## Summary

- render the temporary recap at the end of the scrollable transcript in fullscreen mode
- remove it when input is submitted or agent work starts, without persisting it in session history or model context
- retain the existing above-editor widget as a fail-closed fallback and in regular TUI mode
- add lifecycle/layout tests and document the fullscreen behavior

## Testing

- `npm test --prefix session-recap` — 15 tests passed
- `tsc --noEmit --target ES2022 --module preserve --moduleResolution bundler --skipLibCheck --types node session-recap/index.ts`
- live Pi 0.84.1 fullscreen test in tmux: resumed a prior session, generated a recap, scrolled up and down, then submitted a message and confirmed the recap disappeared

Version bump intentionally deferred until merge.