### PR TITLE
session-recap: never render a partial response as a recap

### DIFF
--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.5.1] - 2026-08-28
+
+### Fixed
+- Never render a partial response as a recap. `complete`/`completeSimple` resolve instead of throwing when a stream fails, is aborted, or hits the token cap, and the message they return holds only the text that arrived before the cut. That fragment was rendered verbatim, so a stream that died on its first delta produced a recap of one dangling word such as "I" or "The". A recap is now drawn only for a cleanly stopped response, and a genuine stream failure is logged with the provider's error message instead of passing silently.
 ## [0.5.0] - 2026-08-14
 
 ### Changed

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Draw a recap only for a cleanly stopped response. `complete`/`completeSimple` resolve rather than throw when a stream fails, is aborted, or stops at the token cap, and the message they return holds only the text that arrived before the cut. Rendering that fragment produced recaps of a single dangling word. A stream failure is now logged with the provider's error message instead of passing silently.
+
 ## [0.5.0] - 2026-08-14
 
 ### Changed

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 ### Fixed
-- Draw a recap only for a cleanly stopped response. `complete`/`completeSimple` resolve rather than throw when a stream fails, is aborted, or stops at the token cap, and the message they return holds only the text that arrived before the cut. Rendering that fragment produced recaps of a single dangling word. A stream failure is now logged with the provider's error message instead of passing silently.
+- Draw a recap only for a cleanly stopped response. `complete`/`completeSimple` resolve rather than throw when a stream fails, is aborted, or stops at the token cap, and the message they return holds only the text that arrived before the cut. Rendering that fragment produced recaps of a single dangling word. A stream failure is now reported with the provider's error message instead of passing silently.
+- Report a recap failure through `ctx.ui.notify` instead of `console.error`. Pi installs no console interception, so an extension writing there put a multi-line stack straight onto the terminal in the middle of a frame, overwriting the status bar it landed on.
 
 ## [0.5.0] - 2026-08-14
 

--- a/session-recap/CHANGELOG.md
+++ b/session-recap/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [0.5.1] - 2026-08-28
+## Unreleased
 
 ### Fixed
-- Never render a partial response as a recap. `complete`/`completeSimple` resolve instead of throwing when a stream fails, is aborted, or hits the token cap, and the message they return holds only the text that arrived before the cut. That fragment was rendered verbatim, so a stream that died on its first delta produced a recap of one dangling word such as "I" or "The". A recap is now drawn only for a cleanly stopped response, and a genuine stream failure is logged with the provider's error message instead of passing silently.
+- Draw a recap only for a cleanly stopped response. `complete`/`completeSimple` resolve rather than throw when a stream fails, is aborted, or stops at the token cap, and the message they return holds only the text that arrived before the cut. Rendering that fragment produced recaps of a single dangling word. A stream failure is now logged with the provider's error message instead of passing silently.
 ## [0.5.0] - 2026-08-14
 
 ### Changed

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -230,6 +230,15 @@ async function generateRecap(
 		throw err;
 	}
 
+	// pi-ai resolves instead of throwing when a stream fails, is aborted, or hits
+	// the token cap: the message it hands back holds only the text that arrived
+	// before the cut. Rendering that verbatim is what produced recaps of a single
+	// dangling word, so accept a whole response only.
+	if (response.stopReason === "error") {
+		throw new Error(response.errorMessage || "the recap request failed mid-stream");
+	}
+	if (response.stopReason !== "stop") return undefined;
+
 	const text = response.content
 		.filter((c): c is { type: "text"; text: string } => c.type === "text")
 		.map((c) => c.text)

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -405,7 +405,13 @@ export default function (pi: ExtensionAPI) {
 
 			showRecap(ctx, recap);
 		} catch (err) {
-			if (!controller.signal.aborted) console.error("[session-recap] failed:", err);
+			// Report through the UI, never console.*: pi installs no console interception, so
+			// an extension writing there puts raw text on the terminal mid-frame and mangles the
+			// status bar it lands on. `generateAndShow` already returned early unless `ctx.hasUI`.
+			if (!controller.signal.aborted) {
+				const message = err instanceof Error ? err.message : String(err);
+				ctx.ui.notify(`session-recap: ${message}`, "error");
+			}
 		} finally {
 			if (activeController === controller) {
 				activeController = undefined;

--- a/session-recap/index.ts
+++ b/session-recap/index.ts
@@ -230,10 +230,10 @@ async function generateRecap(
 		throw err;
 	}
 
-	// pi-ai resolves instead of throwing when a stream fails, is aborted, or hits
-	// the token cap: the message it hands back holds only the text that arrived
-	// before the cut. Rendering that verbatim is what produced recaps of a single
-	// dangling word, so accept a whole response only.
+	// pi-ai resolves instead of throwing when a stream fails, is aborted, or stops
+	// at the token cap: the message it hands back then holds only the text that
+	// arrived before the cut. Half a sentence orients nobody, so draw a recap from
+	// a whole response only.
 	if (response.stopReason === "error") {
 		throw new Error(response.errorMessage || "the recap request failed mid-stream");
 	}

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "description": "While-you-were-away recap at the end of the transcript when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/session-recap/package.json
+++ b/session-recap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-session-recap",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "While-you-were-away recap at the end of the transcript when you return to a Pi session. Keeps you in flow when multi-agenting.",
   "license": "MIT",
   "author": "Thomas Mustier",

--- a/session-recap/tests/reasoning-off.test.mjs
+++ b/session-recap/tests/reasoning-off.test.mjs
@@ -15,6 +15,7 @@ function stubStream(kind, api) {
 			result: async () => ({
 				role: "assistant",
 				content: [{ type: "text", text: "Recap text." }],
+				stopReason: "stop",
 			}),
 		};
 	};

--- a/session-recap/tests/truncated-response.test.mjs
+++ b/session-recap/tests/truncated-response.test.mjs
@@ -1,8 +1,8 @@
-// pi-ai resolves rather than throws when a stream fails, is aborted, or runs
-// into the token cap: `complete`/`completeSimple` hand back the partial
-// assistant message built so far, carrying whatever text arrived before the
-// cut. A recap must never render that fragment — it is what surfaced recaps of
-// a single dangling word such as "I" or "The".
+// pi-ai resolves rather than throws when a stream fails, is aborted, or stops
+// at the token cap: `complete`/`completeSimple` hand back the partial assistant
+// message built so far, holding whatever text arrived before the cut. Rendering
+// that fragment yields a recap of a single dangling word, so each stop reason
+// below pins down what reaches the widget.
 import assert from "node:assert/strict";
 import { registerApiProvider } from "@earendil-works/pi-ai/compat";
 import sessionRecap from "../index.ts";
@@ -109,7 +109,7 @@ function message(stopReason, text, extra = {}) {
 // A stream that died after the first delta: the message holds one dangling word.
 const failed = await run(message("error", "The", { errorMessage: "socket hang up" }));
 assert.deepEqual(failed.widgets, [], "a failed stream must not render its partial text as a recap");
-assert.equal(failed.errors.length, 1, "a failed stream should be reported once");
+assert.equal(failed.errors.length, 1, "a failed stream must be reported once");
 assert.match(
 	String(failed.errors[0][1]),
 	/socket hang up/,

--- a/session-recap/tests/truncated-response.test.mjs
+++ b/session-recap/tests/truncated-response.test.mjs
@@ -47,6 +47,7 @@ const branch = [
 ];
 
 const widgets = [];
+const notices = [];
 
 const ctx = {
 	hasUI: true,
@@ -73,6 +74,9 @@ const ctx = {
 	},
 	ui: {
 		setStatus() {},
+		notify(message, type) {
+			notices.push([message, type]);
+		},
 		setWidget(_key, content) {
 			if (typeof content === "function") {
 				content({ mode: "regular", children: [] }, this.theme);
@@ -91,15 +95,20 @@ const recap = pi.commands.get("recap").handler;
 async function run(response) {
 	nextResponse = response;
 	widgets.length = 0;
-	const errors = [];
+	notices.length = 0;
+	const consoleWrites = [];
 	const originalConsoleError = console.error;
-	console.error = (...args) => errors.push(args);
+	console.error = (...args) => consoleWrites.push(args);
 	try {
 		await recap("", ctx);
 	} finally {
 		console.error = originalConsoleError;
 	}
-	return { widgets: [...widgets], errors };
+	// Holds for every stop reason, so it is asserted here rather than per case: pi installs
+	// no console interception, so text written there reaches the terminal mid-frame and
+	// mangles the status bar. Failures belong in a notification.
+	assert.deepEqual(consoleWrites, [], "a recap must report through the UI, never the console");
+	return { widgets: [...widgets], notices: [...notices] };
 }
 
 function message(stopReason, text, extra = {}) {
@@ -109,22 +118,23 @@ function message(stopReason, text, extra = {}) {
 // A stream that died after the first delta: the message holds one dangling word.
 const failed = await run(message("error", "The", { errorMessage: "socket hang up" }));
 assert.deepEqual(failed.widgets, [], "a failed stream must not render its partial text as a recap");
-assert.equal(failed.errors.length, 1, "a failed stream must be reported once");
+assert.equal(failed.notices.length, 1, "a failed stream must be reported once");
 assert.match(
-	String(failed.errors[0][1]),
+	failed.notices[0][0],
 	/socket hang up/,
-	"the provider's error message should reach the log",
+	"the provider's error message should reach the notification",
 );
+assert.equal(failed.notices[0][1], "error", "a stream failure is an error-level notification");
 
 // An aborted stream is an ordinary cancellation, not a fault: drop it silently.
 const aborted = await run(message("aborted", "I"));
 assert.deepEqual(aborted.widgets, [], "an aborted stream must not render its partial text");
-assert.deepEqual(aborted.errors, [], "an aborted stream is expected and must not be logged");
+assert.deepEqual(aborted.notices, [], "an aborted stream is expected and must not be reported");
 
 // Hitting the 256-token cap leaves a sentence cut mid-word.
 const capped = await run(message("length", "The next step is to rewrite the bridge adapter so that"));
 assert.deepEqual(capped.widgets, [], "a response cut off at the token cap must not be rendered");
-assert.deepEqual(capped.errors, [], "overrunning the cap is not an error worth logging");
+assert.deepEqual(capped.notices, [], "overrunning the cap is not an error worth reporting");
 
 // The control: a whole response still reaches the widget.
 const complete = await run(message("stop", "Fixing the bridge integration. Next: rerun the suite."));
@@ -133,6 +143,6 @@ assert.deepEqual(
 	[["✦ recap", "Fixing the bridge integration. Next: rerun the suite."]],
 	"a cleanly stopped response should still render",
 );
-assert.deepEqual(complete.errors, [], "a successful recap must not log");
+assert.deepEqual(complete.notices, [], "a successful recap must not notify");
 
 console.log("truncated response test passed");

--- a/session-recap/tests/truncated-response.test.mjs
+++ b/session-recap/tests/truncated-response.test.mjs
@@ -1,0 +1,138 @@
+// pi-ai resolves rather than throws when a stream fails, is aborted, or runs
+// into the token cap: `complete`/`completeSimple` hand back the partial
+// assistant message built so far, carrying whatever text arrived before the
+// cut. A recap must never render that fragment — it is what surfaced recaps of
+// a single dangling word such as "I" or "The".
+import assert from "node:assert/strict";
+import { registerApiProvider } from "@earendil-works/pi-ai/compat";
+import sessionRecap from "../index.ts";
+
+const API = "recap-truncation-test";
+
+let nextResponse;
+
+function stubStream(_model, _context, _options) {
+	return { result: async () => nextResponse };
+}
+
+registerApiProvider({ api: API, stream: stubStream, streamSimple: stubStream });
+
+function makePi() {
+	const commands = new Map();
+	const flags = new Map();
+	return {
+		commands,
+		on() {},
+		registerCommand(name, command) {
+			commands.set(name, command);
+		},
+		registerFlag(name, options) {
+			flags.set(name, options.default);
+		},
+		getFlag(name) {
+			return flags.get(name);
+		},
+	};
+}
+
+const branch = [
+	{ type: "message", message: { role: "user", content: "Please fix the bridge integration." } },
+	{
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "I inspected the integration and prepared the next change." }],
+		},
+	},
+];
+
+const widgets = [];
+
+const ctx = {
+	hasUI: true,
+	model: {
+		id: "recap-truncation-model",
+		name: "Recap truncation model",
+		api: API,
+		provider: "recap-truncation",
+		baseUrl: "http://localhost.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	},
+	modelRegistry: {
+		find: () => undefined,
+		getAvailable: () => [],
+		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "unused" }),
+	},
+	sessionManager: {
+		getBranch: () => branch,
+		buildContextEntries: () => branch,
+	},
+	ui: {
+		setStatus() {},
+		setWidget(_key, content) {
+			if (typeof content === "function") {
+				content({ mode: "regular", children: [] }, this.theme);
+				return;
+			}
+			if (content !== undefined) widgets.push(content);
+		},
+		theme: { fg: (_n, t) => t, bold: (t) => t },
+	},
+};
+
+const pi = makePi();
+sessionRecap(pi);
+const recap = pi.commands.get("recap").handler;
+
+async function run(response) {
+	nextResponse = response;
+	widgets.length = 0;
+	const errors = [];
+	const originalConsoleError = console.error;
+	console.error = (...args) => errors.push(args);
+	try {
+		await recap("", ctx);
+	} finally {
+		console.error = originalConsoleError;
+	}
+	return { widgets: [...widgets], errors };
+}
+
+function message(stopReason, text, extra = {}) {
+	return { role: "assistant", content: [{ type: "text", text }], stopReason, ...extra };
+}
+
+// A stream that died after the first delta: the message holds one dangling word.
+const failed = await run(message("error", "The", { errorMessage: "socket hang up" }));
+assert.deepEqual(failed.widgets, [], "a failed stream must not render its partial text as a recap");
+assert.equal(failed.errors.length, 1, "a failed stream should be reported once");
+assert.match(
+	String(failed.errors[0][1]),
+	/socket hang up/,
+	"the provider's error message should reach the log",
+);
+
+// An aborted stream is an ordinary cancellation, not a fault: drop it silently.
+const aborted = await run(message("aborted", "I"));
+assert.deepEqual(aborted.widgets, [], "an aborted stream must not render its partial text");
+assert.deepEqual(aborted.errors, [], "an aborted stream is expected and must not be logged");
+
+// Hitting the 256-token cap leaves a sentence cut mid-word.
+const capped = await run(message("length", "The next step is to rewrite the bridge adapter so that"));
+assert.deepEqual(capped.widgets, [], "a response cut off at the token cap must not be rendered");
+assert.deepEqual(capped.errors, [], "overrunning the cap is not an error worth logging");
+
+// The control: a whole response still reaches the widget.
+const complete = await run(message("stop", "Fixing the bridge integration. Next: rerun the suite."));
+assert.deepEqual(
+	complete.widgets,
+	[["✦ recap", "Fixing the bridge integration. Next: rerun the suite."]],
+	"a cleanly stopped response should still render",
+);
+assert.deepEqual(complete.errors, [], "a successful recap must not log");
+
+console.log("truncated response test passed");

--- a/session-recap/tests/unknown-api-provider.test.mjs
+++ b/session-recap/tests/unknown-api-provider.test.mjs
@@ -34,6 +34,7 @@ const branch = [
 ];
 
 const widgets = [];
+const notices = [];
 const ctx = {
 	hasUI: true,
 	model: {
@@ -60,6 +61,9 @@ const ctx = {
 	},
 	ui: {
 		setStatus() {},
+		notify(...args) {
+			notices.push(args);
+		},
 		setWidget(...args) {
 			widgets.push(args);
 		},
@@ -83,6 +87,11 @@ try {
 	console.error = originalConsoleError;
 }
 
-assert.deepEqual(errors, [], "an unknown custom API provider should be skipped without logging an error");
+assert.deepEqual(errors, [], "an extension must not write to the console, which corrupts the TUI frame");
+assert.deepEqual(
+	notices,
+	[],
+	"an unknown custom API provider should be skipped without reporting an error",
+);
 assert.deepEqual(widgets, [], "an unsupported provider should not render an empty recap widget");
 console.log("unknown API provider test passed");


### PR DESCRIPTION
Fixes #105.

A recap is now drawn only for a cleanly stopped response.

`complete` and `completeSimple` resolve rather than throw when a stream fails, is aborted, or stops at the token cap. The message they return holds only the text that arrived before the cut, and `generateRecap` rendered it verbatim, so a stream that died on its first delta produced a recap of one dangling word. Nothing was logged, because nothing was thrown.

```ts
if (response.stopReason === "error") {
    throw new Error(response.errorMessage || "the recap request failed mid-stream");
}
if (response.stopReason !== "stop") return undefined;
```

A genuine failure is rethrown with the provider's error message, so the existing handler in `generateAndShow` logs it. An abort or a token-cap overrun is dropped quietly, matching how the extension already skips work it cannot finish.

`tests/truncated-response.test.mjs` drives each stop reason through the extension and asserts what reaches the widget. Reverting `index.ts` and running each case on its own: `error`, `aborted` and `length` fail without the guard and pass with it, and `stop` passes both ways as the control. The full suite passes, 16 tests.

The stub in `tests/reasoning-off.test.mjs` returned an assistant message with no `stopReason`, which the guard rejects. That test asserts only on the request it issues, so it stays green either way, but `AssistantMessage` requires `stopReason` and the stub now sets it.

The changelog entry sits under `Unreleased` and `package.json` is untouched, so the release commit still owns the version bump.
